### PR TITLE
[Feature] DB 인덱스 최적화 (User)

### DIFF
--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
@@ -26,10 +27,15 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
 @Table(name = "users",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
-                @UniqueConstraint(name = "uk_oauth_provider_uid", columnNames = {"provider", "provider_uid"})
-        })
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
+        @UniqueConstraint(name = "uk_oauth_provider_uid", columnNames = {"provider", "provider_uid"})
+    },
+    indexes = {
+        @Index(name = "idx_users_nickname", columnList = "nick_name"),
+        @Index(name = "idx_users_daily_step", columnList = "daily_step_count DESC, updated_at ASC"),
+        @Index(name = "idx_users_gender_daily_step", columnList = "gender, daily_step_count DESC, updated_at ASC")
+    })
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -97,12 +103,12 @@ public class User {
 
     @CreatedDate
     @Column(name = "created_at", updatable = false,
-            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+        columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at",
-            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+        columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     @Default
@@ -119,16 +125,16 @@ public class User {
 
     // 사용자가 입력을 하지 않은 경우(빈값) 대비
     public void update(
-            String email,
-            String nickname,
-            Integer age,
-            Gender gender,
-            Double weightKg,
-            Double targetWeightKg,
-            Double heightCm,
-            Double pbf,
-            Double targetPbf,
-            Integer targetStepCount
+        String email,
+        String nickname,
+        Integer age,
+        Gender gender,
+        Double weightKg,
+        Double targetWeightKg,
+        Double heightCm,
+        Double pbf,
+        Double targetPbf,
+        Integer targetStepCount
     ) {
         if (email != null && !email.isBlank()) {
             this.email = email;
@@ -209,7 +215,7 @@ public class User {
     public void updateLastAccessedAt() {
         this.lastAccessedAt = LocalDateTime.now();
     }
-    
+
     public void changeActivityNotificationSetting(boolean allowed) {
         this.allowActivityNotification = allowed;
     }

--- a/src/test/java/com/fitpet/server/user/UserNicknameIndexPerformanceTest.java
+++ b/src/test/java/com/fitpet/server/user/UserNicknameIndexPerformanceTest.java
@@ -13,7 +13,7 @@ import org.springframework.util.StopWatch;
 @ActiveProfiles("local")
 class UserNicknameIndexPerformanceTest {
 
-    private static final int LOOKUP_ITERATION = 100;   // 닉네임 조회 반복 횟수
+    private static final int LOOKUP_ITERATION = 1000;   // 닉네임 조회 반복 횟수
 
     @Autowired
     private UserJpaRepository userJpaRepository;

--- a/src/test/java/com/fitpet/server/user/UserNicknameIndexPerformanceTest.java
+++ b/src/test/java/com/fitpet/server/user/UserNicknameIndexPerformanceTest.java
@@ -1,0 +1,61 @@
+package com.fitpet.server.user;
+
+import com.fitpet.server.user.infra.jpa.UserJpaRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class UserNicknameIndexPerformanceTest {
+
+    private static final int LOOKUP_ITERATION = 100;   // 닉네임 조회 반복 횟수
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Test
+    void measureNicknameLookupPerformance() {
+        System.out.println("===== 닉네임 인덱스 성능 측정 시작 =====");
+
+        String existingNickname = userJpaRepository.findAll(PageRequest.of(0, 1))
+            .getContent()
+            .get(0)
+            .getNickname();
+
+        StopWatch stopWatch = new StopWatch("nickname-index");
+
+        // 실제 존재하는 닉네임으로 existsByNickname 호출
+        stopWatch.start("existsByNickname(existing)");
+        for (int i = 0; i < LOOKUP_ITERATION; i++) {
+            userJpaRepository.existsByNickname(existingNickname);
+        }
+        stopWatch.stop();
+
+        // 무작위 닉네임으로 미존재 조회 수행
+        stopWatch.start("existsByNickname(random)");
+        for (int i = 0; i < LOOKUP_ITERATION; i++) {
+            userJpaRepository.existsByNickname("missing_" + UUID.randomUUID());
+        }
+        stopWatch.stop();
+
+        // 닉네임 중복 체크 시 자주 사용하는 existsByNicknameAndIdNot 도 측정
+        Long existingUserId = userJpaRepository.findAll(PageRequest.of(0, 1))
+            .getContent()
+            .get(0)
+            .getId();
+
+        stopWatch.start("existsByNicknameAndIdNot");
+        for (int i = 0; i < LOOKUP_ITERATION; i++) {
+            userJpaRepository.existsByNicknameAndIdNot(existingNickname, existingUserId + i + 1);
+        }
+        stopWatch.stop();
+
+        System.out.println(stopWatch.prettyPrint());
+        System.out.println("===== 닉네임 인덱스 성능 측정 종료 =====");
+    }
+}

--- a/src/test/java/com/fitpet/server/user/UserRankingPerformanceTest.java
+++ b/src/test/java/com/fitpet/server/user/UserRankingPerformanceTest.java
@@ -1,0 +1,118 @@
+package com.fitpet.server.user;
+
+import com.fitpet.server.user.application.dto.GenderRankingResult;
+import com.fitpet.server.user.application.dto.RankingResult;
+import com.fitpet.server.user.application.service.UserService;
+import com.fitpet.server.user.domain.entity.Gender;
+import com.fitpet.server.user.domain.entity.RegistrationStatus;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.infra.jpa.UserJpaRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
+
+@SpringBootTest
+@ActiveProfiles("local")
+class UserRankingPerformanceTest {
+
+    private static final int TARGET_USER_COUNT = 0;      // 생성할 전체 유저 수
+    private static final int RANKING_CALL_COUNT = 100;   // 랭킹 API 반복 호출 횟수
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void rankingPerformance() {
+        System.out.println("===== 성능 측정용 수동 실행 테스트 시작 =====");
+
+        // 더미 유저가 충분히 없으면 채워 넣기
+//        prepareUsers();
+
+        // 아무 유저나 하나 골라서 내 순위 계산용으로 사용
+        Long targetUserId = userJpaRepository
+            .findTopRankers(PageRequest.of(0, 1))
+            .get(0)
+            .getId();
+
+        StopWatch stopWatch = new StopWatch("user-ranking");
+
+        // 전체 랭킹 성능 측정
+        stopWatch.start("getDailyStepRanking");
+        for (int i = 0; i < RANKING_CALL_COUNT; i++) {
+            RankingResult result = userService.getDailyStepRanking(targetUserId, 10);
+        }
+        stopWatch.stop();
+
+        // 성별 랭킹 성능 측정
+        stopWatch.start("getGenderDailyStepRanking");
+        for (int i = 0; i < RANKING_CALL_COUNT; i++) {
+            GenderRankingResult result = userService.getGenderDailyStepRanking(Gender.female, 10);
+        }
+        stopWatch.stop();
+
+        System.out.println();
+        System.out.println(stopWatch.prettyPrint());
+
+        long totalDaily = stopWatch.getTaskInfo()[0].getTimeMillis();
+        long totalGender = stopWatch.getTaskInfo()[1].getTimeMillis();
+
+        System.out.println("전체 랭킹 총 소요 시간(ms): " + totalDaily);
+        System.out.println("전체 랭킹 평균 호출 시간(ms): " + (totalDaily / (double) RANKING_CALL_COUNT));
+
+        System.out.println("성별 랭킹 총 소요 시간(ms): " + totalGender);
+        System.out.println("성별 랭킹 평균 호출 시간(ms): " + (totalGender / (double) RANKING_CALL_COUNT));
+
+        System.out.println("===== 성능 측정용 수동 실행 테스트 종료 =====");
+    }
+
+    private void prepareUsers() {
+        long current = userJpaRepository.count();
+        if (current >= TARGET_USER_COUNT) {
+            // 이미 TARGET_USER_COUNT 이상이면 아무 것도 안 함
+            System.out.println("현재 유저 수: " + current + " -> 더미 유저 생성 스킵");
+            return;
+        }
+
+        System.out.println("현재 유저 수: " + current + " / 목표: " + TARGET_USER_COUNT + " -> 더미 유저 생성 시작");
+
+        Random random = new Random();
+        List<User> batch = new ArrayList<>();
+
+        for (int i = (int) current; i < TARGET_USER_COUNT; i++) {
+            User user = User.builder()
+                .email("dummy" + i + "@test.com")
+                .password("encoded-password") // 실제 인코딩은 필요 없으니 더미 값
+                .nickname("user" + i)
+                .age(20 + random.nextInt(30))
+                .gender(random.nextBoolean() ? Gender.male : Gender.female)
+                .dailyStepCount(random.nextInt(20_000)) // 0 ~ 19999
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+
+            batch.add(user);
+
+            if (batch.size() == 1000) { // 1000개씩 배치 저장
+                userJpaRepository.saveAll(batch);
+                batch.clear();
+                System.out.println("더미 유저 1000명 저장...");
+            }
+        }
+
+        if (!batch.isEmpty()) {
+            userJpaRepository.saveAll(batch);
+            System.out.println("마지막 배치 " + batch.size() + "명 저장...");
+        }
+
+        System.out.println("더미 유저 생성 완료. 총 유저 수: " + userJpaRepository.count());
+    }
+
+}

--- a/src/test/java/com/fitpet/server/user/UserRankingPerformanceTest.java
+++ b/src/test/java/com/fitpet/server/user/UserRankingPerformanceTest.java
@@ -22,7 +22,7 @@ import org.springframework.util.StopWatch;
 class UserRankingPerformanceTest {
 
     private static final int TARGET_USER_COUNT = 0;      // 생성할 전체 유저 수
-    private static final int RANKING_CALL_COUNT = 100;   // 랭킹 API 반복 호출 횟수
+    private static final int RANKING_CALL_COUNT = 1000;   // 랭킹 API 반복 호출 횟수
 
     @Autowired
     private UserJpaRepository userJpaRepository;


### PR DESCRIPTION
## 📌 PR 요약

- 사용자 랭킹/알림/중복검사 성능을 높이기 위해 users 테이블에 인덱스를 추가/정리했습니다. 미션/뱃지/데일리워크에도 시도했지만 기존 Unique/FK 인덱스와 겹쳐 효과가 없어 즉시 철회했습니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
    - [x]  users 테이블에 닉네임·랭킹·알림 조회 최적화 인덱스 추가
- [ ] 관련 API 변경
- [x] 기타 리팩터링
    - [x]  미션/뱃지/데일리워크 인덱스는 기존 Unique/FK 인덱스와 중복임을 확인하고 추가 적용 없이 원상 복구

## 🧪 테스트 방법
테스트코드로 인덱스 미적용/적용 후 1000번 반복호출
- nickname 인덱스 적용
<img width="412" height="198" alt="닉네임 인덱스 적용 1000번 호출" src="https://github.com/user-attachments/assets/034ad8f3-1002-439a-8122-2f2f8441ff1f" />


- nickname 인덱스 미적용

<img width="438" height="224" alt="닉네임 인덱스 미적용 1000번 호출" src="https://github.com/user-attachments/assets/61795d03-2b0f-4216-a0bf-c6c1fd7b5085" />

- ranking 인덱스 적용
<img width="416" height="245" alt="랭킹 인덱스 적용 1000번 호출" src="https://github.com/user-attachments/assets/5d860ed4-fd17-4812-aad2-753ddc8b3f71" />


- ranking 인덱스 미적용
<img width="428" height="278" alt="랭킹 인덱스 미적용 1000번 호출" src="https://github.com/user-attachments/assets/497f549a-6396-43a4-b555-e1dba79b78ab" />


<html>
<head>

</head>
<body>

<p class="p1">랭킹 API 인덱스 전후 비교 (1000회 호출 기준)</p>



항목 | 인덱스 미적용 | 인덱스 적용 | 개선 배율(미적용/적용) | 평균 시간 감소율
-- | -- | -- | -- | --
getDailyStepRanking | 234.84 s (234.843 ms) | 107.13 s (107.132 ms) | 약 2.19배 | 약 54.4% 감소
getGenderDailyStepRanking | 170.60 s (170.597 ms) | 77.28 s (77.282 ms) | 약 2.21배 | 약 54.7% 감소

<p>닉네임 중복 체크 인덱스 전후 비교 (1000회 호출 기준)</p>

항목 | 인덱스 미적용 | 인덱스 적용 | 개선 배율(미적용/적용) | 평균 시간 감소율
-- | -- | -- | -- | --
existsByNickname(existing) | 12.75 s (12.754 ms) | 11.93 s (11.927 ms) | 약 1.07배 | 약 6.5% 감소
existsByNickname(random) | 39.39 s (39.393 ms) | 13.25 s (13.251 ms) | 약 2.97배 | 약 66.4% 감소
existsByNicknameAndIdNot | 14.68 s (14.682 ms) | 13.06 s (13.056 ms) | 약 1.12배 | 약 11.1% 감소


<!-- notionvc: 87beb21b-e1bf-4b4f-a7fc-5b47f9e15a8e -->

<p class="p2"><span class="s1"><ul><li>
<p class="p1">랭킹 쿼리는 인덱스로 평균 응답 시간이 절반 조금 넘게 줄었음(약 2.2배 빨라짐)</p>
</li><li>
<p class="p1">닉네임 랜덤 조회(existsByNickname(random))는 인덱스 효과가 가장 커서 거의 3배 가까이 빨라짐</p>
</li><li>
<p class="p1">나머지 닉네임 체크들은 실제 값이 이미 작아서 상대적인 개선 폭이 상대적으로 작게 나온 상태</p>
</li></ul></span></p>

</body>
</html>

## 📎 관련 이슈

- https://github.com/Pposiregi/Back/issues/26

## 추가 전달 사항




