### PR TITLE
[Alram] FCM을 이용한 사용자에게 푸시 알림 보내기

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,46 +43,45 @@ jobs:
           script: |
             # 1. Spring Profile 설정
             export SPRING_PROFILES_ACTIVE=prod
-
+            
             # 2. DB 설정
             export DB_URL="${{ secrets.DB_URL }}"
             export DB_USERNAME="${{ secrets.DB_USERNAME }}"
             export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
-
+            
             # 3. Security 설정
             export SECURITY_USER="${{ secrets.SECURITY_USER }}"
             export SECURITY_PASSWORD="${{ secrets.SECURITY_PASSWORD }}"
-
+            
             # 4. JWT 설정
             export JWT_ACCESS_SECRET="${{ secrets.JWT_ACCESS_SECRET }}"
             export JWT_REFRESH_SECRET="${{ secrets.JWT_REFRESH_SECRET }}"
             export JWT_ACCESS_EXPIRATION_MS="${{ secrets.JWT_ACCESS_EXPIRATION_MS }}"
             export JWT_REFRESH_EXPIRATION_MS="${{ secrets.JWT_REFRESH_EXPIRATION_MS }}"
-
+            
             # 5. OAuth 설정
             export GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}"
             export GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}"
             export KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}"
             export KAKAO_JAVASCRIPT_KEY="${{ secrets.KAKAO_JAVASCRIPT_KEY }}"
-
+            
             # 6. AWS S3 설정 
             export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
             
-            # FCM 설정
-            # fcm 디렉토리를 만들고, GitHub Secret의 "내용"을 파일로 쓰기
+            # 7. 배포 디렉토리 정리 및 이동 (✨✨✨ 순서 변경 ✨✨✨)
+            rm -rf /home/ubuntu/fitpet-server/current
+            mkdir -p /home/ubuntu/fitpet-server/current
+            mv /home/ubuntu/fitpet-server/tobe/fitpet.jar /home/ubuntu/fitpet-server/current/fitpet.jar
+            
+            # 8. FCM 설정 (✨✨✨ jar 파일 이동 후, 이 위치에서 생성해야 합니다 ✨✨✨)
+            # "current" 폴더 "안에" fcm 디렉토리를 생성합니다.
             mkdir -p /home/ubuntu/fitpet-server/current/fcm
             
             # "current/fcm" 폴더 "안에" json 파일을 생성합니다.
             echo "${{ secrets.FCM_KEY_JSON }}" > /home/ubuntu/fitpet-server/current/fcm/firebase-service-account-key.json
             
-            
-            # 7. 배포 디렉토리 정리 및 이동
-            rm -rf /home/ubuntu/fitpet-server/current
-            mkdir -p /home/ubuntu/fitpet-server/current
-            mv /home/ubuntu/fitpet-server/tobe/fitpet.jar /home/ubuntu/fitpet-server/current/fitpet.jar
-            
-            # 8. 애플리케이션 실행
+            # 9. 애플리케이션 실행
             cd /home/ubuntu/fitpet-server/current
             
             # 기존 프로세스 종료

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: Deploy To EC2 for FitPet (using Environment Variables)
 on:
   push:
     branches:
-      - dev
+      - feature/meal
 
 jobs:
   deploy:
@@ -41,25 +41,44 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script_stop: true
           script: |
+            # 1. Spring Profile 설정
+            export SPRING_PROFILES_ACTIVE=prod
+
+            # 2. DB 설정
             export DB_URL="${{ secrets.DB_URL }}"
             export DB_USERNAME="${{ secrets.DB_USERNAME }}"
             export DB_PASSWORD="${{ secrets.DB_PASSWORD }}"
+
+            # 3. Security 설정
             export SECURITY_USER="${{ secrets.SECURITY_USER }}"
             export SECURITY_PASSWORD="${{ secrets.SECURITY_PASSWORD }}"
+
+            # 4. JWT 설정
             export JWT_ACCESS_SECRET="${{ secrets.JWT_ACCESS_SECRET }}"
             export JWT_REFRESH_SECRET="${{ secrets.JWT_REFRESH_SECRET }}"
             export JWT_ACCESS_EXPIRATION_MS="${{ secrets.JWT_ACCESS_EXPIRATION_MS }}"
             export JWT_REFRESH_EXPIRATION_MS="${{ secrets.JWT_REFRESH_EXPIRATION_MS }}"
+
+            # 5. OAuth 설정
             export GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}"
             export GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}"
             export KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}"
+            export KAKAO_JAVASCRIPT_KEY="${{ secrets.KAKAO_JAVASCRIPT_KEY }}"
 
+            # 6. AWS S3 설정 (이전 오류의 원인)
+            export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+            export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            
+            # 7. 배포 디렉토리 정리 및 이동
             rm -rf /home/ubuntu/fitpet-server/current
             mkdir -p /home/ubuntu/fitpet-server/current
             mv /home/ubuntu/fitpet-server/tobe/fitpet.jar /home/ubuntu/fitpet-server/current/fitpet.jar
             
+            # 8. 애플리케이션 실행
             cd /home/ubuntu/fitpet-server/current
             
+            # 기존 프로세스 종료
             sudo fuser -k -n tcp 8080 || true
             
