### PR TITLE
[Feat] 월별 GPS Session 조회 기능

### DIFF
--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionJpaRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionJpaRepository.java
@@ -5,9 +5,16 @@ import com.fitpet.server.user.domain.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface GpsSessionJpaRepository extends JpaRepository<GpsSession, Long> {
     List<GpsSession> findByUserAndStartTimeBetween(User user, LocalDateTime start, LocalDateTime end);
-    
+
+    @Query("SELECT s FROM GpsSession s WHERE s.user = :user AND s.startTime >= :start AND s.startTime < :end "
+        + "ORDER BY s.startTime DESC")
+    List<GpsSession> findMonthlySessions(@Param("user") User user,
+                                         @Param("start") LocalDateTime start,
+                                         @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionRepositoryAdapter.java
@@ -26,6 +26,11 @@ public class GpsSessionRepositoryAdapter implements GpsSessionRepository {
     }
 
     @Override
+    public List<GpsSession> findMonthlySessions(User user, LocalDateTime start, LocalDateTime end) {
+        return gpsSessionJpaRepository.findMonthlySessions(user, start, end);
+    }
+
+    @Override
     public Optional<GpsSession> findById(Long id) {
         return gpsSessionJpaRepository.findById(id);
     }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
@@ -5,7 +5,9 @@ import com.fitpet.server.dailyworkout.presentation.dto.request.SessionEndRequest
 import com.fitpet.server.dailyworkout.presentation.dto.request.SessionStartRequest;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsLogResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionStartResponse;
+import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionSummaryResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndResponse;
+import java.util.List;
 
 public interface GpsSessionService {
 
@@ -14,4 +16,6 @@ public interface GpsSessionService {
     GpsLogResponse logGps(GpsLogRequest request);
 
     SessionEndResponse endSession(SessionEndRequest request);
+
+    List<GpsSessionSummaryResponse> getMonthlySessions(Long userId, int year, int month);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
@@ -10,11 +10,17 @@ import com.fitpet.server.dailyworkout.presentation.dto.request.SessionEndRequest
 import com.fitpet.server.dailyworkout.presentation.dto.request.SessionStartRequest;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsLogResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionStartResponse;
+import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionSummaryResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndResponse;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.exception.ErrorCode;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,15 +43,15 @@ public class GpsSessionServiceImpl implements GpsSessionService {
         log.info("GPS 세션 시작 요청: userId={}", request.getUserId());
 
         User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> {
-                    log.warn("사용자를 찾을 수 없음: userId={}", request.getUserId());
-                    return new BusinessException(ErrorCode.USER_NOT_FOUND);
-                });
+            .orElseThrow(() -> {
+                log.warn("사용자를 찾을 수 없음: userId={}", request.getUserId());
+                return new BusinessException(ErrorCode.USER_NOT_FOUND);
+            });
 
         GpsSession newSession = GpsSession.builder()
-                .user(user)
-                .startTime(request.getStartTime())
-                .build();
+            .user(user)
+            .startTime(request.getStartTime())
+            .build();
 
         GpsSession savedSession = gpsSessionRepository.save(newSession);
         log.info("GPS 세션 생성 완료: sessionId={}", savedSession.getId());
@@ -58,10 +64,10 @@ public class GpsSessionServiceImpl implements GpsSessionService {
         log.debug("GPS 로그 기록 요청: sessionId={}", request.getSessionId());
 
         GpsSession session = gpsSessionRepository.findById(request.getSessionId())
-                .orElseThrow(() -> {
-                    log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
-                    return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
-                });
+            .orElseThrow(() -> {
+                log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
+                return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+            });
 
         GpsLog newLog = gpsMapper.toGpsLogEntity(request, session);
         GpsLog savedLog = gpsLogRepository.save(newLog);
@@ -75,15 +81,49 @@ public class GpsSessionServiceImpl implements GpsSessionService {
         log.info("GPS 세션 종료 요청: sessionId={}", request.getSessionId());
 
         GpsSession session = gpsSessionRepository.findById(request.getSessionId())
-                .orElseThrow(() -> {
-                    log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
-                    return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
-                });
+            .orElseThrow(() -> {
+                log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
+                return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+            });
 
         gpsMapper.updateSessionFromEndRequest(request, session);
         session.setEndTime(request.getEndTime());
         log.info("GPS 세션 종료 완료: sessionId={}", session.getId());
 
         return gpsMapper.toSessionEndResponse(session);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GpsSessionSummaryResponse> getMonthlySessions(
+        Long userId, int year, int month
+    ) {
+        LocalDate startDate;
+        try {
+            startDate = LocalDate.of(year, month, 1);
+        } catch (DateTimeException e) {
+            log.warn("잘못된 연월 요청: year={}, month={}", year, month);
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = startDate.plusMonths(1).atStartOfDay();
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> {
+                log.warn("사용자를 찾을 수 없음: userId={}", userId);
+                return new BusinessException(ErrorCode.USER_NOT_FOUND);
+            });
+
+        List<GpsSession> sessions = gpsSessionRepository.findMonthlySessions(user, start, end);
+
+        return sessions.stream()
+            .map(session -> GpsSessionSummaryResponse.of(
+                session.getId(),
+                session.getStartTime(),
+                session.getEndTime(),
+                session.getTotalDistance()
+            ))
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsSessionRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsSessionRepository.java
@@ -12,5 +12,7 @@ public interface GpsSessionRepository {
 
     List<GpsSession> findByUserAndStartTimeBetween(User user, LocalDateTime start, LocalDateTime end);
 
+    List<GpsSession> findMonthlySessions(User user, LocalDateTime start, LocalDateTime end);
+
     Optional<GpsSession> findById(Long id);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -11,10 +11,13 @@ import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndRespon
 import com.fitpet.server.shared.annotation.AuthUser;
 import com.fitpet.server.shared.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/gps")
 @RequiredArgsConstructor
+@Validated
 public class GpsController {
 
     private final GpsSessionService gpsSessionService;
@@ -54,8 +58,8 @@ public class GpsController {
     @GetMapping("/sessions")
     public ResponseEntity<List<GpsSessionSummaryResponse>> getMonthlySessions(
         @AuthUser Long userId,
-        @RequestParam int year,
-        @RequestParam int month
+        @RequestParam @Min(2025) @Max(2100) int year,
+        @RequestParam @Min(1) @Max(12) int month
     ) {
         List<GpsSessionSummaryResponse> sessions = gpsSessionService.getMonthlySessions(userId, year, month);
         return ResponseEntity.ok(sessions);

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -6,15 +6,20 @@ import com.fitpet.server.dailyworkout.presentation.dto.request.SessionEndRequest
 import com.fitpet.server.dailyworkout.presentation.dto.request.SessionStartRequest;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsLogResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionStartResponse;
+import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionSummaryResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndResponse;
+import com.fitpet.server.shared.annotation.AuthUser;
 import com.fitpet.server.shared.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,8 +31,8 @@ public class GpsController {
 
     @PostMapping("/start")
     public ResponseEntity<GpsSessionStartResponse> startSession(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @Valid @RequestBody SessionStartRequest request
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @Valid @RequestBody SessionStartRequest request
     ) {
         //Long currentUserId = userDetails.getUserId();
         GpsSessionStartResponse response = gpsSessionService.startSession(request);
@@ -44,5 +49,15 @@ public class GpsController {
     public ResponseEntity<SessionEndResponse> endSession(@Valid @RequestBody SessionEndRequest request) {
         SessionEndResponse response = gpsSessionService.endSession(request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/sessions")
+    public ResponseEntity<List<GpsSessionSummaryResponse>> getMonthlySessions(
+        @AuthUser Long userId,
+        @RequestParam int year,
+        @RequestParam int month
+    ) {
+        List<GpsSessionSummaryResponse> sessions = gpsSessionService.getMonthlySessions(userId, year, month);
+        return ResponseEntity.ok(sessions);
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/response/GpsSessionSummaryResponse.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/response/GpsSessionSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.fitpet.server.dailyworkout.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record GpsSessionSummaryResponse(
+    Long sessionId,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    BigDecimal totalDistance
+) {
+    public static GpsSessionSummaryResponse of(
+        Long sessionId,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        BigDecimal totalDistance
+    ) {
+        return new GpsSessionSummaryResponse(sessionId, startTime, endTime, totalDistance);
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약

- 월별 GPS Session 조회 기능 구현 했습니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [ ] 관련 API 변경
- [ ] 기타 리팩터링

## 🧪 테스트 방법

- 포스트맨으로 테스트 했습니다
<img width="1296" height="786" alt="image" src="https://github.com/user-attachments/assets/1618327c-75b1-4884-9f60-1524956bae24" />


## 📎 관련 이슈

- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 월별 GPS 운동 세션 조회: 연도와 월을 지정해 해당 기간의 모든 GPS 세션을 조회할 수 있습니다. 각 세션의 시작/종료 시간 및 총 이동 거리를 확인할 수 있고 최신 세션부터 내림차순으로 정렬되어 표시됩니다. 요청 파라미터에 대한 유효성 검사도 적용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->