### PR TITLE
[🛠️Fix]알람 발송시 발송된 알람 저장 실패 해결

### DIFF
--- a/src/main/java/com/fitpet/server/alram/application/mapper/AlramMapper.java
+++ b/src/main/java/com/fitpet/server/alram/application/mapper/AlramMapper.java
@@ -18,6 +18,7 @@ public interface AlramMapper {
     Notification toNotification(AlramRequestDto requestDto);
 
     @Mapping(source = "requestDto.body", target = "message")
+    @Mapping(source = "user", target = "user")
     AlramMessage toAlramMessage(AlramRequestDto requestDto, User user);
 
     @Mapping(source = "savedAlram.id", target = "alramId")

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
@@ -37,11 +37,10 @@ public class AlramServiceImpl implements AlramService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         String deviceToken = user.getDeviceToken();
-        log.info("[AlramService] 사용자(ID: {}) 디바이스 토큰: {}", user.getId(), deviceToken);
+        log.info("[AlramService] 사용자(ID: {}) 디바이스 토큰 확인 완료", user.getId());
 
         if (deviceToken == null || deviceToken.isBlank()) {
             log.warn("[AlramService] FCM 알림 발송 실패: 사용자(ID: {})의 디바이스 토큰이 없습니다.", user.getId());
-
             throw new BusinessException(ErrorCode.DEVICE_TOKEN_NOT_FOUND);
         }
 
@@ -56,29 +55,27 @@ public class AlramServiceImpl implements AlramService {
         }
 
         Message fcmMessage = fcmMessageBuilder.build();
-
         String fcmMessageId;
+
         try {
             fcmMessageId = firebaseMessaging.send(fcmMessage);
             log.info("[AlramService] FCM 알림 발송 성공. Message ID: {}", fcmMessageId);
         } catch (FirebaseMessagingException e) {
             log.error("[AlramService] FCM 알림 발송 실패: {}", e.getMessage(), e);
-
             throw new BusinessException(ErrorCode.FCM_SEND_FAILED);
         }
 
         AlramMessage alramToSave = alramMapper.toAlramMessage(requestDto, user);
+        alramToSave.setUser(user);
 
         AlramMessage savedAlram = alramRepository.save(alramToSave);
-
-        log.info("[AlramService] 알림 발송 내역 저장 완료");
+        log.info("[AlramService] 알림 발송 내역 저장 완료 (ID: {})", savedAlram.getId());
 
         return alramMapper.toAlramResponseDto(
                 savedAlram,
                 fcmMessageId,
                 "알림 발송 및 저장 성공",
                 requestDto.getData()
-
         );
     }
 }

--- a/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
+++ b/src/main/java/com/fitpet/server/alram/application/service/AlramServiceImpl.java
@@ -66,7 +66,6 @@ public class AlramServiceImpl implements AlramService {
         }
 
         AlramMessage alramToSave = alramMapper.toAlramMessage(requestDto, user);
-        alramToSave.setUser(user);
 
         AlramMessage savedAlram = alramRepository.save(alramToSave);
         log.info("[AlramService] 알림 발송 내역 저장 완료 (ID: {})", savedAlram.getId());