+            # 새 프로세스 시작
             nohup java -jar fitpet.jar > ./output.log 2>&1 &

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,10 @@ jobs:
         run: mv ./build/libs/*SNAPSHOT.jar ./fitpet.jar
 
       - name: FCM 키 파일을 로컬에 생성
-        run: printf "%s" "${{ secrets.FCM_KEY_JSON }}" > ./firebase-service-account-key.json
+        run: |
+          cat <<EOF > ./firebase-service-account-key.json
+          ${{ secrets.FCM_KEY_JSON }}
+          EOF
 
       - name: SCP로 EC2에 빌드 파일(jar) 전송
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,9 +65,13 @@ jobs:
             export KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}"
             export KAKAO_JAVASCRIPT_KEY="${{ secrets.KAKAO_JAVASCRIPT_KEY }}"
 
-            # 6. AWS S3 설정 (이전 오류의 원인)
+            # 6. AWS S3 설정 
             export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+            
+            # FCM 설정
+            export FCM_KEY_PATH="${{ secrets.FCM_KEY_PATH }}"
+            
             
             # 7. 배포 디렉토리 정리 및 이동
             rm -rf /home/ubuntu/fitpet-server/current

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: Deploy To EC2 for FitPet (using Environment Variables)
+name: Deploy To EC2 for FitPet
 
 on:
   push:
@@ -96,7 +96,6 @@ jobs:
             # 기존 프로세스 종료
             sudo fuser -k -n tcp 8080 || true
             
-            # 9. 새 프로세스 시작 
-            # -cp ".:fitpet.jar" : 현재폴더(.)와 fitpet.jar를 모두 클래스패스로 지정
-            # com.fitpet.server.FitPetApplication : Main 클래스 직접 지정
-            nohup java -cp ".:fitpet.jar" com.fitpet.server.FitPetApplication > ./output.log 2>&1 &
+            # 9. 새 프로세스 시작
+            # -Dloader.path=./ : Spring Boot에게 현재 디렉토리(.)도 클래스패스에 포함하도록 지시
+            nohup java -Dloader.path=./ -jar fitpet.jar > ./output.log 2>&1 &

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,6 +96,5 @@ jobs:
             # 기존 프로세스 종료
             sudo fuser -k -n tcp 8080 || true
             
-            # 9. 새 프로세스 시작
-            # -Dloader.path=./ : Spring Boot에게 현재 디렉토리(.)도 클래스패스에 포함하도록 지시
-            nohup java -Dloader.path=./ -jar fitpet.jar > ./output.log 2>&1 &
+            # 9. 새 프로세스 시작 
+            nohup java -cp ".:fitpet.jar" org.springframework.boot.loader.launch.JarLauncher > ./output.log 2>&1 &

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,13 +24,25 @@ jobs:
       - name: 빌드된 파일 이름 변경
         run: mv ./build/libs/*SNAPSHOT.jar ./fitpet.jar
 
-      - name: SCP로 EC2에 빌드 파일 전송
+      - name: FCM 키 파일을 로컬에 생성
+        run: echo "${{ secrets.FCM_KEY_JSON }}" > ./firebase-service-account-key.json
+
+      - name: SCP로 EC2에 빌드 파일(jar) 전송
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           source: fitpet.jar
+          target: /home/ubuntu/fitpet-server/tobe
+
+      - name: SCP로 EC2에 FCM 키 파일 전송
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          source: ./firebase-service-account-key.json
           target: /home/ubuntu/fitpet-server/tobe
 
       - name: EC2에서 환경변수 설정 및 배포 스크립트 실행
@@ -69,23 +81,22 @@ jobs:
             export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
             
-            # 7. 배포 디렉토리 정리 및 이동 (✨✨✨ 순서 변경 ✨✨✨)
+            # 7. 배포 디렉토리 정리 및 파일 이동
             rm -rf /home/ubuntu/fitpet-server/current
             mkdir -p /home/ubuntu/fitpet-server/current
-            mv /home/ubuntu/fitpet-server/tobe/fitpet.jar /home/ubuntu/fitpet-server/current/fitpet.jar
-            
-            # 8. FCM 설정 (✨✨✨ jar 파일 이동 후, 이 위치에서 생성해야 합니다 ✨✨✨)
-            # "current" 폴더 "안에" fcm 디렉토리를 생성합니다.
             mkdir -p /home/ubuntu/fitpet-server/current/fcm
             
-            # "current/fcm" 폴더 "안에" json 파일을 생성합니다.
-            echo "${{ secrets.FCM_KEY_JSON }}" > /home/ubuntu/fitpet-server/current/fcm/firebase-service-account-key.json
+            # tobe에 있던 파일들을 current로 이동
+            mv /home/ubuntu/fitpet-server/tobe/fitpet.jar /home/ubuntu/fitpet-server/current/fitpet.jar
+            mv /home/ubuntu/fitpet-server/tobe/firebase-service-account-key.json /home/ubuntu/fitpet-server/current/fcm/firebase-service-account-key.json
             
-            # 9. 애플리케이션 실행
+            # 8. 애플리케이션 실행 디렉토리로 이동
             cd /home/ubuntu/fitpet-server/current
             
             # 기존 프로세스 종료
             sudo fuser -k -n tcp 8080 || true
             
-            # 새 프로세스 시작
-            nohup java -jar fitpet.jar > ./output.log 2>&1 &
+            # 9. 새 프로세스 시작 
+            # -cp ".:fitpet.jar" : 현재폴더(.)와 fitpet.jar를 모두 클래스패스로 지정
+            # com.fitpet.server.FitPetApplication : Main 클래스 직접 지정
+            nohup java -cp ".:fitpet.jar" com.fitpet.server.FitPetApplication > ./output.log 2>&1 &

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,7 +70,9 @@ jobs:
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
             
             # FCM 설정
-            export FCM_KEY_PATH="${{ secrets.FCM_KEY_PATH }}"
+            # fcm 디렉토리를 만들고, GitHub Secret의 "내용"을 파일로 쓰
+            mkdir -p fcm
+            echo "${{ secrets.FCM_KEY_PATH }}" > ./fcm/firebase-service-account-key.json
             
             
             # 7. 배포 디렉토리 정리 및 이동

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,9 +70,11 @@ jobs:
             export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"
             
             # FCM 설정
-            # fcm 디렉토리를 만들고, GitHub Secret의 "내용"을 파일로 쓰
-            mkdir -p fcm
-            echo "${{ secrets.FCM_KEY_PATH }}" > ./fcm/firebase-service-account-key.json
+            # fcm 디렉토리를 만들고, GitHub Secret의 "내용"을 파일로 쓰기
+            mkdir -p /home/ubuntu/fitpet-server/current/fcm
+            
+            # "current/fcm" 폴더 "안에" json 파일을 생성합니다.
+            echo "${{ secrets.FCM_KEY_JSON }}" > /home/ubuntu/fitpet-server/current/fcm/firebase-service-account-key.json
             
             
             # 7. 배포 디렉토리 정리 및 이동

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,7 @@ jobs:
         run: mv ./build/libs/*SNAPSHOT.jar ./fitpet.jar
 
       - name: FCM 키 파일을 로컬에 생성
-        run: echo "${{ secrets.FCM_KEY_JSON }}" > ./firebase-service-account-key.json
+        run: printf "%s" "${{ secrets.FCM_KEY_JSON }}" > ./firebase-service-account-key.json
 
       - name: SCP로 EC2에 빌드 파일(jar) 전송
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: Deploy To EC2 for FitPet (using Environment Variables)
 on:
   push:
     branches:
-      - feature/meal
+      - feature/alram
 
 jobs:
   deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: Deploy To EC2 for FitPet
 on:
   push:
     branches:
-      - feature/alram
+      - dev
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ logs/
 *.env
 !.env.sample
 **/keystore
