### PR TITLE
[Pet] 펫 수정 기능 구현

### DIFF
--- a/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
+++ b/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
@@ -14,18 +14,20 @@ public interface PetMapper {
 
     // 생성: 요청 + 소유자(User) -> 엔티티
     @Mappings({
-        @Mapping(target = "id", ignore = true),
-        @Mapping(target = "exp", expression = "java(0L)"),
-        @Mapping(target = "createdAt", ignore = true),
-        @Mapping(target = "updatedAt", ignore = true),
-        @Mapping(target = "owner", source = "owner")   // 소유자
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "exp", expression = "java(0L)"),
+            @Mapping(target = "createdAt", ignore = true),
+            @Mapping(target = "updatedAt", ignore = true),
+            @Mapping(target = "color", source = "request.color"),
+            @Mapping(target = "owner", source = "owner")   // 소유자
     })
     Pet toEntity(PetCreateRequest request, User owner);
 
     // 엔티티 -> DTO
     @Mappings({
-        @Mapping(target = "petId", source = "id"),
-        @Mapping(target = "ownerId", source = "owner.id")
+            @Mapping(target = "petId", source = "id"),
+            @Mapping(target = "ownerId", source = "owner.id"),
+            @Mapping(target = "color", source = "color")
     })
     PetDto toDto(Pet pet);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetService.java
@@ -2,6 +2,7 @@ package com.fitpet.server.pet.application.service;
 
 import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
 import com.fitpet.server.pet.presentation.dto.PetDto;
