### PR TITLE
[Pet] Pet 생성 

### DIFF
--- a/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
+++ b/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
@@ -1,0 +1,30 @@
+package com.fitpet.server.pet.application.mapper;
+
+import com.fitpet.server.pet.domain.entity.Pet;
+import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
+import com.fitpet.server.pet.presentation.dto.PetDto;
+import com.fitpet.server.user.domain.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PetMapper {
+
+    // 생성: 요청 + 소유자(User) -> 엔티티
+    @Mappings({
+        @Mapping(target = "id", ignore = true),
+        @Mapping(target = "exp", expression = "java(0L)"),
+        @Mapping(target = "createdAt", ignore = true),
+        @Mapping(target = "updatedAt", ignore = true),
+        @Mapping(target = "owner", source = "owner")   // 소유자
+    })
+    Pet toEntity(PetCreateRequest request, User owner);
+
+    // 엔티티 -> DTO
+    @Mappings({
+        @Mapping(target = "ownerId", source = "owner.id")
+    })
+    PetDto toDto(Pet pet);
+}

--- a/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
+++ b/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
@@ -24,6 +24,7 @@ public interface PetMapper {
 
     // 엔티티 -> DTO
     @Mappings({
+        @Mapping(target = "petId", source = "id"),
         @Mapping(target = "ownerId", source = "owner.id")
     })
     PetDto toDto(Pet pet);

--- a/src/main/java/com/fitpet/server/pet/application/service/PetService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetService.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.pet.application.service;
+
+import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
+import com.fitpet.server.pet.presentation.dto.PetDto;
+
+public interface PetService {
+    PetDto create(Long ownerId, PetCreateRequest request);
+}

--- a/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
@@ -1,0 +1,41 @@
+package com.fitpet.server.pet.application.service;
+
+import com.fitpet.server.pet.application.mapper.PetMapper;
+import com.fitpet.server.pet.domain.entity.Pet;
+import com.fitpet.server.pet.domain.exception.PetAlreadyExistsException;
+import com.fitpet.server.pet.domain.repository.PetRepository;
+import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
+import com.fitpet.server.pet.presentation.dto.PetDto;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.exception.UserNotFoundException;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PetServiceImpl implements PetService {
+
+    private final PetRepository petRepository;
+    private final PetMapper petMapper;
+    private final UserRepository userRepository;
+
+    @Override
+    public PetDto create(Long ownerId, PetCreateRequest request) {
+        log.info("[PetService] Pet 생성 시작: ownerId ={}", ownerId);
+        User owner = userRepository.findById(ownerId).orElseThrow(UserNotFoundException::new);
+
+        // 사용자가 펫을 이미 소유하고 있는 경우 예외처리
+        if (petRepository.existsByOwnerId(owner.getId())) {
+            throw new PetAlreadyExistsException();
+        }
+
+        Pet pet = petMapper.toEntity(request, owner);
+        Pet saved = petRepository.save(pet);
+
+        log.info("[PetService] Pet 생성 완료: ownerId ={}", ownerId);
+        return petMapper.toDto(saved);
+    }
+}

--- a/src/main/java/com/fitpet/server/pet/controller/ex.java
+++ b/src/main/java/com/fitpet/server/pet/controller/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.controller;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +29,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "pet",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_pet_owner", columnNames = "user_id")
+    },
     indexes = {
         @Index(name = "idx_pet_owner", columnList = "user_id")
     }
