### PR TITLE
[User] 최초 로그인 시 정보 입력

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ logs/
 /.env.*
 *.env
 !.env.sample
+**/keystore

--- a/src/main/java/com/fitpet/server/auth/infra/KakaoClient.java
+++ b/src/main/java/com/fitpet/server/auth/infra/KakaoClient.java
@@ -2,6 +2,7 @@ package com.fitpet.server.auth.infra;
 
 import com.fitpet.server.auth.domain.exception.OAuthProfileNotFoundException;
 import com.fitpet.server.auth.domain.exception.OAuthVerificationFailedException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -25,7 +26,7 @@ public class KakaoClient {
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
             .retrieve()
             .bodyToMono(KakaoMeResponse.class)
-            .timeout(java.time.Duration.ofSeconds(5))   // ← 이 줄 추가
+            .timeout(Duration.ofSeconds(5))
             .onErrorResume(e -> Mono.error(new OAuthVerificationFailedException()))
             .block();
 

--- a/src/main/java/com/fitpet/server/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/fitpet/server/auth/presentation/controller/AuthController.java
@@ -28,17 +28,16 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     private ResponseEntity<TokenResponse> withRefreshCookie(TokenResponse tokens) {
-        ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", tokens.refreshToken())
+        ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", tokens.serverRefreshToken())
             .httpOnly(true).secure(true)   // 운영할 때 반드시 true (HTTPS)
             .sameSite("None")              // 크로스 도메인일 때
             .path("/")
             .maxAge(Duration.ofMillis(jwtTokenProvider.getRefreshExpirationMs()))
             .build();
 
-        // 바디에는 access만 싣고 refresh는 쿠키로만
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, cookie.toString())
-            .body(new TokenResponse(tokens.accessToken(), null)); // refresh는 바디에 안 줌
+            .body(tokens.withoutRefreshToken());// refresh는 바디에 안 줌
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/fitpet/server/auth/presentation/dto/TokenResponse.java
+++ b/src/main/java/com/fitpet/server/auth/presentation/dto/TokenResponse.java
@@ -1,7 +1,21 @@
 package com.fitpet.server.auth.presentation.dto;
 
+import com.fitpet.server.user.domain.entity.RegistrationStatus;
+
 public record TokenResponse(
-        String accessToken,
-        String refreshToken
+        boolean success,
+        RegistrationStatus registrationStatus,
+        String serverAccessToken,
+        String serverRefreshToken
 ) {
+
+    public static TokenResponse success(RegistrationStatus registrationStatus,
+                                        String accessToken,
+                                        String refreshToken) {
+        return new TokenResponse(true, registrationStatus, accessToken, refreshToken);
+    }
+
+    public TokenResponse withoutRefreshToken() {
+        return new TokenResponse(success, registrationStatus, serverAccessToken, null);
+    }
 }

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -18,6 +18,7 @@ public interface UserMapper {
         @Mapping(target = "providerUid", ignore = true),
         @Mapping(target = "deviceToken", ignore = true),
         @Mapping(target = "refreshToken", ignore = true),
+        @Mapping(target = "registrationStatus", ignore = true),
         @Mapping(target = "password", ignore = true),
         @Mapping(target = "createdAt", ignore = true),
         @Mapping(target = "updatedAt", ignore = true)

--- a/src/main/java/com/fitpet/server/user/application/service/UserService.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.fitpet.server.user.application.service;
 
 import com.fitpet.server.user.presentation.dto.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.UserDto;
+import com.fitpet.server.user.presentation.dto.UserInputInfoRequest;
 import com.fitpet.server.user.presentation.dto.UserUpdateRequest;
 
 public interface UserService {
@@ -12,4 +13,8 @@ public interface UserService {
     UserDto updateUser(Long userId, UserUpdateRequest req);
 
     void deleteUser(Long userID);
+
+    UserDto inputInfo(Long userId, UserInputInfoRequest request);
+
+    boolean isRegistrationComplete(Long userId);
 }

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.user.application.service;
 
 import com.fitpet.server.user.application.mapper.UserMapper;
+import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
@@ -8,6 +9,7 @@ import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import com.fitpet.server.user.presentation.dto.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.UserDto;
+import com.fitpet.server.user.presentation.dto.UserInputInfoRequest;
 import com.fitpet.server.user.presentation.dto.UserUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +44,7 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public UserDto findUser(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(UserNotFoundException::new);
         return userMapper.toDto(user);
     }
 
@@ -50,7 +52,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserDto updateUser(Long userId, UserUpdateRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(UserNotFoundException::new);
 
         validateUserUpdateRequest(userId, request);
 
@@ -66,8 +68,34 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(UserNotFoundException::new);
         userRepository.delete(user);
+    }
+
+    @Override
+    @Transactional
+    public UserDto inputInfo(Long userId, UserInputInfoRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+
+        if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+            log.warn("사용자 정보 입력 실패 - 닉네임 중복: {} (요청자 id: {})", maskNickname(request.nickname()), userId);
+            throw new DuplicateNicknameException();
+        }
+
+        user.userInformation(request);
+
+        userRepository.save(user);
+
+        return userMapper.toDto(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isRegistrationComplete(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+        return user.getRegistrationStatus() == RegistrationStatus.COMPLETE;
     }
 
 
@@ -84,12 +112,12 @@ public class UserServiceImpl implements UserService {
 
     private void validateUserUpdateRequest(Long userId, UserUpdateRequest request) {
         if (StringUtils.hasText(request.email()) &&
-                userRepository.existsByEmailAndIdNot(request.email(), userId)) {
+            userRepository.existsByEmailAndIdNot(request.email(), userId)) {
             log.warn("사용자 수정 실패 - 이메일 중복: {} (요청자 id: {})", maskEmail(request.email()), userId);
             throw new DuplicateEmailException();
         }
         if (StringUtils.hasText(request.nickname()) &&
-                userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+            userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
             log.warn("사용자 수정 실패 - 닉네임 중복: {} (요청자 id: {})", maskNickname(request.nickname()), userId);
             throw new DuplicateNicknameException();
         }

--- a/src/main/java/com/fitpet/server/user/domain/entity/RegistrationStatus.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/RegistrationStatus.java
@@ -1,0 +1,5 @@
+package com.fitpet.server.user.domain.entity;
+
+public enum RegistrationStatus {
+    COMPLETE, INCOMPLETE
+}

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -15,6 +15,7 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -81,6 +82,10 @@ public class User {
     @Column(name = "refresh_token", length = 255)
     private String refreshToken;
 
+    @Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "registration_status", nullable = false, length = 20)
+    private RegistrationStatus registrationStatus = RegistrationStatus.INCOMPLETE;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false,

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.user.domain.entity;
 
 
+import com.fitpet.server.user.presentation.dto.UserInputInfoRequest;
 import com.fitpet.server.user.presentation.dto.UserUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -131,6 +132,18 @@ public class User {
         if (request.targetPbf() != null) {
             this.targetPbf = request.targetPbf();
         }
+    }
+
+    public void userInformation(UserInputInfoRequest request) {
+        this.nickname = request.nickname();
+        this.age = request.age();
+        this.gender = request.gender();
+        this.weightKg = request.weightKg();
+        this.targetWeightKg = request.targetWeightKg();
+        this.heightCm = request.heightCm();
+        this.pbf = null;
+        this.targetPbf = null;
+        this.registrationStatus = RegistrationStatus.COMPLETE;
     }
 
     public void linkSocial(String provider, String providerUid) {

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserInputInfoRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserInputInfoRequest.java
@@ -1,0 +1,26 @@
+package com.fitpet.server.user.presentation.dto;
+
+import com.fitpet.server.user.domain.entity.Gender;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+public record UserInputInfoRequest(
+    @NotNull
+    @Length(min = 5, max = 20, message = "닉네임은 5자 이상 20자 미만이어야 합니다.")
+    String nickname,
+
+    @NotNull
+    int age,
+
+    @NotNull
+    Gender gender,
+
+    @NotNull
+    Double weightKg,
+    @NotNull
+    Double heightCm,
+    Double targetWeightKg,
+    Double pbf,
+    Double targetPbf
+) {
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8"/>
+    <title>FitPet OAuth/JWT 테스트</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Google Identity Services -->
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <!-- Kakao JS SDK (JS 키 필요: REST 키 아님) -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.min.js"></script>
+    <style>
+        body {
+            font-family: ui-sans-serif, system-ui, -apple-system;
+            max-width: 920px;
+            margin: 24px auto;
+            padding: 0 16px;
+        }
+
+        h1 {
+            font-size: 22px;
+            margin: 0 0 8px;
+        }
+
+        fieldset {
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 14px;
+            margin: 14px 0;
+        }
+
+        legend {
+            padding: 0 6px;
+            color: #374151;
+        }
+
+        label {
+            display: block;
+            font-size: 13px;
+            color: #6b7280;
+            margin: 6px 0 4px;
+        }
+
+        input, button {
+            padding: 10px 12px;
+            border: 1px solid #d1d5db;
+            border-radius: 10px;
+            font-size: 14px;
+        }
+
+        input[type=text] {
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        .row {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .grow {
+            flex: 1;
+            min-width: 240px;
+        }
+
+        .btn {
+            cursor: pointer;
+            background: #111827;
+            color: white;
+            border: none;
+        }
+
+        .btn.light {
+            background: #f3f4f6;
+            color: #111827;
+            border: 1px solid #e5e7eb;
+        }
+
+        .token {
+            word-break: break-all;
+            background: #f9fafb;
+            padding: 10px;
+            border-radius: 10px;
+            border: 1px dashed #e5e7eb;
+            min-height: 38px;
+        }
+
+        .ok {
+            color: #137333;
+            white-space: pre-wrap;
+        }
+
+        .err {
+            color: #c5221f;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+<body>
+<h1>FitPet OAuth/JWT 테스트</h1>
+
+<fieldset>
+    <legend>환경</legend>
+    <div class="row">
+        <div class="grow">
+            <label>Backend Base URL</label>
+            <input id="baseUrl" type="text" value="https://localhost:8443">
+        </div>
+    </div>
+    <div class="row">
+        <div class="grow">
+            <label>Google Client ID (웹)</label>
+            <input id="googleClientId" type="text"
+                   value="670074275623-4pqtm5i7a7octebi7qnpgsvb1m0sh3l6.apps.googleusercontent.com">
+        </div>
+        <div class="grow">
+            <label>Kakao JavaScript Key (앱 설정의 JS 키)</label>
+            <input id="kakaoJsKey" type="text" value="18c019f0750792b5c858ba163ed720fb">
+        </div>
+    </div>
+    <div class="row" style="margin-top:8px">
+        <button class="btn light" onclick="initProviders()">Google/Kakao 초기화</button>
+    </div>
+    <small>
+        ※ 로컬 http 환경에서 refresh 쿠키가 안 보이면 서버가 <code>secure(true)</code>로 내려서 그럴 수 있어요(HTTPS 전용).<br/>
+        개발용으로는 서버에서 refresh 쿠키를 <code>secure(false)</code>로 내려 테스트하세요.
+    </small>
+</fieldset>
+
+<fieldset>
+    <legend>로그인</legend>
+    <div class="row" style="gap:12px">
+        <button class="btn" onclick="googlePopup()">구글 로그인 팝업</button>
+        <div id="googleButtonContainer"></div>
+        <button class="btn" style="background:#fee500; color:#191600" onclick="kakaoPopup()">카카오 로그인 팝업</button>
+    </div>
+</fieldset>
+
+<fieldset>
+    <legend>토큰/세션</legend>
+    <div class="row">
+        <button class="btn light" onclick="refresh()">리프레시로 Access 재발급</button>
+        <button class="btn light" onclick="logout()">로그아웃</button>
+        <button class="btn light" onclick="clearAccess()">Access 지우기(프론트 저장)</button>
+    </div>
+    <label>Access Token</label>
+    <div id="access" class="token"></div>
+</fieldset>
+
+<fieldset>
+    <legend>로그</legend>
+    <div class="ok" id="ok"></div>
+    <div class="err" id="err"></div>
+</fieldset>
+
+<script>
+    // -----------------------------
+    // 상태/도움 함수
+    // -----------------------------
+    const $ = (id) => document.getElementById(id);
+    const ok = (t) => {
+        $('ok').textContent = t || '';
+        $('err').textContent = '';
+    };
+    const err = (t) => {
+        $('err').textContent = (typeof t === 'string') ? t : JSON.stringify(t, null, 2);
+        $('ok').textContent = '';
+    };
+    const getBase = () => $('baseUrl').value.trim();
+
+    function setAccess(t) {
+        localStorage.setItem('fitpet_access', t || '');
+        $('access').textContent = t || '';
+    }
+
+    function getAccess() {
+        return localStorage.getItem('fitpet_access') || '';
+    }
+
+    function clearAccess() {
+        setAccess('');
+        ok('Access 토큰 삭제됨(로컬 저장소)');
+    }
+
+    // -----------------------------
+    // Provider 초기화
+    // -----------------------------
+    let googleInitialized = false;
+    let kakaoInitialized = false;
+
+    function initProviders() {
+        // Google
+        const gid = $('googleClientId').value.trim();
+        if (gid) {
+            try {
+                google.accounts.id.initialize({
+                    client_id: gid,
+                    callback: onGoogleCredential,
+                    ux_mode: 'popup'
+                });
+                // 공식 버튼 렌더(선택)
+                const container = $('googleButtonContainer');
+                container.innerHTML = '';
+                google.accounts.id.renderButton(container, {theme: 'outline', size: 'large'});
+                googleInitialized = true;
+            } catch (e) {
+                err('Google 초기화 실패: ' + e.message);
+            }
+        } else {
+            err('Google Client ID를 입력하세요.');
+        }
+
+        // Kakao
+        const kkey = $('kakaoJsKey').value.trim();
+        if (kkey) {
+            try {
+                if (!window.Kakao) throw new Error('Kakao SDK 로드 실패');
+                if (!Kakao.isInitialized()) Kakao.init(kkey);
+                kakaoInitialized = true;
+                ok('초기화 완료');
+            } catch (e) {
+                err('Kakao 초기화 실패: ' + e.message);
+            }
+        } else {
+            err('Kakao JavaScript 키를 입력하세요.');
+        }
+    }
+
+    // -----------------------------
+    // Google 로그인
+    // -----------------------------
+    function googlePopup() {
+        if (!googleInitialized) {
+            return err('먼저 Google/Kakao 초기화 버튼을 눌러 초기화하세요.');
+        }
+        try {
+            // 팝업 호출 (원탭/프롬프트)
+            google.accounts.id.prompt((notification) => {
+                if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+                    // 버튼 클릭 유도(이미 렌더됨)
+                    ok('팝업이 차단되었거나 표시되지 않았습니다. 옆의 Google 버튼을 클릭해보세요.');
+                }
+            });
+        } catch (e) {
+            err('Google 팝업 실패: ' + e.message);
+        }
+    }
+
+    function onGoogleCredential(resp) {
+        const idToken = resp.credential; // Google ID Token
+        ok('구글 id_token 수신 → 서버로 전송 중...');
+        fetch(getBase() + '/auth/oauth/google', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            credentials: 'include', // refresh 쿠키 수신
+            body: JSON.stringify({idToken})
+        })
+            .then(r => r.json().then(b => ({ok: r.ok, body: b})))
+            .then(({ok: okRes, body}) => {
+                if (!okRes) throw body;
+                setAccess(body.accessToken || '');
+                ok('구글 로그인 성공');
+            })
+            .catch(err);
+    }
+
+    // -----------------------------
+    // Kakao 로그인
+    // -----------------------------
+    function kakaoPopup() {
+        if (!kakaoInitialized) {
+            return err('먼저 Google/Kakao 초기화 버튼을 눌러 초기화하세요.');
+        }
+        try {
+            Kakao.Auth.login({
+                scope: 'account_email', // 필요시 확장
+                success: async function (authObj) {
+                    ok('카카오 access_token 수신 → 서버로 전송 중...');
+                    const res = await fetch(getBase() + '/auth/oauth/kakao', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        credentials: 'include', // refresh 쿠키 수신
+                        body: JSON.stringify({accessToken: authObj.access_token})
+                    });
+                    const data = await res.json();
+                    if (!res.ok) throw data;
+                    setAccess(data.accessToken || '');
+                    ok('카카오 로그인 성공');
+                },
+                fail: function (e) {
+                    err(e);
+                }
+            });
+        } catch (e) {
+            err('Kakao 팝업 실패: ' + e.message);
+        }
+    }
+
+    // -----------------------------
+    // 세션 조작 (리프레시/로그아웃)
+    // -----------------------------
+    async function refresh() {
+        ok('리프레시 중...');
+        try {
+            const res = await fetch(getBase() + '/auth/refresh', {
+                method: 'POST',
+                credentials: 'include' // 쿠키 전송
+            });
+            const data = await res.json();
+            if (!res.ok) throw data;
+            setAccess(data.accessToken || '');
+            ok('액세스 토큰 재발급 성공');
+        } catch (e) {
+            err(e);
+        }
+    }
+
+    async function logout() {
+        ok('로그아웃 중...');
+        try {
+            const at = getAccess();
+            const res = await fetch(getBase() + '/auth/logout', {
+                method: 'POST',
+                headers: {'Authorization': 'Bearer ' + at},
+                credentials: 'include' // 쿠키 만료 수신
+            });
+            if (!res.ok) throw await res.text();
+            clearAccess();
+            ok('로그아웃 성공');
+        } catch (e) {
+            err(e);
+        }
+    }
+
+    // 초기 표시
+    document.addEventListener('DOMContentLoaded', () => {
+        setAccess(getAccess());
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 요약

- 이 PR은 무엇을 해결하거나 개선합니까?
- 최초 로그인 시 정보 입력 받아 사용자 정보에 저장하는 로직 구현했습니다.

## ✅ 작업 상세 내용

- [x] Controller에서 Http 헤더를 통해 유저를 받아옵니다
- [x] 헤더를 통해 Registration 값을 확인 후 INCOMPLETED인 경우 정보를 입력받는 창으로 넘어갑니다

## 🧪 테스트 방법

- 기능 테스트 방식 또는 실행 방법을 설명해주세요.
- 포스트맨으로 테스트했습니다.
- 최초 로그인 후 정보 입력 받는 테스트
<img width="735" height="584" alt="스크린샷 2025-09-29 오후 5 44 45" src="https://github.com/user-attachments/assets/caf62cad-718c-4c14-ba9c-cecf3425ef3b" />
- 최초 로그인이 아닌 경우 테스트
<img width="771" height="616" alt="스크린샷 2025-09-29 오후 6 03 09" src="https://github.com/user-attachments/assets/22faf4e8-bf73-4d3f-a34b-8b97bce9749a" />




## 📎 관련 이슈

- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 회원가입 완료(정보 입력) API 추가 및 유효성 검증 강화
  - 로그인/토큰 응답에 가입 상태 포함 및 성공 여부 제공
  - 리프레시 토큰을 응답 본문에서 제거하고 안전한 쿠키로만 전달
  - OAuth/JWT 테스트용 정적 페이지 추가(구글·카카오 로그인, 토큰 갱신, 로그아웃 지원)
- Refactor
  - 토큰 발급 로직 단일화로 응답 일관성 개선
- Chores
  - keystore 디렉터리 무시 규칙 추가 (.gitignore)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->