### PR TITLE
Fix : CICD prod -> dev로 변경

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,7 +57,7 @@ jobs:
           script_stop: true
           script: |
             # 1. Spring Profile 설정
-            export SPRING_PROFILES_ACTIVE=prod
+            export SPRING_PROFILES_ACTIVE=dev
             
             # 2. DB 설정
             export DB_URL="${{ secrets.DB_URL }}"


### PR DESCRIPTION
## 📌 PR 요약

- CI/CD 배포 스크립트(deploy.yml)에서 애플리케이션 실행 프로파일을 prod에서 dev로 변경했습니다.

## ✅ 작업 상세 내용

[x] Github Actions 워크플로우 수정 (deploy.yml)

- 기존: export SPRING_PROFILES_ACTIVE=prod (강제 운영 모드)

- 변경: export SPRING_PROFILES_ACTIVE=dev (개발 모드)

[x] 목적

- 테스트 서버(EC2)에서 dev-user-id 헤더(백도어) 기능이 동작하지 않는 문제 해결

- 서버 내부 .env 설정보다 CI/CD 스크립트가 우선순위가 높아 강제로 prod로 덮어씌워지던 현상 수정

## 🧪 테스트 방법
1. 이 PR이 머지되고 Github Actions 배포가 완료될 때까지 대기합니다.

2. Postman에서 dev-user-id 헤더에 유효한 userId 값을 넣고 API를 호출합니다. (예: /report/meals)

3. 401/403 에러 대신 200 OK가 반환되는지 확인합니다.

## 📎 관련 이슈


## 추가 전달 사항

⚠️ 주의: 현재는 개발/테스트 단계라 dev로 설정했지만, 추후 실제 운영(Production) 배포 시에는 prod 프로파일이 적용되도록 워크플로우 분리가 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이번 업데이트는 내부 배포 인프라 구성의 변경 사항을 포함하고 있습니다.

* **Chores**
  * 배포 워크플로우 환경 설정을 업데이트했습니다.

**사용자 영향:** 이번 업데이트는 사용자 경험에 직접적인 변화가 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->