@@ -45,6 +49,8 @@ public class Pet {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id",
+        nullable = false,
+        unique = true,
         foreignKey = @ForeignKey(name = "fk_pet_user"))
     private User owner;
 

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -1,0 +1,91 @@
+package com.fitpet.server.pet.domain.entity;
+
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "pet",
+    indexes = {
+        @Index(name = "idx_pet_owner", columnList = "user_id")
+    }
+)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Pet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pet_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id",
+        foreignKey = @ForeignKey(name = "fk_pet_user"))
+    private User owner;
+
+    @Column(nullable = false, length = 60)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pet_type", nullable = false, length = 20)
+    private PetType petType;
+
+    @Column(name = "exp", nullable = false)
+    private Long exp; // 기본 0
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public void rename(String newName) {
+        if (newName != null && !newName.isBlank()) {
+            this.name = newName;
+        }
+    }
+
+    public void addExp(long amount) {
+        if (amount <= 0) {
+            return;
+        }
+        if (this.exp == null) {
+            this.exp = 0L;
+        }
+        this.exp += amount;
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (this.exp == null) {
+            this.exp = 0L;
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/pet/domain/entity/PetType.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/PetType.java
@@ -1,0 +1,5 @@
+package com.fitpet.server.pet.domain.entity;
+
+public enum PetType {
+    DOG, CAT
+}

--- a/src/main/java/com/fitpet/server/pet/domain/exception/PetAlreadyExistsException.java
+++ b/src/main/java/com/fitpet/server/pet/domain/exception/PetAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.fitpet.server.pet.domain.exception;
+
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+
+public class PetAlreadyExistsException extends BusinessException {
+
+    public PetAlreadyExistsException() {
+        super(ErrorCode.PET_ALREADY_EXISTS);
+    }
+}

--- a/src/main/java/com/fitpet/server/pet/domain/repository/PetRepository.java
+++ b/src/main/java/com/fitpet/server/pet/domain/repository/PetRepository.java
@@ -1,0 +1,9 @@
+package com.fitpet.server.pet.domain.repository;
+
+import com.fitpet.server.pet.domain.entity.Pet;
+
+public interface PetRepository {
+    Pet save(Pet pet);
+
+    boolean existsByOwnerId(Long ownerId);
+}

--- a/src/main/java/com/fitpet/server/pet/dto/ex.java
+++ b/src/main/java/com/fitpet/server/pet/dto/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.dto;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/entity/ex.java
+++ b/src/main/java/com/fitpet/server/pet/entity/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.entity;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/exception/ex.java
+++ b/src/main/java/com/fitpet/server/pet/exception/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.exception;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/infra/adapter/PetRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/pet/infra/adapter/PetRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package com.fitpet.server.pet.infra.adapter;
+
+import com.fitpet.server.pet.domain.entity.Pet;
+import com.fitpet.server.pet.domain.repository.PetRepository;
+import com.fitpet.server.pet.infra.jpa.PetJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PetRepositoryAdapter implements PetRepository {
+    private final PetJpaRepository jpa;
+
+    @Override
+    public Pet save(Pet pet) {
+        return jpa.save(pet);
+    }
+
+    @Override
+    public boolean existsByOwnerId(Long ownerId) {
+        return jpa.existsByOwnerId(ownerId);
+    }
+
+}

--- a/src/main/java/com/fitpet/server/pet/infra/jpa/PetJpaRepository.java
+++ b/src/main/java/com/fitpet/server/pet/infra/jpa/PetJpaRepository.java
@@ -1,0 +1,11 @@
+package com.fitpet.server.pet.infra.jpa;
+
+import com.fitpet.server.pet.domain.entity.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PetJpaRepository extends JpaRepository<Pet, Long> {
+
+    boolean existsByOwnerId(Long ownerId);
+}

--- a/src/main/java/com/fitpet/server/pet/mapper/ex.java
+++ b/src/main/java/com/fitpet/server/pet/mapper/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.mapper;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
@@ -1,0 +1,43 @@
+package com.fitpet.server.pet.presentation.controller;
+
+import com.fitpet.server.pet.application.service.PetService;
+import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
+import com.fitpet.server.pet.presentation.dto.PetDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/pets")
+@Slf4j
+public class PetController {
+    private final PetService petService;
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<PetDto> create(
+        @PathVariable Long userId,
+        @Valid @RequestBody PetCreateRequest request
+    ) {
+
+        log.info("[PetController] 펫 생성 요청 : petName = {} , petType = {},  ownerId = {}",
+            request.name(), request.petType(), userId);
+
+        PetDto createdPet = petService.create(userId, request);
+
+        log.info("[PetController] 펫 생성 완료 : petName = {} , petType = {},  ownerId = {}",
+            request.name(), request.petType(), userId);
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(createdPet);
+    }
+
+}

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.pet.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PetCreateRequest(
+    @NotBlank String name,
+    @NotNull String petType // enum 문자열로 받음: "DOG", "CAT"
+) {
+}

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.pet.presentation.dto;
+
+import com.fitpet.server.pet.domain.entity.PetType;
+import java.time.LocalDateTime;
+
+public record PetDto(
+    Long petId,
+    Long ownerId,
+    String name,
+    PetType petType,
+    Long exp,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/fitpet/server/pet/repository/ex.java
+++ b/src/main/java/com/fitpet/server/pet/repository/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.repository;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/pet/service/ex.java
+++ b/src/main/java/com/fitpet/server/pet/service/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.pet.service;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .requestMatchers("/body-histories/**").permitAll() // 신체 변화 기록 관련 허용
                 .requestMatchers("/actuator/**").permitAll() // health, info 등 actuator 공개
                 .requestMatchers("/auth/**").permitAll()
-                .anyRequest().permitAll()                 // 나머지는 인증 필요
+                .anyRequest().permitAll()                 // 개발 편의를 위해 permitAll 처리
             );
         return http.build();
     }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .requestMatchers("/body-histories/**").permitAll() // 신체 변화 기록 관련 허용
                 .requestMatchers("/actuator/**").permitAll() // health, info 등 actuator 공개
                 .requestMatchers("/auth/**").permitAll()
-                .anyRequest().authenticated()                 // 나머지는 인증 필요
+                .anyRequest().permitAll()                 // 나머지는 인증 필요
             );
         return http.build();
     }

--- a/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
+++ b/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     BODY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "해당 신체 기록을 찾을 수 없습니다."),
     BODY_HISTORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "B002", "해당 날짜의 신체 기록이 이미 존재합니다."),
 
+    PET_ALREADY_EXISTS(HttpStatus.CONFLICT, "P001", "사용자는 이미 펫을 보유하고 있습니다."),
+
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "C001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C999", "서버 에러가 발생했습니다."),
 


### PR DESCRIPTION
## 📌 PR 요약

- Pet 생성 기능 구현

## ✅ 작업 상세 내용

- [x] Pet 생성 기능 구현
- [x] 사용자 1명 당 펫 1마리씩 생성되게 검증 로직 구현


## 🧪 테스트 방법
- 최초 생성

<img width="759" height="590" alt="image" src="https://github.com/user-attachments/assets/cf57442d-4a4d-443e-9414-eb6f6894ed3f" />

- 중복 생성
<img width="737" height="643" alt="image" src="https://github.com/user-attachments/assets/6bac5f74-0b2b-4b70-877d-7cf7166436e2" />

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 사용자 펫 생성 API 추가: POST /pets/{userId}, 생성 성공 시 펫 정보 반환
  - 이름/종류 유효성 검증 적용, 초기 경험치 0 설정, 지원 펫 종류: DOG, CAT
- 버그 픽스 / 안정성
  - 동일 사용자 중복 펫 생성 방지 및 충돌 오류(PET_ALREADY_EXISTS) 처리 추가
- 잡무
  - 미지정 엔드포인트 기본 접근 정책을 허용으로 완화
  - 불필요한 빈 타입 파일 정리(코드베이스 정리)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->