+
+/src/main/resources/fcm/firebase-service-account-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     // S3
     implementation platform('software.amazon.awssdk:bom:2.20.41')
     implementation 'software.amazon.awssdk:s3'
+
+    //FCM
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') { useJUnitPlatform() }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm'
 }
 
 group = 'com.fitpet'
@@ -85,6 +86,7 @@ dependencies {
 
     //FCM
     implementation 'com.google.firebase:firebase-admin:9.3.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 tasks.named('test') { useJUnitPlatform() }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,10 @@ configurations {
     compileOnly { extendsFrom annotationProcessor }
 }
 
-repositories { mavenCentral() }
+repositories {
+    google()
+    mavenCentral()
+}
 
 dependencies {
     // Web (MVC)
@@ -81,7 +84,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
 
     //FCM
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 tasks.named('test') { useJUnitPlatform() }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.2.0'
+    }
+}
 rootProject.name = 'FitPet'

--- a/src/main/java/com/fitpet/server/FitPetApplication.java
+++ b/src/main/java/com/fitpet/server/FitPetApplication.java
@@ -2,8 +2,10 @@ package com.fitpet.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FitPetApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fitpet/server/alram/application/mapper/AlramMapper.java
+++ b/src/main/java/com/fitpet/server/alram/application/mapper/AlramMapper.java
@@ -1,0 +1,30 @@
+package com.fitpet.server.alram.application.mapper;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import com.fitpet.server.alram.presentation.dto.request.AlramRequestDto;
+import com.fitpet.server.alram.presentation.dto.response.AlramResponseDto;
+import com.fitpet.server.user.domain.entity.User;
+import com.google.firebase.messaging.Notification;
+import java.util.Map;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface AlramMapper {
+    Notification toNotification(AlramRequestDto requestDto);
+
+    @Mapping(source = "requestDto.body", target = "message")
+    AlramMessage toAlramMessage(AlramRequestDto requestDto, User user);
+
+    @Mapping(source = "savedAlram.id", target = "alramId")
+    AlramResponseDto toAlramResponseDto(
+            AlramMessage savedAlram,
+            String fcmMessageId,
+            String message,
+            Map<String, String> data
+    );
+}

