### PR TITLE
[Pet] 펫 조회 기능 구현

### DIFF
--- a/src/main/java/com/fitpet/server/pet/application/service/PetService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetService.java
@@ -7,4 +7,6 @@ public interface PetService {
     PetDto create(Long ownerId, PetCreateRequest request);
 
     void delete(Long ownerId, Long petId);
+
+    PetDto read(Long ownerId, Long petId);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
@@ -65,4 +65,25 @@ public class PetServiceImpl implements PetService {
         log.info("[PetService] Pet 삭제 완료: ownerId={}, petId={}", ownerId, petId);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public PetDto read(Long ownerId, Long petId) {
+        log.info("[PetService] Pet 조회 시작: petId={}", petId);
+
+        Pet pet = petRepository.findById(petId)
+            .orElseThrow(PetNotFoundException::new);
+
+        Long petOwnerId = pet.getOwner().getId();
+        if (!petOwnerId.equals(ownerId)) {
+            log.warn("[PetService] 조회 권한 없음: 요청 ownerId={}, 실제 ownerId={}, petId={}",
+                ownerId, petOwnerId, petId);
+            throw new PetAccessDeniedException();
+        }
+
+        log.info("[PetService] Pet 조회 완료: petId={}", petId);
+
+        return petMapper.toDto(pet);
+    }
+
+
 }

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -72,7 +72,7 @@ public class Pet {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void rename(String newName) {
+    public void updateName(String newName) {
         if (newName != null && !newName.isBlank()) {
             this.name = newName;
         }

--- a/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -53,5 +54,17 @@ public class PetController {
         return ResponseEntity
             .noContent()
             .build();
+    }
+
+    @GetMapping("/{userId}/{petId}")
+    public ResponseEntity<PetDto> read(
+        @PathVariable Long userId,
+        @PathVariable Long petId
+    ) {
+        log.info("[PetController] 펫 조회 요청 : userId = {}, petId = {}", userId, petId);
+        PetDto pet = petService.read(userId, petId);
+        log.info("[PetController] 펫 조회 완료 : userId = {}, petId = {}", userId, petId);
+        return ResponseEntity.ok().body(pet);
+
     }
 }


### PR DESCRIPTION
## 📌 PR 요약

- 이 PR은 무엇을 해결하거나 개선합니까?
- 펫 조회 기능 구현했습니다.

## ✅ 작업 상세 내용

- [x] petId와 ownerId를 받아 pet의 ownerId와 검증 구현했습니다.
- [x] 유니크 제약 위반 시만 중복 생성 감지하여 예외처리 했습니다.


## 🧪 테스트 방법

- 포스트맨으로 테스트했습니다.
<img width="759" height="684" alt="image" src="https://github.com/user-attachments/assets/110616dd-bfc9-4820-8765-b9aca4f56194" />


## 📎 관련 이슈

- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 반려동물 조회 API 추가: GET /pets/{userId}/{petId}
  - 소유자 검증으로 본인 소유 반려동물만 조회 가능
  - 성공 시 반려동물 상세 정보(PetDto) 반환(조회 전후 로깅 포함)

- 버그 수정
  - 반려동물 생성 시 중복 등록(유니크 제약) 감지 로직 개선
  - 중복일 경우 명확한 중복 오류 안내, 기타 무결성 오류는 재발생 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->