### PR TITLE
[미션/펫] 미션, 목표걸음수 달성 시 펫 표정 변화

### DIFF
--- a/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
+++ b/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
@@ -27,6 +27,8 @@ public interface MissionCheckMapper {
     @Mapping(target = "user", source = "user")
     @Mapping(target = "completed", source = "request.completed")
     @Mapping(target = "checkAt", source = "request.checkDate")
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
     MissionCheck create(Mission mission, User user, MissionCheckRequest request);
 
     default MissionCheck updateFromRequest(@MappingTarget MissionCheck target, MissionCheckRequest request) {

--- a/src/main/java/com/fitpet/server/mission/application/mapper/MissionMapper.java
+++ b/src/main/java/com/fitpet/server/mission/application/mapper/MissionMapper.java
@@ -3,13 +3,9 @@ package com.fitpet.server.mission.application.mapper;
 import com.fitpet.server.mission.domain.entity.Mission;
 import com.fitpet.server.mission.presentation.dto.MissionCreateRequest;
 import com.fitpet.server.mission.presentation.dto.MissionDto;
-import com.fitpet.server.mission.presentation.dto.MissionUpdateRequest;
 import java.util.List;
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -25,7 +21,4 @@ public interface MissionMapper {
     @Mapping(target = "id", ignore = true)
     Mission toEntity(MissionCreateRequest request);
 
-    // UpdateRequest -> Entity (부분 갱신; null은 무시)
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    void updateFromRequest(MissionUpdateRequest request, @MappingTarget Mission target);
 }

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
@@ -24,6 +24,8 @@ public class MissionServiceImpl implements MissionService {
 
     @Override
     public MissionDto createMission(MissionCreateRequest request) {
+        log.info("[MissionService] 미션 생성 요청: title={}, type={}, goal={}",
+            request.title(), request.type(), request.goal());
         Mission mission = missionMapper.toEntity(request);
         Mission saved = missionRepository.save(mission);
         log.info("[MissionService] 미션 생성: missionId={}", saved.getId());
@@ -33,19 +35,24 @@ public class MissionServiceImpl implements MissionService {
     @Override
     @Transactional(readOnly = true)
     public List<MissionDto> getMissions() {
+        log.info("[MissionService] 미션 전체 조회 요청");
         return missionMapper.toDtos(missionRepository.findAll());
     }
 
     @Override
     @Transactional(readOnly = true)
     public MissionDto getMission(Long missionId) {
+        log.info("[MissionService] 미션 단건 조회 요청: missionId={}", missionId);
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(MissionNotFoundException::new);
+        log.info("[MissionService] 미션 단건 조회 완료: missionId={}", missionId);
         return missionMapper.toDto(mission);
     }
 
     @Override
     public MissionDto updateMission(Long missionId, MissionUpdateRequest request) {
+        log.info("[MissionService] 미션 수정 요청: missionId={}, title={}, type={}, goal={}",
+            missionId, request.title(), request.type(), request.goal());
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(MissionNotFoundException::new);
         mission.update(request.title(), request.content(), request.type(), request.goal());

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
@@ -48,7 +48,7 @@ public class MissionServiceImpl implements MissionService {
     public MissionDto updateMission(Long missionId, MissionUpdateRequest request) {
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(MissionNotFoundException::new);
-        missionMapper.updateFromRequest(request, mission);
+        mission.update(request.title(), request.content(), request.type(), request.goal());
         Mission updated = missionRepository.save(mission);
         log.info("[MissionService] 미션 수정: missionId={}", updated.getId());
         return missionMapper.toDto(updated);

--- a/src/main/java/com/fitpet/server/mission/presentation/controller/MissionController.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/controller/MissionController.java
@@ -34,7 +34,10 @@ public class MissionController {
 
     @PostMapping
     public ResponseEntity<MissionDto> createMission(@Valid @RequestBody MissionCreateRequest request) {
+        log.info("[MissionController] 미션 생성 요청: title={}, type={}", request.title(), request.type());
         MissionDto created = missionService.createMission(request);
+        log.info("[MissionController] 미션 생성 완료: missionId={}, title={}, type={}", created.missionId(),
+            created.title(), created.type());
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{missionId}")
                 .buildAndExpand(created.missionId())
@@ -44,23 +47,34 @@ public class MissionController {
 
     @GetMapping
     public ResponseEntity<List<MissionDto>> getMissions() {
-        return ResponseEntity.ok(missionService.getMissions());
+        log.info("[MissionController] 미션 전체 조회 요청");
+        List<MissionDto> responses = missionService.getMissions();
+        log.info("[MissionController] 미션 전체 조회 완료: count={}", responses.size());
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/{missionId}")
     public ResponseEntity<MissionDto> getMission(@PathVariable Long missionId) {
-        return ResponseEntity.ok(missionService.getMission(missionId));
+        log.info("[MissionController] 미션 단건 조회 요청: missionId={}", missionId);
+        MissionDto response = missionService.getMission(missionId);
+        log.info("[MissionController] 미션 단건 조회 완료: missionId={}", missionId);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/{missionId}")
     public ResponseEntity<MissionDto> updateMission(@PathVariable Long missionId,
                                                     @Valid @RequestBody MissionUpdateRequest request) {
-        return ResponseEntity.ok(missionService.updateMission(missionId, request));
+        log.info("[MissionController] 미션 수정 요청: missionId={}, title={}, type={}", missionId, request.title(),
+            request.type());
+        MissionDto updated = missionService.updateMission(missionId, request);
+        log.info("[MissionController] 미션 수정 완료: missionId={}", missionId);
+        return ResponseEntity.ok(updated);
     }
 
     @DeleteMapping("/{missionId}")
     public ResponseEntity<Void> deleteMission(@PathVariable Long missionId) {
         missionService.deleteMission(missionId);
+        log.info("[MissionController] 미션 삭제 완료: missionId={}", missionId);
         return ResponseEntity.noContent().build();
     }
 
@@ -68,18 +82,26 @@ public class MissionController {
     public ResponseEntity<MissionCheckDto> upsertMissionCheck(@PathVariable Long missionId,
                                                               @PathVariable Long userId,
                                                               @Valid @RequestBody MissionCheckRequest request) {
+        log.info("[MissionController] 미션 수행 여부 저장 요청: missionId={}, userId={}, date={}, completed={}",
+            missionId, userId, request.checkDate(), request.completed());
         MissionCheckDto response = missionCheckService.upsertMissionCheck(missionId, userId, request);
+        log.info("[MissionController] 미션 수행 여부 저장 완료: missionCheckId={}, missionId={}, userId={}",
+            response.missionCheckId(), missionId, userId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/users/{userId}/checks")
     public ResponseEntity<List<MissionCheckDto>> getMissionChecks(@PathVariable Long userId) {
-        return ResponseEntity.ok(missionCheckService.getMissionChecks(userId));
+        log.info("[MissionController] 사용자 수행 기록 조회 요청: userId={}", userId);
+        List<MissionCheckDto> responses = missionCheckService.getMissionChecks(userId);
+        log.info("[MissionController] 사용자 수행 기록 조회 완료: userId={}, count={}", userId, responses.size());
+        return ResponseEntity.ok(responses);
     }
 
     @DeleteMapping("/checks/{missionCheckId}")
     public ResponseEntity<Void> deleteMissionCheck(@PathVariable Long missionCheckId) {
         missionCheckService.deleteMissionCheck(missionCheckId);
+        log.info("[MissionController] 미션 수행 기록 삭제 완료: missionCheckId={}", missionCheckId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
+++ b/src/main/java/com/fitpet/server/pet/application/mapper/PetMapper.java
@@ -27,7 +27,8 @@ public interface PetMapper {
     @Mappings({
             @Mapping(target = "petId", source = "id"),
             @Mapping(target = "ownerId", source = "owner.id"),
-            @Mapping(target = "color", source = "color")
+            @Mapping(target = "color", source = "color"),
+            @Mapping(target = "expression", source = "expression")
     })
     PetDto toDto(Pet pet);
 }

--- a/src/main/java/com/fitpet/server/pet/application/service/PetExpressionService.java
+++ b/src/main/java/com/fitpet/server/pet/application/service/PetExpressionService.java
@@ -1,0 +1,23 @@
+package com.fitpet.server.pet.application.service;
+
+import com.fitpet.server.pet.domain.entity.PetExpression;
+import com.fitpet.server.pet.domain.repository.PetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PetExpressionService {
+
+    private final PetRepository petRepository;
+
+    @Transactional
+    public void updateExpression(Long ownerId, PetExpression expression) {
+        if (expression == null || ownerId == null) {
+            return;
+        }
+        petRepository.findByOwnerId(ownerId)
+            .ifPresent(pet -> pet.changeExpression(expression));
+    }
+}

--- a/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/Pet.java
@@ -20,6 +20,7 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -67,6 +68,11 @@ public class Pet {
     @Column(name = "exp", nullable = true)
     private Long exp; // 기본 0
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "expression", nullable = false, length = 20)
+    @Default
+    private PetExpression expression = PetExpression.NEUTRAL;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -87,6 +93,12 @@ public class Pet {
         }
     }
 
+    public void changeExpression(PetExpression newExpression) {
+        if (newExpression != null) {
+            this.expression = newExpression;
+        }
+    }
+
     public void addExp(long amount) {
         if (amount <= 0) {
             return;
@@ -101,6 +113,9 @@ public class Pet {
     void prePersist() {
         if (this.exp == null) {
             this.exp = 0L;
+        }
+        if (this.expression == null) {
+            this.expression = PetExpression.NEUTRAL;
         }
     }
 }

--- a/src/main/java/com/fitpet/server/pet/domain/entity/PetExpression.java
+++ b/src/main/java/com/fitpet/server/pet/domain/entity/PetExpression.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.pet.domain.entity;
+
+public enum PetExpression {
+    NEUTRAL,
+    HAPPY,
+    PROUD,
+    TIRED
+}

--- a/src/main/java/com/fitpet/server/pet/domain/repository/PetRepository.java
+++ b/src/main/java/com/fitpet/server/pet/domain/repository/PetRepository.java
@@ -8,5 +8,7 @@ public interface PetRepository {
 
     Optional<Pet> findById(Long petId);
 
+    Optional<Pet> findByOwnerId(Long ownerId);
+
     void delete(Pet pet);
 }

--- a/src/main/java/com/fitpet/server/pet/infra/adapter/PetRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/pet/infra/adapter/PetRepositoryAdapter.java
@@ -23,6 +23,11 @@ public class PetRepositoryAdapter implements PetRepository {
     }
 
     @Override
+    public Optional<Pet> findByOwnerId(Long ownerId) {
+        return jpa.findByOwnerId(ownerId);
+    }
+
+    @Override
     public void delete(Pet pet) {
         jpa.delete(pet);
     }

--- a/src/main/java/com/fitpet/server/pet/infra/jpa/PetJpaRepository.java
+++ b/src/main/java/com/fitpet/server/pet/infra/jpa/PetJpaRepository.java
@@ -1,9 +1,12 @@
 package com.fitpet.server.pet.infra.jpa;
 
 import com.fitpet.server.pet.domain.entity.Pet;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PetJpaRepository extends JpaRepository<Pet, Long> {
+
+    Optional<Pet> findByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
+++ b/src/main/java/com/fitpet/server/pet/presentation/dto/PetDto.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.pet.presentation.dto;
 
+import com.fitpet.server.pet.domain.entity.PetExpression;
 import com.fitpet.server.pet.domain.entity.PetType;
 import java.time.LocalDateTime;
 
@@ -10,6 +11,7 @@ public record PetDto(
     PetType petType,
     String color,
     Long exp,
+    PetExpression expression,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -20,6 +20,7 @@ public interface UserMapper {
         @Mapping(target = "refreshToken", ignore = true),
         @Mapping(target = "registrationStatus", ignore = true),
         @Mapping(target = "password", ignore = true),
+        @Mapping(target = "dailyStepCount", ignore = true),
         @Mapping(target = "createdAt", ignore = true),
         @Mapping(target = "updatedAt", ignore = true)
     })


### PR DESCRIPTION
## 📌 PR 요약

- 미션 완료 시 펫 표정 HAPPY 로 변화
- 목표걸음수 달성 시 펫 표정 PROUD로 변화
- 평소에는 NETURAL
- TIRED는 어디에 쓸지 고민 중..!

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [ ] 관련 API 변경
- [ ] 기타 리팩터링

## 🧪 테스트 방법

- 포스트맨으로 확인
- 미션 완료 후
<img width="1343" height="792" alt="image" src="https://github.com/user-attachments/assets/9ddaac32-bc32-45fb-961a-a0651931422d" />

- 목표걸음 수 달성 후
<img width="1372" height="875" alt="image" src="https://github.com/user-attachments/assets/38dec638-19db-4968-99ec-74d19313f120" />


## 📎 관련 이슈

- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 펫 표정 시스템 추가: 중립, 행복, 자랑스러움, 피곤 표정 지원.
  * 일일 활동 연동: 걸음수 목표 달성 시 펫이 자랑스러운 표정으로 변경.
  * 미션 완료 반응: 미션 완료 시 펫이 행복한 표정으로 반응.
  * 펫 조회에 현재 표정 포함.

* **Refactor**
  * 일일/미션 관련 업데이트 로직 정리 및 내부 처리 개선.
  * 미션 관련 처리에 추가 로깅 적용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->