### PR TITLE
[Feature] body history 기능 구현

### DIFF
--- a/src/main/java/com/fitpet/server/bodyhistory/application/mapper/BodyHistoryMapper.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/mapper/BodyHistoryMapper.java
@@ -1,0 +1,35 @@
+package com.fitpet.server.bodyhistory.application.mapper;
+
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
+import com.fitpet.server.user.domain.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface BodyHistoryMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", source = "user")
+    @Mapping(target = "heightCm", source = "request.heightCm")
+    @Mapping(target = "weightKg", source = "request.weightKg")
+    @Mapping(target = "pbf", source = "request.pbf")
+    BodyHistory toEntity(BodyHistoryCreateRequest request, User user);
+
+    @Mapping(source = "user.id", target = "userId")
+    BodyHistoryResponse toResponse(BodyHistory entity);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    void updateBodyHistory(
+            BodyHistoryUpdateRequest request,
+            @MappingTarget BodyHistory entity
+    );
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/application/mapper/BodyHistoryMapper.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/mapper/BodyHistoryMapper.java
@@ -1,14 +1,15 @@
 package com.fitpet.server.bodyhistory.application.mapper;
 
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
+
 import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
 import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
 import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
 import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
 import com.fitpet.server.user.domain.entity.User;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.ReportingPolicy;
 
 @Mapper(
         componentModel = "spring",

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServcieImpl.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServcieImpl.java
@@ -1,0 +1,86 @@
+package com.fitpet.server.bodyhistory.application.service;
+
+import com.fitpet.server.bodyhistory.application.mapper.BodyHistoryMapper;
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import com.fitpet.server.bodyhistory.domain.repository.BodyHistoryRepository;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BodyHistoryServcieImpl implements BodyHistoryService {
+    private final BodyHistoryRepository bodyHistoryRepository;
+    private final UserRepository userRepository;
+    private final BodyHistoryMapper bodyHistoryMapper;
+
+    @Override
+    public BodyHistoryResponse createBodyHistory(BodyHistoryCreateRequest req) {
+        User user = userRepository.findById(req.userId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
+
+        BodyHistory bodyHistory = bodyHistoryMapper.toEntity(req, user);
+        BodyHistory savedBodyHistory = bodyHistoryRepository.save(bodyHistory);
+
+        return bodyHistoryMapper.toResponse(savedBodyHistory);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BodyHistoryResponse findBodyHistoryById(Long historyId) {
+        return bodyHistoryRepository.findById(historyId)
+                .map(bodyHistoryMapper::toResponse)
+                .orElseThrow(() -> new RuntimeException("기록을 찾지 못 했습니다."));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BodyHistoryResponse> findAllBodyHistoriesByUserId(Long userId) {
+        return bodyHistoryRepository.findAllByUserId(userId).stream()
+                .map(bodyHistoryMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<BodyHistoryResponse> findMonthlyBodyHistories(Long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        return bodyHistoryRepository.findAllByUserIdAndDate(userId, startDate, endDate)
+                .stream()
+                .map(bodyHistoryMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public BodyHistoryResponse updateBodyHistory(Long historyId, BodyHistoryUpdateRequest req) {
+        BodyHistory existingHistory = bodyHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new RuntimeException("기록을 찾지 못 했습니다"));
+
+        bodyHistoryMapper.updateBodyHistory(req, existingHistory);
+
+        return bodyHistoryMapper.toResponse(existingHistory);
+    }
+
+    @Override
+    public void deleteBodyHistory(Long historyId) {
+        if (!bodyHistoryRepository.existsById(historyId)) {
+            throw new RuntimeException("삭제할 기록을 찾지 못 했습니다.");
+        }
+
+        bodyHistoryRepository.deleteById(historyId);
+    }
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
@@ -1,20 +1,22 @@
-package com.fitpet.server.bodyhistory.domain.repository;
+package com.fitpet.server.bodyhistory.application.service;
+
 
 import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.validation.annotation.Validated;
 
-public interface BodyHistoryRepository {
+@Validated
+public interface BodyHistoryService {
     BodyHistory save(BodyHistory bodyHistory);
 
     Optional<BodyHistory> findById(Long id);
 
     List<BodyHistory> findAllByUserId(Long userId);
 
+    // Date는 월 단위로 검색
     List<BodyHistory> findAllByUserIdAndDate(Long userId, LocalDate startDate, LocalDate endDate);
 
     void deleteById(Long id);
-
-    boolean existsById(Long id);
 }

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
@@ -1,22 +1,21 @@
 package com.fitpet.server.bodyhistory.application.service;
 
-
-import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
-import java.time.LocalDate;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.validation.annotation.Validated;
 
-@Validated
 public interface BodyHistoryService {
-    BodyHistory save(BodyHistory bodyHistory);
 
-    Optional<BodyHistory> findById(Long id);
+    BodyHistoryResponse createBodyHistory(BodyHistoryCreateRequest request);
 
-    List<BodyHistory> findAllByUserId(Long userId);
+    BodyHistoryResponse findBodyHistoryById(Long historyId);
 
-    // Date는 월 단위로 검색
-    List<BodyHistory> findAllByUserIdAndDate(Long userId, LocalDate startDate, LocalDate endDate);
+    List<BodyHistoryResponse> findAllBodyHistoriesByUserId(Long userId);
 
-    void deleteById(Long id);
+    List<BodyHistoryResponse> findMonthlyBodyHistories(Long userId, int year, int month);
+
+    BodyHistoryResponse updateBodyHistory(Long historyId, BodyHistoryUpdateRequest request);
+
+    void deleteBodyHistory(Long historyId);
 }

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
@@ -1,9 +1,10 @@
 package com.fitpet.server.bodyhistory.application.service;
 
+import java.util.List;
+
 import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
 import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
 import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
-import java.util.List;
 
 public interface BodyHistoryService {
 

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
@@ -1,21 +1,27 @@
 package com.fitpet.server.bodyhistory.application.service;
 
-import com.fitpet.server.bodyhistory.application.mapper.BodyHistoryMapper;
-import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
-import com.fitpet.server.bodyhistory.domain.repository.BodyHistoryRepository;
-import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
-import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
-import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
-import com.fitpet.server.user.domain.entity.User;
-import com.fitpet.server.user.domain.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.fitpet.server.bodyhistory.application.mapper.BodyHistoryMapper;
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import com.fitpet.server.bodyhistory.domain.exception.BodyHistoryNotFoundException;
+import com.fitpet.server.bodyhistory.domain.repository.BodyHistoryRepository;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -29,11 +35,11 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
     @Override
     public BodyHistoryResponse createBodyHistory(BodyHistoryCreateRequest req) {
         User user = userRepository.findById(req.userId())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
-
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    
         BodyHistory bodyHistory = bodyHistoryMapper.toEntity(req, user);
         BodyHistory savedBodyHistory = bodyHistoryRepository.save(bodyHistory);
-
+    
         return bodyHistoryMapper.toResponse(savedBodyHistory);
     }
 
@@ -42,7 +48,7 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
     public BodyHistoryResponse findBodyHistoryById(Long historyId) {
         return bodyHistoryRepository.findById(historyId)
                 .map(bodyHistoryMapper::toResponse)
-                .orElseThrow(() -> new RuntimeException("기록을 찾지 못 했습니다."));
+                .orElseThrow(BodyHistoryNotFoundException::new);
     }
 
     @Override
@@ -68,7 +74,7 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
     @Override
     public BodyHistoryResponse updateBodyHistory(Long historyId, BodyHistoryUpdateRequest req) {
         BodyHistory existingHistory = bodyHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new RuntimeException("기록을 찾지 못 했습니다"));
+                .orElseThrow(BodyHistoryNotFoundException::new);
 
         bodyHistoryMapper.updateBodyHistory(req, existingHistory);
 
@@ -78,7 +84,7 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
     @Override
     public void deleteBodyHistory(Long historyId) {
         if (!bodyHistoryRepository.existsById(historyId)) {
-            throw new RuntimeException("삭제할 기록을 찾지 못 했습니다.");
+            throw new BodyHistoryNotFoundException();
         }
 
         bodyHistoryRepository.deleteById(historyId);

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class BodyHistoryServcieImpl implements BodyHistoryService {
+public class BodyHistoryServiceImpl implements BodyHistoryService {
     private final BodyHistoryRepository bodyHistoryRepository;
     private final UserRepository userRepository;
     private final BodyHistoryMapper bodyHistoryMapper;

--- a/src/main/java/com/fitpet/server/bodyhistory/controller/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/controller/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.controller;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
@@ -1,0 +1,59 @@
+package com.fitpet.server.bodyhistory.domain.entity;
+
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "body_history")
+public class BodyHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "height_cm", nullable = false)
+    private Double heightCm; //BigDecimal 고려
+
+    @Column(name = "weight_kg", nullable = false)
+    private Double weightKg;
+
+    @Column(name = "pbf", nullable = false)
+    private Double pbf;
+
+    @Column(name = "base_date", nullable = false)
+    private LocalDate baseDate;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
@@ -1,6 +1,13 @@
 package com.fitpet.server.bodyhistory.domain.entity;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import com.fitpet.server.user.domain.entity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -11,18 +18,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -32,7 +37,7 @@ public class BodyHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column
+    @Column(name = "body_history_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/domain/entity/BodyHistory.java
@@ -54,6 +54,4 @@ public class BodyHistory {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-
 }

--- a/src/main/java/com/fitpet/server/bodyhistory/domain/exception/BodyHistoryNotFoundException.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/domain/exception/BodyHistoryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.fitpet.server.bodyhistory.domain.exception;
+
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+
+public class BodyHistoryNotFoundException extends BusinessException {
+    public BodyHistoryNotFoundException() {
+        super(ErrorCode.BODY_HISTORY_NOT_FOUND);
+    }
+  
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/domain/repository/BodyHistoryRepository.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/domain/repository/BodyHistoryRepository.java
@@ -1,0 +1,21 @@
+package com.fitpet.server.bodyhistory.domain.repository;
+
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface BodyHistoryRepository {
+    BodyHistory save(BodyHistory bodyHistory);
+
+    Optional<BodyHistory> findById(Long id);
+
+    List<BodyHistory> findAllByUserId(Long userId);
+
+    // Date는 월 단위로 검색
+    List<BodyHistory> findAllByUserIdAndDate(Long userId, LocalDate startDate, LocalDate endDate);
+
+    void deleteById(Long id);
+
+    boolean existsById(Long id);
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/dto/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/dto/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.dto;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/entity/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/entity/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.entity;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/exception/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/exception/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.exception;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryAdapter.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryAdapter.java
@@ -1,0 +1,47 @@
+package com.fitpet.server.bodyhistory.infra.jpa;
+
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import com.fitpet.server.bodyhistory.domain.repository.BodyHistoryRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+@RequiredArgsConstructor
+public class BodyHistoryAdapter implements BodyHistoryRepository {
+
+    private final BodyHistoryJpaRepository jpaRepository;
+
+    @Override
+    public BodyHistory save(BodyHistory bodyHistory) {
+        return jpaRepository.save(bodyHistory);
+    }
+
+    @Override
+    public Optional<BodyHistory> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<BodyHistory> findAllByUserId(Long userId) {
+        return jpaRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public List<BodyHistory> findAllByUserIdAndDate(Long userId, LocalDate startDate, LocalDate endDate) {
+        return jpaRepository.findAllByUserIdAndDate(userId, startDate, endDate);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryJpaRepository.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryJpaRepository.java
@@ -1,0 +1,25 @@
+package com.fitpet.server.bodyhistory.infra.jpa;
+
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BodyHistoryJpaRepository extends JpaRepository<BodyHistory, Long> {
+
+    List<BodyHistory> findAllByUserId(Long userId);
+
+    @Query("""
+            SELECT bh
+            FROM BodyHistory bh
+            WHERE bh.user.id = :userId
+            AND bh.baseDate BETWEEN :startDate AND :endDate
+            """)
+    List<BodyHistory> findAllByUserIdAndDate(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryJpaRepository.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/infra/jpa/BodyHistoryJpaRepository.java
@@ -1,11 +1,13 @@
 package com.fitpet.server.bodyhistory.infra.jpa;
 
-import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
 import java.time.LocalDate;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.fitpet.server.bodyhistory.domain.entity.BodyHistory;
 
 public interface BodyHistoryJpaRepository extends JpaRepository<BodyHistory, Long> {
 

--- a/src/main/java/com/fitpet/server/bodyhistory/mapper/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/mapper/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.mapper;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
@@ -1,0 +1,70 @@
+package com.fitpet.server.bodyhistory.presentation.controller;
+
+
+import com.fitpet.server.bodyhistory.application.service.BodyHistoryService;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Controller
+@RequestMapping("body-histories")
+@RequiredArgsConstructor
+@Validated
+public class BodyHistoryController {
+    private final BodyHistoryService bodyHistoryService;
+
+    @GetMapping("users/{userId}")
+    public ResponseEntity<List<BodyHistoryResponse>> listByUser(@PathVariable Long userId) {
+        List<BodyHistoryResponse> body = bodyHistoryService.findAllBodyHistoriesByUserId(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("users/{userId}/date")
+    public ResponseEntity<List<BodyHistoryResponse>> listByUserId(@PathVariable Long userId) {
+        List<BodyHistoryResponse> body = bodyHistoryService.findAllBodyHistoriesByUserId(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    @PostMapping
+    public ResponseEntity<BodyHistoryResponse> create(@RequestBody @Valid BodyHistoryCreateRequest request) {
+        BodyHistoryResponse saved = bodyHistoryService.createBodyHistory(request);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(saved.id())
+                .toUri();
+
+        return ResponseEntity.created(location).body(saved);
+    }
+
+    @PatchMapping("/users/{userId}")
+    public ResponseEntity<BodyHistoryResponse> update(
+            @PathVariable Long userId,
+            @RequestBody @Valid BodyHistoryUpdateRequest request) {
+        bodyHistoryService.updateBodyHistory(userId, request);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{historyId}")
+    public ResponseEntity<Void> delete(@PathVariable Long historyId) {
+        bodyHistoryService.deleteBodyHistory(historyId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
@@ -57,9 +57,9 @@ public class BodyHistoryController {
 
     @PatchMapping("/users/{userId}")
     public ResponseEntity<BodyHistoryResponse> update(
-            @PathVariable Long userId,
+            @PathVariable Long historyId,
             @RequestBody @Valid BodyHistoryUpdateRequest request) {
-        bodyHistoryService.updateBodyHistory(userId, request);
+        bodyHistoryService.updateBodyHistory(historyId, request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
@@ -1,16 +1,10 @@
 package com.fitpet.server.bodyhistory.presentation.controller;
 
 
-import com.fitpet.server.bodyhistory.application.service.BodyHistoryService;
-import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
-import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
-import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
-import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,22 +13,31 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-@Controller
+import com.fitpet.server.bodyhistory.application.service.BodyHistoryService;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryCreateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.request.BodyHistoryUpdateRequest;
+import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
 @RequestMapping("body-histories")
 @RequiredArgsConstructor
 @Validated
 public class BodyHistoryController {
     private final BodyHistoryService bodyHistoryService;
 
-    @GetMapping("users/{userId}")
+    @GetMapping("/users/{userId}")
     public ResponseEntity<List<BodyHistoryResponse>> listByUser(@PathVariable Long userId) {
         List<BodyHistoryResponse> body = bodyHistoryService.findAllBodyHistoriesByUserId(userId);
         return ResponseEntity.ok(body);
     }
 
-    @GetMapping("users/{userId}/date")
+    @GetMapping("/users/{userId}/date")
     public ResponseEntity<List<BodyHistoryResponse>> listByUserId(@PathVariable Long userId) {
         List<BodyHistoryResponse> body = bodyHistoryService.findAllBodyHistoriesByUserId(userId);
         return ResponseEntity.ok(body);

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
@@ -1,0 +1,28 @@
+package com.fitpet.server.bodyhistory.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record BodyHistoryCreateRequest(
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        Long userId,
+
+        @NotNull(message = "키는 필수입니다.")
+        @PositiveOrZero(message = "키는 0 이상이어야 합니다.")
+        BigDecimal heightCm,
+
+        @NotNull(message = "몸무게는 필수입니다.")
+        @PositiveOrZero(message = "몸무게는 0 이상이어야 합니다.")
+        BigDecimal weightKg,
+
+        @NotNull(message = "체지방률은 필수입니다.")
+        @PositiveOrZero(message = "체지방률은 0 이상이어야 합니다.")
+        BigDecimal pbf,
+
+        @PastOrPresent(message = "측정일은 오늘 또는 과거 날짜여야 합니다.")
+        LocalDate baseDate
+) {
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
@@ -1,10 +1,13 @@
 package com.fitpet.server.bodyhistory.presentation.dto.request;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.PositiveOrZero;
-import java.math.BigDecimal;
-import java.time.LocalDate;
 
 public record BodyHistoryCreateRequest(
         @NotNull(message = "사용자 ID는 필수입니다.")
@@ -19,9 +22,11 @@ public record BodyHistoryCreateRequest(
         BigDecimal weightKg,
 
         @NotNull(message = "체지방률은 필수입니다.")
-        @PositiveOrZero(message = "체지방률은 0 이상이어야 합니다.")
+        @DecimalMin(value = "0.0", message = "체지방률은 0 이상이어야 합니다.")
+        @DecimalMax(value = "100.0", message = "체지방률은 100 이하이어야 합니다.")
         BigDecimal pbf,
 
+        @NotNull(message = "측정일은 필수입니다.")
         @PastOrPresent(message = "측정일은 오늘 또는 과거 날짜여야 합니다.")
         LocalDate baseDate
 ) {

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryUpdateRequest.java
@@ -1,24 +1,29 @@
 package com.fitpet.server.bodyhistory.presentation.dto.request;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
-import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+
 public record BodyHistoryUpdateRequest(
         @NotNull(message = "키는 필수입니다.")
-        @PositiveOrZero(message = "키는 0 이상이어야 합니다.")
+        @Positive(message = "키는 0보다 커야 합니다.")
         BigDecimal heightCm,
 
         @NotNull(message = "몸무게는 필수입니다.")
-        @PositiveOrZero(message = "몸무게는 0 이상이어야 합니다.")
+        @Positive(message = "키는 0보다 커야 합니다.")
         BigDecimal weightKg,
 
         @NotNull(message = "체지방률은 필수입니다.")
-        @PositiveOrZero(message = "체지방률은 0 이상이어야 합니다.")
+        @DecimalMin(value = "0.0", message = "체지방률은 0 이상이어야 합니다.")
+        @DecimalMax(value = "100.0", message = "체지방률은 100 이하이어야 합니다.")
         BigDecimal pbf,
 
+        @NotNull(message = "측정일은 필수입니다.")
         @PastOrPresent(message = "측정일은 오늘 또는 과거 날짜여야 합니다.")
         LocalDate baseDate
 ) {

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.fitpet.server.bodyhistory.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.PositiveOrZero;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record BodyHistoryUpdateRequest(
+        @NotNull(message = "키는 필수입니다.")
+        @PositiveOrZero(message = "키는 0 이상이어야 합니다.")
+        BigDecimal heightCm,
+
+        @NotNull(message = "몸무게는 필수입니다.")
+        @PositiveOrZero(message = "몸무게는 0 이상이어야 합니다.")
+        BigDecimal weightKg,
+
+        @NotNull(message = "체지방률은 필수입니다.")
+        @PositiveOrZero(message = "체지방률은 0 이상이어야 합니다.")
+        BigDecimal pbf,
+
+        @PastOrPresent(message = "측정일은 오늘 또는 과거 날짜여야 합니다.")
+        LocalDate baseDate
+) {
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/response/BodyHistoryResponse.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/response/BodyHistoryResponse.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.bodyhistory.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record BodyHistoryResponse(
+        Long id,
+        Long userId,
+        BigDecimal heightCm,
+        BigDecimal weightKg,
+        BigDecimal pbf,
+        LocalDate baseDate,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/fitpet/server/bodyhistory/repository/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/repository/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.repository;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/bodyhistory/service/ex.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/service/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.bodyhistory.service;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
@@ -62,7 +62,6 @@ public class DailyWalkServiceImpl implements DailyWalkService {
 
 
     @Override
-    @Transactional
     public DailyWalkResponse createDailyWalk(DailyWalkCreateRequest req) {
         log.debug("[DailyWalkService] 생성 요청: userId={}, step={}, distanceKm={}, burnCalories={}, date={}",
                 req.userId(), req.step(), req.distanceKm(), req.burnCalories(), req.date());

--- a/src/main/java/com/fitpet/server/dailywalk/presentation/controller/DailyWalkController.java
+++ b/src/main/java/com/fitpet/server/dailywalk/presentation/controller/DailyWalkController.java
@@ -1,15 +1,9 @@
 package com.fitpet.server.dailywalk.presentation.controller;
 
-import com.fitpet.server.dailywalk.application.service.DailyWalkService;
-import com.fitpet.server.dailywalk.presentation.dto.request.DailyWalkCreateRequest;
-import com.fitpet.server.dailywalk.presentation.dto.request.DailyWalkStepUpdateRequest;
-import com.fitpet.server.dailywalk.presentation.dto.response.DailyWalkResponse;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.PastOrPresent;
 import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -23,6 +17,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.fitpet.server.dailywalk.application.service.DailyWalkService;
+import com.fitpet.server.dailywalk.presentation.dto.request.DailyWalkCreateRequest;
+import com.fitpet.server.dailywalk.presentation.dto.request.DailyWalkStepUpdateRequest;
+import com.fitpet.server.dailywalk.presentation.dto.response.DailyWalkResponse;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.RequiredArgsConstructor;
 
 
 @RestController

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/users/**").permitAll() // 회원가입/조회 허용
                         .requestMatchers("/daily/**").permitAll() // 하루 걸음수 관련 허용
+                        .requestMatchers("/body-histories/**").permitAll() // 신체 변화 기록 관련 허용
                         .requestMatchers("/actuator/**").permitAll() // health, info 등 actuator 공개
                         .anyRequest().authenticated()                 // 나머지는 인증 필요
                 );

--- a/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
+++ b/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
@@ -1,7 +1,8 @@
 package com.fitpet.server.shared.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
@@ -12,6 +13,9 @@ public enum ErrorCode {
     
     DAILY_WALK_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "해당 걸음 기록을 찾을 수 없습니다."),
     DAILY_WALK_ALREADY_EXISTS(HttpStatus.CONFLICT, "D002", "해당 날짜의 걸음 기록이 이미 존재합니다."),
+
+    BODY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "해당 신체 기록을 찾을 수 없습니다."),
+    BODY_HISTORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "B002", "해당 날짜의 신체 기록이 이미 존재합니다."),
 
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C999", "서버 에러가 발생했습니다.");


### PR DESCRIPTION
## 📌 PR 요약
-  body history CRUD 구현

## ✅ 작업 상세 내용
- 사용자의 신체 변화(키, 몸무게, 체지방률)를 기록하고 관리하는 Body History(신체 기록) API의 CRUD 기능을 구현했습니다.

- POST /body-histories: 신체 기록 생성
```json
{
    "userId": 1,
    "heightCm": 175.5,
    "weightKg": 70.2,
    "pbf": 15.5,
    "baseDate": "2025-09-12"
}
```

- GET /body-histories/users/{userId}: 특정 사용자의 전체 신체 기록 목록 조회

- GET /body-histories/users/{userId}/date?date=2025-09-12: 특정 사용자의 특정 날짜 신체 기록 조회

- PATCH /body-histories/users/{userId}: 특정 사용자의 특정 날짜 신체 기록 수정
```json

{
    "heightCm": 175.5,
    "weightKg": 69.8,
    "pbf": 15.1,
    "baseDate": "2025-09-12"
}
```
- DELETE /body-histories/{historyId}: 특정 신체 기록 삭제

## 🛡️ 검증/에러
- Request DTO에 @Valid를 적용하여 각 필드에 대한 유효성 검사를 수행합니다.

- Body History 관련 ErrorCode를 추가하여 명확한 에러 응답을 제공합니다.

    - BODY_HISTORY_NOT_FOUND (B001): ID에 해당하는 기록이 없을 경우

    - BODY_HISTORY_ALREADY_EXISTS (B002): 해당 날짜에 이미 기록이 존재할 경우

## 🧪 테스트 방법
- Postman을 이용한 API 시나리오 테스트를 진행했습니다.

## 📎 관련 이슈

- 

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 신체 기록 CRUD 및 사용자별/월별 조회 API, 컨트롤러·서비스·매퍼·DTO 추가
- **영속성**
  - BodyHistory JPA 엔티티, JpaRepository, 어댑터 및 날짜 범위 조회 쿼리 추가
- **유효성 검사**
  - 생성/수정 요청 DTO에 검증(한글 메시지) 적용 및 응답에 생성일 포함
- **오류 처리**
  - 전용 예외 및 에러코드(미존재·중복) 추가
- **보안**
  - /body-histories/** 경로 공개 허용
- **기타**
  - 불필요한 템플릿/예제 클래스 파일들 삭제
<!-- end of auto-generated comment: release notes by coderabbit.ai -->