--- a/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
+++ b/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
@@ -16,14 +16,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "alram")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
+++ b/src/main/java/com/fitpet/server/alram/domain/entity/AlramMessage.java
@@ -16,12 +16,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "alram")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.shared.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -21,7 +22,7 @@ public class FcmConfig {
     private String serviceAccountKeyPath;
 
     @Value("${fcm.project-id}")
-    private String fcmProjectId;
+    private String propertiesProjectId;
 
     private FirebaseApp firebaseApp;
 
@@ -30,23 +31,49 @@ public class FcmConfig {
         try {
             ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
 
+            if (!resource.exists()) {
+                throw new RuntimeException("❌ FCM 키 파일을 찾을 수 없습니다. 경로를 확인해주세요: " + serviceAccountKeyPath);
+            }
+
             try (InputStream serviceAccountStream = resource.getInputStream()) {
+                GoogleCredentials credentials = GoogleCredentials.fromStream(serviceAccountStream);
+
+                String realProjectId = null;
+                if (credentials instanceof ServiceAccountCredentials) {
+                    realProjectId = ((ServiceAccountCredentials) credentials).getProjectId();
+                }
+
+                log.info("=================================================================");
+                log.info("🔥 FCM 설정 진단 시작");
+                log.info("   1. 키 파일 경로: {}", serviceAccountKeyPath);
+                log.info("   2. application.yml에 설정된 ID: {}", propertiesProjectId);
+                log.info("   3. JSON 키 파일 내부의 실제 ID: {}", realProjectId);
+
+                if (realProjectId != null && !realProjectId.equals(propertiesProjectId)) {
+                    log.error("🚨 [경고] 설정 파일(yml)의 ID와 키 파일(json)의 ID가 다릅니다!");
+                    log.error("🚨 JSON 파일의 ID({})가 우선 적용됩니다.", realProjectId);
+                } else {
+                    log.info("✅ 프로젝트 ID가 일치합니다.");
+                }
+                log.info("=================================================================");
+
                 FirebaseOptions options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(serviceAccountStream))
-                        .setProjectId(fcmProjectId)
+                        .setCredentials(credentials)
+                        .setProjectId(realProjectId != null ? realProjectId : propertiesProjectId)
                         .build();
 
                 if (FirebaseApp.getApps().isEmpty()) {
                     this.firebaseApp = FirebaseApp.initializeApp(options);
-                    log.info("FirebaseApp 초기화 성공 (Project ID: {})", fcmProjectId);
+                    log.info("🎉 FirebaseApp 초기화 성공 (Target Project ID: {})",
+                            this.firebaseApp.getOptions().getProjectId());
                 } else {
                     this.firebaseApp = FirebaseApp.getInstance();
-                    log.info("FirebaseApp 이미 초기화됨 (Loaded Project ID: {})",
+                    log.info("⚠ FirebaseApp이 이미 존재합니다. (Existing Project ID: {})",
                             this.firebaseApp.getOptions().getProjectId());
                 }
             }
         } catch (IOException e) {
-            log.error("FCM 키 파일을 찾을 수 없거나 읽는 데 실패했습니다. (경로: {}): {}", serviceAccountKeyPath, e.getMessage());
+            log.error("❌ FCM 초기화 실패: {}", e.getMessage());
             throw new RuntimeException(e);
         }
     }
@@ -54,7 +81,11 @@ public class FcmConfig {
     @Bean
     public FirebaseMessaging firebaseMessaging() {
         if (this.firebaseApp == null) {
-            throw new IllegalStateException("FirebaseApp이 초기화되어야 합니다.");
+            try {
+                this.firebaseApp = FirebaseApp.getInstance();
+            } catch (Exception e) {
+                throw new IllegalStateException("FirebaseApp이 정상적으로 초기화되지 않았습니다.", e);
+            }
         }
         return FirebaseMessaging.getInstance(this.firebaseApp);
     }


### PR DESCRIPTION
## 📌 PR 요약
 - FCM 알림 발송시 발송은 성공했으나 Alarm 테이블에 저장 실패하여 응답이 실패로 오는 것을 해결했습니다.

## ✅ 작업 상세 내용

- 알림을 발송 받은 user_id값을 넘겨주지 않아 실패했었습니다

## 🧪 테스트 방법
- FCM 메세지 발송 후 성공 응답을 받고 디비에도 잘 저장이 됩니다.
<img width="847" height="478" alt="image" src="https://github.com/user-attachments/assets/93eecff3-01c7-447e-95eb-4d4f3c291adf" />

<img width="1952" height="370" alt="image" src="https://github.com/user-attachments/assets/b86444a1-faab-406c-9d8b-5395b4236aa6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 민감한 장치 정보 로그 기록 방지로 보안 강화

* **버그 수정**
  * Firebase 초기화 검증 로직 개선 및 오류 처리 최적화
  * 알람 메시지 사용자 연결 관계 설정 개선
  * 저장된 알람 정보 추적 기능 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->