+import com.fitpet.server.pet.presentation.dto.PetUpdateRequest;
 
 public interface PetService {
     PetDto createPet(Long ownerId, PetCreateRequest request);
@@ -10,5 +11,5 @@ public interface PetService {
 
     PetDto findPet(Long ownerId, Long petId);
 
-    PetDto updatePet(Long petId);
+    PetDto updatePet(Long owerId, Long petId, PetUpdateRequest request);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetService.java
@@ -11,5 +11,5 @@ public interface PetService {
 
     PetDto findPet(Long ownerId, Long petId);
 
-    PetDto updatePet(Long owerId, Long petId, PetUpdateRequest request);
+    PetDto updatePet(Long ownerId, Long petId, PetUpdateRequest request);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetService.java
@@ -4,9 +4,11 @@ import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
 import com.fitpet.server.pet.presentation.dto.PetDto;
 
 public interface PetService {
-    PetDto create(Long ownerId, PetCreateRequest request);
+    PetDto createPet(Long ownerId, PetCreateRequest request);
 
-    void delete(Long ownerId, Long petId);
+    void deletePet(Long ownerId, Long petId);
 
-    PetDto read(Long ownerId, Long petId);
+    PetDto findPet(Long ownerId, Long petId);
+
+    PetDto updatePet(Long petId);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
@@ -104,7 +104,7 @@ public class PetServiceImpl implements PetService {
             throw new PetAccessDeniedException();
         }
 
-        pet.update(request);
+        pet.update(request.name(), request.petType(), request.color());
 
         log.info("[PetService] Pet 수정 완료: ownerId={}, petId={}", ownerId, petId);
         return petMapper.toDto(pet);

--- a/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
@@ -29,7 +29,7 @@ public class PetServiceImpl implements PetService {
 
     @Override
     @Transactional
-    public PetDto create(Long ownerId, PetCreateRequest request) {
+    public PetDto createPet(Long ownerId, PetCreateRequest request) {
         log.info("[PetService] Pet 생성 시작: ownerId ={}", ownerId);
         User owner = userRepository.findById(ownerId).orElseThrow(UserNotFoundException::new);
 
@@ -50,16 +50,16 @@ public class PetServiceImpl implements PetService {
 
     @Override
     @Transactional
-    public void delete(Long ownerId, Long petId) {
+    public void deletePet(Long ownerId, Long petId) {
         log.info("[PetService] Pet 삭제 시작: ownerId={}, petId={}", ownerId, petId);
 
         Pet pet = petRepository.findById(petId)
-            .orElseThrow(PetNotFoundException::new);
+                .orElseThrow(PetNotFoundException::new);
 
         Long petOwnerId = pet.getOwner().getId();
         if (!petOwnerId.equals(ownerId)) {
             log.warn("[PetService] 삭제 권한 없음: 요청 ownerId={}, 실제 ownerId={}, petId={}",
-                ownerId, petOwnerId, petId);
+                    ownerId, petOwnerId, petId);
             throw new PetAccessDeniedException();
         }
 
@@ -70,16 +70,16 @@ public class PetServiceImpl implements PetService {
 
     @Override
     @Transactional(readOnly = true)
-    public PetDto read(Long ownerId, Long petId) {
+    public PetDto findPet(Long ownerId, Long petId) {
         log.info("[PetService] Pet 조회 시작: petId={}", petId);
 
         Pet pet = petRepository.findById(petId)
-            .orElseThrow(PetNotFoundException::new);
+                .orElseThrow(PetNotFoundException::new);
 
         Long petOwnerId = pet.getOwner().getId();
         if (!petOwnerId.equals(ownerId)) {
             log.warn("[PetService] 조회 권한 없음: 요청 ownerId={}, 실제 ownerId={}, petId={}",
-                ownerId, petOwnerId, petId);
+                    ownerId, petOwnerId, petId);
             throw new PetAccessDeniedException();
         }
 

--- a/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetServiceImpl.java
@@ -92,6 +92,8 @@ public class PetServiceImpl implements PetService {
     @Override
     @Transactional
     public PetDto updatePet(Long ownerId, Long petId, PetUpdateRequest request) {
+        log.info("[PetService] Pet 수정 시작: ownerId={}, petId={}", ownerId, petId);
+
         Pet pet = petRepository.findById(petId)
                 .orElseThrow(PetNotFoundException::new);
 
@@ -104,6 +106,7 @@ public class PetServiceImpl implements PetService {
 
         pet.update(request);
 
+        log.info("[PetService] Pet 수정 완료: ownerId={}, petId={}", ownerId, petId);
         return petMapper.toDto(pet);
     }
 

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -61,6 +61,9 @@ public class Pet {
     @Column(name = "pet_type", nullable = false, length = 20)
     private PetType petType;
 
+    @Column(length = 9, nullable = false)
+    private String color;
+
     @Column(name = "exp", nullable = true)
     private Long exp; // 기본 0
 

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -1,6 +1,5 @@
 package com.fitpet.server.pet.domain.entity;
 
-import com.fitpet.server.pet.presentation.dto.PetUpdateRequest;
 import com.fitpet.server.user.domain.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -76,15 +75,15 @@ public class Pet {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void update(PetUpdateRequest request) {
-        if (request.name() != null && !request.name().isBlank()) {
-            this.name = request.name();
+    public void update(String name, PetType petType, String color) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
         }
-        if (request.petType() != null) {
-            this.petType = request.petType();
+        if (petType != null) {
+            this.petType = petType;
         }
-        if (request.color() != null && !request.color().isBlank()) {
-            this.color = request.color();
+        if (color != null && !color.isBlank()) {
+            this.color = color;
         }
     }
 

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.pet.domain.entity;
 
+import com.fitpet.server.pet.presentation.dto.PetUpdateRequest;
 import com.fitpet.server.user.domain.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,12 +30,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "pet",
-    uniqueConstraints = {
-        @UniqueConstraint(name = "uk_pet_owner", columnNames = "user_id")
-    },
-    indexes = {
-        @Index(name = "idx_pet_owner", columnList = "user_id")
-    }
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_pet_owner", columnNames = "user_id")
+        },
+        indexes = {
+                @Index(name = "idx_pet_owner", columnList = "user_id")
+        }
 )
 @Getter
 @NoArgsConstructor
@@ -49,9 +50,9 @@ public class Pet {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id",
-        nullable = false,
-        unique = true,
-        foreignKey = @ForeignKey(name = "fk_pet_user"))
+            nullable = false,
+            unique = true,
+            foreignKey = @ForeignKey(name = "fk_pet_user"))
     private User owner;
 
     @Column(nullable = false, length = 60)
@@ -75,9 +76,15 @@ public class Pet {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public void updateName(String newName) {
-        if (newName != null && !newName.isBlank()) {
-            this.name = newName;
+    public void update(PetUpdateRequest request) {
+        if (request.name() != null && !request.name().isBlank()) {
+            this.name = request.name();
+        }
+        if (request.petType() != null) {
+            this.petType = request.petType();
+        }
+        if (request.color() != null && !request.color().isBlank()) {
+            this.color = request.color();
         }
     }
 

--- a/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
@@ -25,44 +25,44 @@ public class PetController {
 
     @PostMapping("/{userId}")
     public ResponseEntity<PetDto> create(
-        @PathVariable Long userId,
-        @Valid @RequestBody PetCreateRequest request
+            @PathVariable Long userId,
+            @Valid @RequestBody PetCreateRequest request
     ) {
 
         log.info("[PetController] 펫 생성 요청 : petName = {} , petType = {},  ownerId = {}",
-            request.name(), request.petType(), userId);
+                request.name(), request.petType(), userId);
 
-        PetDto createdPet = petService.create(userId, request);
+        PetDto createdPet = petService.createPet(userId, request);
 
         log.info("[PetController] 펫 생성 완료 : petName = {} , petType = {},  ownerId = {}",
-            request.name(), request.petType(), userId);
+                request.name(), request.petType(), userId);
 
         return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(createdPet);
+                .status(HttpStatus.CREATED)
+                .body(createdPet);
     }
 
     @DeleteMapping("/{userId}/{petId}")
     public ResponseEntity<Void> delete(
-        @PathVariable Long userId,
-        @PathVariable Long petId
+            @PathVariable Long userId,
+            @PathVariable Long petId
     ) {
         log.info("[PetController] 펫 삭제 요청 : userId = {}, petId = {}", userId, petId);
-        petService.delete(userId, petId);
+        petService.deletePet(userId, petId);
         log.info("[PetController] 펫 삭제 완료 : userId = {}, petId = {}", userId, petId);
 
         return ResponseEntity
-            .noContent()
-            .build();
+                .noContent()
+                .build();
     }
 
     @GetMapping("/{userId}/{petId}")
     public ResponseEntity<PetDto> read(
-        @PathVariable Long userId,
-        @PathVariable Long petId
+            @PathVariable Long userId,
+            @PathVariable Long petId
     ) {
         log.info("[PetController] 펫 조회 요청 : userId = {}, petId = {}", userId, petId);
-        PetDto pet = petService.read(userId, petId);
+        PetDto pet = petService.findPet(userId, petId);
         log.info("[PetController] 펫 조회 완료 : userId = {}, petId = {}", userId, petId);
         return ResponseEntity.ok().body(pet);
 

--- a/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/controller/PetController.java
@@ -3,6 +3,7 @@ package com.fitpet.server.pet.presentation.controller;
 import com.fitpet.server.pet.application.service.PetService;
 import com.fitpet.server.pet.presentation.dto.PetCreateRequest;
 import com.fitpet.server.pet.presentation.dto.PetDto;
+import com.fitpet.server.pet.presentation.dto.PetUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -65,6 +67,17 @@ public class PetController {
         PetDto pet = petService.findPet(userId, petId);
         log.info("[PetController] 펫 조회 완료 : userId = {}, petId = {}", userId, petId);
         return ResponseEntity.ok().body(pet);
+    }
 
+    @PatchMapping("/{userId}/{petId}")
+    public ResponseEntity<PetDto> update(
+            @PathVariable Long userId,
+            @PathVariable Long petId,
+            @Valid @RequestBody PetUpdateRequest request
+    ) {
+        log.info("[PetController] 펫 수정 요청 : userId = {}, petId = {}", userId, petId);
+        PetDto pet = petService.updatePet(userId, petId, request);
+        log.info("[PetController] 펫 수정 완료 : userId = {}, petId = {}", userId, petId);
+        return ResponseEntity.ok().body(pet);
     }
 }

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
@@ -1,11 +1,12 @@
 package com.fitpet.server.pet.presentation.dto;
 
+import com.fitpet.server.pet.domain.entity.PetType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PetCreateRequest(
-    @NotBlank String name,
-    @NotNull String petType, // enum 문자열로 받음: "DOG", "CAT"
-    @NotNull String color
+        @NotBlank String name,
+        @NotNull PetType petType,
+        @NotNull String color
 ) {
 }

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record PetCreateRequest(
     @NotBlank String name,
-    @NotNull String petType // enum 문자열로 받음: "DOG", "CAT"
+    @NotNull String petType, // enum 문자열로 받음: "DOG", "CAT"
+    @NotNull String color
 ) {
 }

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetCreateRequest.java
@@ -7,6 +7,6 @@ import jakarta.validation.constraints.NotNull;
 public record PetCreateRequest(
         @NotBlank String name,
         @NotNull PetType petType,
-        @NotNull String color
+        @NotBlank String color
 ) {
 }

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
@@ -8,6 +8,7 @@ public record PetDto(
     Long ownerId,
     String name,
     PetType petType,
+    String color,
     Long exp,
     LocalDateTime createdAt,
     LocalDateTime updatedAt

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.fitpet.server.pet.presentation.dto;
+
+import com.fitpet.server.pet.domain.entity.PetType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PetUpdateRequest(
+        @NotBlank String name,
+        @NotNull PetType petType,
+        @NotNull String color
+) {
+}

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetUpdateRequest.java
@@ -1,12 +1,10 @@
 package com.fitpet.server.pet.presentation.dto;
 
 import com.fitpet.server.pet.domain.entity.PetType;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record PetUpdateRequest(
-        @NotBlank String name,
-        @NotNull PetType petType,
-        @NotNull String color
+        String name,
+        PetType petType,
+        String color
 ) {
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
             "/users/**",
             "/daily/**",
             "/body-histories/**",
-            "/actuator/**"
+            "/actuator/**",
+            "/pets/**"
     };
 
     @Bean


### PR DESCRIPTION
## 📌 PR 요약

- Pet color 컬럼 추가 및 수정 로직 구현

## ✅ 작업 상세 내용

- [ ] Pet 이름,색상,타입 수정하는 기능 구현
- [ ] Pet 엔티티에 색상 컬럼 추가
## 🧪 테스트 방법

- 기존 펫
<img width="450" height="294" alt="image" src="https://github.com/user-attachments/assets/bac6cfe4-a9b9-42b6-9b15-065fef856245" />

- 수정 후 펫
<img width="443" height="327" alt="image" src="https://github.com/user-attachments/assets/5c2e0075-b3b4-4d80-8267-e64df9a36f4a" />

## 📎 관련 이슈

- Close #123

## 추가 전달 사항
- 색상컬럼이 String 인 이유는 프론트측에서 색상코드를 받기 위함 입니다 !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 펫에 색상(color) 속성 추가 — 응답(PetDto)과 생성/수정 요청에 color 포함
  * 펫 수정 엔드포인트 추가 (PATCH /pets/{userId}/{petId}) — 펫 이름/종류/색상 변경 지원
  * 수정 요청 형식 추가 및 생성 요청에서 petType이 enum으로 변경(요청 페이로드 확장)
* **Chores**
  * /pets/** 경로를 공개 접근 허용하도록 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->