--- a/src/main/java/com/fitpet/server/alram/application/scheduler/ActivityNotificationScheduler.java
+++ b/src/main/java/com/fitpet/server/alram/application/scheduler/ActivityNotificationScheduler.java
@@ -1,0 +1,136 @@
+package com.fitpet.server.alram.application.scheduler;
+
+import com.fitpet.server.alram.application.service.AlramBatchService;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivityNotificationScheduler {
+
+    private final UserRepository userRepository;
+    private final AlramBatchService alramBatchService;
+
+    private static final int BATCH_SIZE = 500;
+
+    private static final List<String> ENCOURAGEMENT_MESSAGES = List.of(
+            "오늘 목표 걸음까지 조금만 더 힘내세요! 🏃",
+            "아직 늦지 않았어요! 지금 가벼운 산책 어떠세요?",
+            "움직일 시간이에요! 목표 달성이 얼마 남지 않았어요.",
+            "FitPet이 응원할게요! 조금만 더 걸어볼까요?"
+    );
+
+    private static final List<String> INACTIVE_MESSAGES = List.of(
+            "오랜만이에요! FitPet이 기다리고 있어요. 👟",
+            "다시 함께 걸어볼까요? 건강한 습관을 되찾아보세요!",
+            "회원님을 위한 맞춤 운동 정보가 업데이트되었어요!"
+    );
+
+    private final Random random = new Random();
+
+    @Scheduled(cron = "0 0 20 * * ?", zone = "Asia/Seoul") // 매일 20시 정각
+    //@Scheduled(cron = "0 * * * * ?", zone = "Asia/Seoul") // Test용 매분 실행
+    public void scheduleStepEncouragement() {
+        log.info("[스케줄러 시작] 걷기 독려 알림 (목표 50% 미만 사용자)");
+
+        Pageable pageable = PageRequest.of(0, BATCH_SIZE);
+        boolean hasNextPage = true;
+        int totalSentCount = 0;
+
+        while (hasNextPage) {
+            Page<User> userPage = userRepository.findUsersBelowStepTarget(pageable);
+
+            if (!userPage.hasContent()) {
+                if (totalSentCount == 0) {
+                    log.info("[스케줄러] 걷기 독려 알림 대상자가 없습니다.");
+                }
+                break;
+            }
+
+            List<String> tokens = userPage.getContent().stream()
+                    .map(User::getDeviceToken)
+                    .collect(Collectors.toList());
+
+            String title = "👟 FitPet 걸음 독려";
+            String body = getRandomEncouragementMessage();
+            Map<String, String> data = Map.of("screen", "/main");
+
+            alramBatchService.sendMulticastNotification(tokens, title, body, data);
+
+            totalSentCount += tokens.size();
+
+            if (userPage.hasNext()) {
+                pageable = userPage.nextPageable();
+            } else {
+                hasNextPage = false;
+            }
+        }
+
+        log.info("[스케줄러 종료] 총 {}명에게 걷기 독려 알림 발송 완료", totalSentCount);
+    }
+
+    @Scheduled(cron = "0 0 10 * * 1", zone = "Asia/Seoul")
+    public void scheduleInactivityNotification() {
+        log.info("[스케줄러 시작] 비활성 사용자(7일) 알림");
+
+        final int INACTIVE_DAYS = 7;
+        LocalDateTime inactiveSince = LocalDateTime.now().minusDays(INACTIVE_DAYS);
+
+        Pageable pageable = PageRequest.of(0, BATCH_SIZE);
+        boolean hasNextPage = true;
+        int totalSentCount = 0;
+
+        while (hasNextPage) {
+            Page<User> userPage = userRepository.findInactiveUsers(inactiveSince, pageable);
+
+            if (!userPage.hasContent()) {
+                if (totalSentCount == 0) {
+                    log.info("[스케줄러] 비활성 사용자 알림 대상자가 없습니다.");
+                }
+                break;
+            }
+
+            List<String> tokens = userPage.getContent().stream()
+                    .map(User::getDeviceToken)
+                    .collect(Collectors.toList());
+
+            String title = "FitPet이 기다리고 있어요! 👋";
+            String body = getRandomInactiveMessage();
+            Map<String, String> data = Map.of("screen", "/main");
+
+            alramBatchService.sendMulticastNotification(tokens, title, body, data);
+
+            totalSentCount += tokens.size();
+
+            if (userPage.hasNext()) {
+                pageable = userPage.nextPageable();
+            } else {
+                hasNextPage = false;
+            }
+        }
+
+        log.info("[스케줄러 종료] 총 {}명에게 비활성 알림 발송 완료", totalSentCount);
+    }
+
+
+    private String getRandomEncouragementMessage() {
+        return ENCOURAGEMENT_MESSAGES.get(random.nextInt(ENCOURAGEMENT_MESSAGES.size()));
+    }
+
+    private String getRandomInactiveMessage() {
+        return INACTIVE_MESSAGES.get(random.nextInt(INACTIVE_MESSAGES.size()));
+    }
+}

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramBatchService.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramBatchService.java
@@ -1,0 +1,63 @@
+package com.fitpet.server.alram.application.service;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlramBatchService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendMulticastNotification(List<String> tokens, String title, String body, Map<String, String> data) {
+        if (tokens == null || tokens.isEmpty()) {
+            log.warn("[FCM 멀티캐스트] 전송 대상 토큰이 없습니다.");
+            return;
+        }
+
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        MulticastMessage message = MulticastMessage.builder()
+                .setNotification(notification)
+                .addAllTokens(tokens)
+                .putAllData(data != null ? data : Map.of())
+                .build();
+
+        try {
+            BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
+            log.info("[FCM v1 멀티캐스트] 알림 전송 성공: {}/{}건", response.getSuccessCount(), tokens.size());
+
+            if (response.getFailureCount() > 0) {
+                List<String> failedTokens = new ArrayList<>();
+                List<SendResponse> responses = response.getResponses();
+
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        String failedToken = tokens.get(i);
+                        failedTokens.add(failedToken);
+                        log.warn("[FCM v1 멀티캐스트] 전송 실패: 토큰={}, 에러={}",
+                                failedToken, responses.get(i).getException().getMessage());
+                    }
+                }
+                log.warn("[FCM v1 멀티캐스트] 총 {}건 실패. 실패 토큰 목록: {}", response.getFailureCount(), failedTokens);
+            }
+
+        } catch (FirebaseMessagingException e) {
+            log.error("[FCM v1 멀티캐스트] 전송 중 심각한 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramService.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramService.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.alram.application.service;
+
+import com.fitpet.server.alram.presentation.dto.request.AlramRequestDto;
+import com.fitpet.server.alram.presentation.dto.response.AlramResponseDto;
+
+public interface AlramService {
+    AlramResponseDto sendAndSaveAlram(AlramRequestDto requestDto);
+}

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
@@ -1,0 +1,65 @@
+package com.fitpet.server.alram.application.service;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import com.fitpet.server.alram.domain.repository.AlramRepository;
+import com.fitpet.server.alram.presentation.dto.request.AlramRequestDto;
+import com.fitpet.server.alram.presentation.dto.response.AlramResponseDto;
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlramServiceImpl implements AlramService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final UserRepository userRepository;
+    private final AlramRepository alramRepository;
+
+    @Override
+    @Transactional
+    public AlramResponseDto sendAndSaveAlram(AlramRequestDto requestDto) {
+
+        User user = userRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Notification notification = Notification.builder()
+                .setTitle(requestDto.getTitle())
+                .setBody(requestDto.getBody())
+                .build();
+        Message fcmMessage = Message.builder()
+                .setToken(requestDto.getTargetDeviceToken())
+                .setNotification(notification)
+                .build();
+
+        String fcmMessageId;
+        try {
+            fcmMessageId = firebaseMessaging.send(fcmMessage);
+            log.info("FCM 알림 발송 성공: {}", fcmMessageId);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 알림 발송 실패: {}", e.getMessage(), e);
+            // TODO: FCM_SEND_FAILED와 같은 ErrorCode를 정의하여 BusinessException 처리
+            throw new RuntimeException("FCM 알림 발송에 실패했습니다.", e);
+        }
+
+        AlramMessage alramToSave = AlramMessage.builder()
+                .user(user)
+                .title(requestDto.getTitle())
+                .message(requestDto.getBody())
+                .build();
+
+        AlramMessage savedAlram = alramRepository.save(alramToSave);
+
+        return new AlramResponseDto(savedAlram.getId(), fcmMessageId, "알림 발송 및 저장 성공");
+    }
+}

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
@@ -29,15 +29,16 @@ public class AlramServiceImpl implements AlramService {
     @Override
     @Transactional
     public AlramResponseDto sendAndSaveAlram(AlramRequestDto requestDto) {
+        log.info("[AlramService] FCM 알림 전송 시작");
 
         User user = userRepository.findById(requestDto.getUserId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         String deviceToken = user.getDeviceToken();
-        log.info("🔥디바이스 토큰 {}", user.getDeviceToken());
+        log.info("[AlramService] 사용자(ID: {}) 디바이스 토큰: {}", user.getId(), deviceToken);
 
         if (deviceToken == null || deviceToken.isBlank()) {
-            log.warn("FCM 알림 발송 실패: 사용자(ID: {})의 디바이스 토큰이 없습니다.", user.getId());
+            log.warn("[AlramService] FCM 알림 발송 실패: 사용자(ID: {})의 디바이스 토큰이 없습니다.", user.getId());
             // TODO: DEVICE_TOKEN_NOT_FOUND와 같은 ErrorCode를 정의하여 BusinessException 처리
             throw new RuntimeException("사용자의 디바이스 토큰이 존재하지 않습니다.");
         }
@@ -60,9 +61,9 @@ public class AlramServiceImpl implements AlramService {
         String fcmMessageId;
         try {
             fcmMessageId = firebaseMessaging.send(fcmMessage);
-            log.info("FCM 알림 발송 성공: {}", fcmMessageId);
+            log.info("[AlramService] FCM 알림 발송 성공. Message ID: {}", fcmMessageId);
         } catch (FirebaseMessagingException e) {
-            log.error("FCM 알림 발송 실패: {}", e.getMessage(), e);
+            log.error("[AlramService] FCM 알림 발송 실패: {}", e.getMessage(), e);
             // TODO: FCM_SEND_FAILED와 같은 ErrorCode를 정의하여 BusinessException 처리
             throw new RuntimeException("FCM 알림 발송에 실패했습니다.", e);
         }
@@ -74,6 +75,8 @@ public class AlramServiceImpl implements AlramService {
                 .build();
 
         AlramMessage savedAlram = alramRepository.save(alramToSave);
+
+        log.info("[AlramService] 알림 발송 내역 저장 완료");
 
         return new AlramResponseDto(
                 savedAlram.getId(),

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
@@ -34,6 +34,7 @@ public class AlramServiceImpl implements AlramService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         String deviceToken = user.getDeviceToken();
+        log.info("🔥디바이스 토큰 {}", user.getDeviceToken());
 
         if (deviceToken == null || deviceToken.isBlank()) {
             log.warn("FCM 알림 발송 실패: 사용자(ID: {})의 디바이스 토큰이 없습니다.", user.getId());

--- a/src/main/java/com/fitpet/server/alram/controller/ex.java
+++ b/src/main/java/com/fitpet/server/alram/controller/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.controller;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
+++ b/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
@@ -1,0 +1,49 @@
+package com.fitpet.server.alram.domain.entity;
+
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "alram")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class AlramMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "alram_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String message;
+
+    @CreatedDate
+    @Column(name = "sent_at", nullable = false, updatable = false)
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/fitpet/server/alram/domain/repository/AlramRepository.java
+++ b/src/main/java/com/fitpet/server/alram/domain/repository/AlramRepository.java
@@ -1,0 +1,7 @@
+package com.fitpet.server.alram.domain.repository;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+
+public interface AlramRepository {
+    AlramMessage save(AlramMessage alramMessage);
+}

--- a/src/main/java/com/fitpet/server/alram/dto/ex.java
+++ b/src/main/java/com/fitpet/server/alram/dto/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.dto;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/entity/ex.java
+++ b/src/main/java/com/fitpet/server/alram/entity/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.entity;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/exception/ex.java
+++ b/src/main/java/com/fitpet/server/alram/exception/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.exception;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/infra/jpa/AlramJpaRepository.java
+++ b/src/main/java/com/fitpet/server/alram/infra/jpa/AlramJpaRepository.java
@@ -1,0 +1,7 @@
+package com.fitpet.server.alram.infra.jpa;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlramJpaRepository extends JpaRepository<AlramMessage, Long> {
+}

--- a/src/main/java/com/fitpet/server/alram/infra/jpa/AlramRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/alram/infra/jpa/AlramRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.fitpet.server.alram.infra.jpa;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import com.fitpet.server.alram.domain.repository.AlramRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AlramRepositoryAdapter implements AlramRepository {
+
+    private final AlramJpaRepository alramJpaRepository;
+
+    @Override
+    public AlramMessage save(AlramMessage alramMessage) {
+        return alramJpaRepository.save(alramMessage);
+    }
+}

--- a/src/main/java/com/fitpet/server/alram/mapper/ex.java
+++ b/src/main/java/com/fitpet/server/alram/mapper/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.mapper;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/presentation/controller/AlramController.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/controller/AlramController.java
@@ -5,14 +5,16 @@ import com.fitpet.server.alram.presentation.dto.request.AlramRequestDto;
 import com.fitpet.server.alram.presentation.dto.response.AlramResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@RequestMapping("/api/alram")
+@RequestMapping("/alram")
 @RequiredArgsConstructor
 public class AlramController {
 
@@ -23,6 +25,7 @@ public class AlramController {
             @Valid @RequestBody AlramRequestDto requestDto
     ) {
         AlramResponseDto response = alramService.sendAndSaveAlram(requestDto);
+        log.info("✅FCM 알림 컨트롤러");
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/fitpet/server/alram/presentation/controller/AlramController.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/controller/AlramController.java
@@ -1,0 +1,28 @@
+package com.fitpet.server.alram.presentation.controller;
+
+import com.fitpet.server.alram.application.service.AlramService;
+import com.fitpet.server.alram.presentation.dto.request.AlramRequestDto;
+import com.fitpet.server.alram.presentation.dto.response.AlramResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/alram")
+@RequiredArgsConstructor
+public class AlramController {
+
+    private final AlramService alramService;
+
+    @PostMapping("/send")
+    public ResponseEntity<AlramResponseDto> sendAlram(
+            @Valid @RequestBody AlramRequestDto requestDto
+    ) {
+        AlramResponseDto response = alramService.sendAndSaveAlram(requestDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
@@ -1,0 +1,23 @@
+package com.fitpet.server.alram.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AlramRequestDto {
+
+    @NotNull(message = "알림을 받을 사용자 ID는 필수입니다.")
+    private Long userId;
+
+    @NotBlank(message = "디바이스 토큰은 필수입니다.")
+    private String targetDeviceToken;
+
+    @NotBlank(message = "알림 제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "알림 내용은 필수입니다.")
+    private String body;
+}

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
@@ -1,4 +1,4 @@
-package com.fitpet.server.alram.presentation.dto;
+package com.fitpet.server.alram.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/request/AlramRequestDto.java
@@ -2,6 +2,7 @@ package com.fitpet.server.alram.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,12 +13,11 @@ public class AlramRequestDto {
     @NotNull(message = "알림을 받을 사용자 ID는 필수입니다.")
     private Long userId;
 
-    @NotBlank(message = "디바이스 토큰은 필수입니다.")
-    private String targetDeviceToken;
-
     @NotBlank(message = "알림 제목은 필수입니다.")
     private String title;
 
     @NotBlank(message = "알림 내용은 필수입니다.")
     private String body;
+
+    private Map<String, String> data;
 }

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.alram.presentation.dto.response;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,4 +10,5 @@ public class AlramResponseDto {
     private Long alramId;
     private String fcmMessageId; // FCM이 반환한 메시지 ID
     private String message;
+    private Map<String, String> data;
 }

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
@@ -1,0 +1,12 @@
+package com.fitpet.server.alram.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AlramResponseDto {
+    private Long alramId;
+    private String fcmMessageId; // FCM이 반환한 메시지 ID
+    private String message;
+}

--- a/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
+++ b/src/main/java/com/fitpet/server/alram/presentation/dto/response/AlramResponseDto.java
@@ -1,4 +1,4 @@
-package com.fitpet.server.alram.presentation.dto;
+package com.fitpet.server.alram.presentation.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/fitpet/server/alram/repository/ex.java
+++ b/src/main/java/com/fitpet/server/alram/repository/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.repository;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/alram/service/ex.java
+++ b/src/main/java/com/fitpet/server/alram/service/ex.java
@@ -1,4 +1,0 @@
-package com.fitpet.server.alram.service;
-
-public class ex {
-}

--- a/src/main/java/com/fitpet/server/dailywalk/infra/jpa/DailyWalkRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/dailywalk/infra/jpa/DailyWalkRepositoryAdapter.java
@@ -25,8 +25,8 @@ public class DailyWalkRepositoryAdapter implements DailyWalkRepository {
 
     @Override
     public Optional<DailyWalk> findByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(Long userId,
-                                                                                            LocalDateTime start,
-                                                                                            LocalDateTime end) {
+                                                                                             LocalDateTime start,
+                                                                                             LocalDateTime end) {
         return jpaRepository.findByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(userId, start, end);
     }
 
@@ -35,7 +35,8 @@ public class DailyWalkRepositoryAdapter implements DailyWalkRepository {
                                                                                             LocalDateTime start,
                                                                                             LocalDateTime end) {
         return jpaRepository
-            .findAllByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(userId, start, end);
+                .findAllByUser_IdAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtAsc(userId, start,
+                        end);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/dailywalk/presentation/dto/response/DailyWalkResponse.java
+++ b/src/main/java/com/fitpet/server/dailywalk/presentation/dto/response/DailyWalkResponse.java
@@ -1,12 +1,13 @@
 package com.fitpet.server.dailywalk.presentation.dto.response;
 
-import java.time.LocalDateTime;
 import com.fitpet.server.dailywalk.domain.entity.DailyWalk;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 public record DailyWalkResponse(
         Long id,
         Integer step,
-        java.math.BigDecimal distanceKm,
+        BigDecimal distanceKm,
         Integer burnCalories,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/com/fitpet/server/report/application/service/ReportServiceImpl.java
+++ b/src/main/java/com/fitpet/server/report/application/service/ReportServiceImpl.java
@@ -46,6 +46,7 @@ public class ReportServiceImpl implements ReportService {
 
     private final ReportMapper reportMapper;
 
+
     @Override
     public TodayActivityResponse getTodayActivity(Long userId, LocalDate date) {
         User user = findUserById(userId);

--- a/src/main/java/com/fitpet/server/report/presentation/controller/ReportController.java
+++ b/src/main/java/com/fitpet/server/report/presentation/controller/ReportController.java
@@ -50,8 +50,7 @@ public class ReportController {
         return ResponseEntity.ok(response);
     }
 
-    // (수정) 일별 식단 상세 조회
-    @GetMapping("/meal/day") // 명세서 경로: /api/meal/day (Base URL에 /api가 있다면 /meal/day)
+    @GetMapping("/meal/day")
     public ResponseEntity<DailyMealSummaryResponse> getDailyMealsReport(
             //@AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("day") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate day) {

--- a/src/main/java/com/fitpet/server/report/presentation/dto/response/ReportResponseDto.java
+++ b/src/main/java/com/fitpet/server/report/presentation/dto/response/ReportResponseDto.java
@@ -11,6 +11,7 @@ public class ReportResponseDto {
     @Builder
     public static class TodayActivityResponse {
         private LocalDate date;
+        private Integer steps;
         private BigDecimal distanceKm;
         private Integer burnCalories;
     }

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -20,6 +20,9 @@ public class FcmConfig {
     @Value("${fcm.service-account-key-path}")
     private String serviceAccountKeyPath;
 
+    @Value("${fcm.project-id}")
+    private String fcmProjectId;
+
     private FirebaseApp firebaseApp;
 
     @PostConstruct
@@ -30,14 +33,16 @@ public class FcmConfig {
             try (InputStream serviceAccountStream = resource.getInputStream()) {
                 FirebaseOptions options = FirebaseOptions.builder()
                         .setCredentials(GoogleCredentials.fromStream(serviceAccountStream))
+                        .setProjectId(fcmProjectId)
                         .build();
 
                 if (FirebaseApp.getApps().isEmpty()) {
                     this.firebaseApp = FirebaseApp.initializeApp(options);
-                    log.info("FirebaseApp 초기화 성공");
+                    log.info("FirebaseApp 초기화 성공 (Project ID: {})", fcmProjectId);
                 } else {
                     this.firebaseApp = FirebaseApp.getInstance();
-                    log.info("FirebaseApp 이미 초기화됨");
+                    log.info("FirebaseApp 이미 초기화됨 (Loaded Project ID: {})",
+                            this.firebaseApp.getOptions().getProjectId());
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -5,12 +5,13 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
 @Configuration
@@ -23,20 +24,22 @@ public class FcmConfig {
 
     @PostConstruct
     public void initialize() {
-        try (FileInputStream serviceAccountStream = new FileInputStream(serviceAccountKeyPath)) {
+        try {
+            ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
 
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccountStream))
-                    .build();
+            try (InputStream serviceAccountStream = resource.getInputStream()) {
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(serviceAccountStream))
+                        .build();
 
-            if (FirebaseApp.getApps().isEmpty()) {
-                this.firebaseApp = FirebaseApp.initializeApp(options);
-                log.info("FirebaseApp 초기화 성공");
-            } else {
-                this.firebaseApp = FirebaseApp.getInstance();
-                log.info("FirebaseApp 이미 초기화됨");
+                if (FirebaseApp.getApps().isEmpty()) {
+                    this.firebaseApp = FirebaseApp.initializeApp(options);
+                    log.info("FirebaseApp 초기화 성공");
+                } else {
+                    this.firebaseApp = FirebaseApp.getInstance();
+                    log.info("FirebaseApp 이미 초기화됨");
+                }
             }
-
         } catch (IOException e) {
             log.error("FCM 키 파일을 찾을 수 없거나 읽는 데 실패했습니다. (경로: {}): {}", serviceAccountKeyPath, e.getMessage());
             throw new RuntimeException(e);

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -1,0 +1,53 @@
+package com.fitpet.server.shared.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import jakarta.annotation.PostConstruct;
+import java.io.FileInputStream;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+
+    @Value("${fcm.service-account-key-path}")
+    private String serviceAccountKeyPath;
+
+    private FirebaseApp firebaseApp;
+
+    @PostConstruct
+    public void initialize() {
+        try (FileInputStream serviceAccountStream = new FileInputStream(serviceAccountKeyPath)) {
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccountStream))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                this.firebaseApp = FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp 초기화 성공");
+            } else {
+                this.firebaseApp = FirebaseApp.getInstance();
+                log.info("FirebaseApp 이미 초기화됨");
+            }
+
+        } catch (IOException e) {
+            log.error("FCM 키 파일을 찾을 수 없거나 읽는 데 실패했습니다. (경로: {}): {}", serviceAccountKeyPath, e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        if (this.firebaseApp == null) {
+            throw new IllegalStateException("FirebaseApp이 초기화되어야 합니다.");
+        }
+        return FirebaseMessaging.getInstance(this.firebaseApp);
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -31,8 +30,8 @@ public class SecurityConfig {
             "/gps/**",
             "/report/**",
             "/meal/**",
-            "/pets/**",
-            "/alram/**"
+            "/alram/**",
+            "/pets/**"
     };
 
     @Bean
@@ -59,10 +58,10 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-                .requestMatchers(SWAGGER_WHITELIST);
-    }
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return web -> web.ignoring()
+//                .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+//                .requestMatchers(SWAGGER_WHITELIST);
+//    }
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -31,8 +31,8 @@ public class SecurityConfig {
             "/gps/**",
             "/report/**",
             "/meal/**",
-            "/pets/**"
-
+            "/pets/**",
+            "/alram/**"
     };
 
     @Bean

--- a/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
+++ b/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     MEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "해당 식단 기록을 찾을 수 없습니다."),
     MEAL_ACCESS_DENIED(HttpStatus.FORBIDDEN, "M002", "해당 식단 기록에 대한 권한이 없습니다."),
 
+    DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "사용자의 디바이스 토큰이 없습니다."),
+    FCM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "FCM 알림 발송에 실패했습니다."),
+
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "A001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 액세스 토큰입니다."),

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -13,15 +13,18 @@ public interface UserMapper {
 
 
     @Mappings({
-        @Mapping(target = "id", ignore = true),
-        @Mapping(target = "provider", ignore = true),
-        @Mapping(target = "providerUid", ignore = true),
-        @Mapping(target = "deviceToken", ignore = true),
-        @Mapping(target = "refreshToken", ignore = true),
-        @Mapping(target = "registrationStatus", ignore = true),
-        @Mapping(target = "password", ignore = true),
-        @Mapping(target = "createdAt", ignore = true),
-        @Mapping(target = "updatedAt", ignore = true)
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "provider", ignore = true),
+            @Mapping(target = "providerUid", ignore = true),
+            @Mapping(target = "deviceToken", ignore = true),
+            @Mapping(target = "refreshToken", ignore = true),
+            @Mapping(target = "registrationStatus", ignore = true),
+            @Mapping(target = "password", ignore = true),
+            @Mapping(target = "createdAt", ignore = true),
+            @Mapping(target = "updatedAt", ignore = true),
+            @Mapping(target = "dailyStepCount", ignore = true),
+            @Mapping(target = "allowActivityNotification", ignore = true),
+            @Mapping(target = "lastAccessedAt", ignore = true)
     })
     User toEntity(UserCreateRequest request);
 

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -205,4 +205,12 @@ public class User {
         this.provider = provider;
         this.providerUid = providerUid;
     }
+
+    public void updateLastAccessedAt() {
+        this.lastAccessedAt = LocalDateTime.now();
+    }
+    
+    public void changeActivityNotificationSetting(boolean allowed) {
+        this.allowActivityNotification = allowed;
+    }
 }

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -17,12 +17,14 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@DynamicUpdate
 @Table(name = "users",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
@@ -102,6 +104,13 @@ public class User {
     @Column(name = "updated_at",
             columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
+
+    @Default
+    @Column(name = "allow_activity_notification", nullable = false)
+    private Boolean allowActivityNotification = true;
+
+    @Column(name = "last_accessed_at")
+    private LocalDateTime lastAccessedAt; // 마지막 접속 시간
 
 
     public void changePassword(String encodedPassword) {

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.fitpet.server.user.domain.repository;
 
 import com.fitpet.server.user.domain.entity.User;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 
 public interface UserRepository {
@@ -24,4 +27,8 @@ public interface UserRepository {
     Optional<User> findByProviderAndProviderUid(String provider, String providerUid);
 
     int resetDailyStepCount();
+
+    Page<User> findUsersBelowStepTarget(Pageable pageable);
+
+    Page<User> findInactiveUsers(LocalDateTime inactiveSince, Pageable pageable);
 }

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
@@ -3,8 +3,11 @@ package com.fitpet.server.user.infra.adapter;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import com.fitpet.server.user.infra.jpa.UserJpaRepository;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -65,6 +68,16 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public int resetDailyStepCount() {
         return jpa.resetDailyStepCount();
+    }
+
+    @Override
+    public Page<User> findUsersBelowStepTarget(Pageable pageable) {
+        return jpa.findUsersBelowStepTarget(pageable);
+    }
+
+    @Override
+    public Page<User> findInactiveUsers(LocalDateTime inactiveSince, Pageable pageable) {
+        return jpa.findInactiveUsers(inactiveSince, pageable);
     }
 
 }

--- a/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
+++ b/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
@@ -1,10 +1,14 @@
 package com.fitpet.server.user.infra.jpa;
 
 import com.fitpet.server.user.domain.entity.User;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -25,4 +29,20 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update User user set user.dailyStepCount = 0")
     int resetDailyStepCount();
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u.targetStepCount IS NOT NULL AND u.targetStepCount > 0 " +
+            "AND u.dailyStepCount < (u.targetStepCount * 0.5) " +
+            "AND u.deviceToken IS NOT NULL AND u.deviceToken != '' " +
+            "AND u.allowActivityNotification = true")
+    Page<User> findUsersBelowStepTarget(Pageable pageable);
+
+    @Query("SELECT u FROM User u " +
+            "WHERE u.lastAccessedAt < :inactiveSince " +
+            "AND u.deviceToken IS NOT NULL AND u.deviceToken != '' " +
+            "AND u.allowActivityNotification = true")
+    Page<User> findInactiveUsers(
+            @Param("inactiveSince") LocalDateTime inactiveSince,
+            Pageable pageable
+    );
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,3 +80,6 @@ cloud:
 aws:
   s3:
     bucket: fitpet-bucket
+
+fcm:
+  service-account-key-path: "fcm/firebase-service-account-key.json"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,3 +83,4 @@ aws:
 
 fcm:
   service-account-key-path: "fcm/firebase-service-account-key.json"
+  project-id: fitp-9e7ad


### PR DESCRIPTION
## 📌 PR 요약

- FCM을 이용하여 사용자의 디바이스 토큰에 푸시 알림을 보내는 기능 
- 스케줄러를 이용해 목표 걷기 미달과 장기간 접속하지 않은 회원에게 알림 보내기 기능

## ✅ 작업 상세 내용

- [x]  userId를 이용한 푸시 알림 발송 API 구현
- [x] 스케줄러를 이용한 목표 걸음수에 50%이하로 걸은 사람에게 알림 발송 ( 매일 20시)
- [x] 스케줄러를 이용한 일주일간 접속을 하지 않은 사용자에게 알림 발송

## 🧪 테스트 방법
- postman을 이용한 FCM 알림 발송 test
<img width="743" height="792" alt="image" src="https://github.com/user-attachments/assets/74d5c739-fdda-40f5-b69d-59e54daae1f0" />

## 📎 관련 이슈


## 추가 전달 사항
- 배치에 대한 test는 현재 하지 못 했습니다.
- 프론트에 FCM 기능을 추가하면 진행할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신 기능**
  * 예약 푸시 알림 도입: 매일 저녁 격려 메시지 및 주간 비활동 알림 자동 발송
  * 수동 알림 전송용 API 및 알림 저장/조회 추가
  * 대규모 멀티캐스트 FCM 푸시 지원 및 FCM 설정 초기화 개선

* **기타**
  * 사용자별 알림 수신 동의 설정 및 마지막 접속 시간 추적 추가
  * 리포트에 일일 걸음수(steps) 필드 추가
  * 프로덕션 배포 및 환경설정 처리 강화 (배포 키/프로파일 처리 개선)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->