### PR TITLE
Feature/gcp test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     // GCP
-   // implementation platform("com.google.cloud:spring-cloud-gcp-dependencies:5.13.6")
     implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.27.1"
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     // GCP
-    implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.19.0"
+   // implementation platform("com.google.cloud:spring-cloud-gcp-dependencies:5.13.6")
+    implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.27.1"
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     // GCP
-    implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.16.0"
+    implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.19.0"
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ dependencies {
     //FCM
     implementation 'com.google.firebase:firebase-admin:9.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    // GCP
+    implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.16.0"
+
 }
 
 tasks.named('test') { useJUnitPlatform() }

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -42,7 +42,16 @@ public class FcmConfig {
 //            ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
 
             // 2025.12.24 KKR]  GCP 설정파일 읽기위함
-            Resource resource = resourceLoader.getResource(serviceAccountKeyPath);
+            Resource resource;
+            if (serviceAccountKeyPath.startsWith("classpath:")) {
+                resource = resourceLoader.getResource(serviceAccountKeyPath);
+            } else if (serviceAccountKeyPath.startsWith("file:")) {
+                resource = resourceLoader.getResource(serviceAccountKeyPath);
+            } else if (serviceAccountKeyPath.startsWith("/")) {
+                resource = new FileSystemResource(serviceAccountKeyPath);
+            } else {
+                resource = resourceLoader.getResource("file:" + serviceAccountKeyPath);
+            }
 
             if (!resource.exists()) {
                 throw new RuntimeException("❌ FCM 키 파일을 찾을 수 없습니다. 경로를 확인해주세요: " + serviceAccountKeyPath);

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.ResourceLoader;
 
 @Slf4j
 @Configuration
@@ -29,13 +30,19 @@ public class FcmConfig {
 
     private FirebaseApp firebaseApp;
 
+    private final ResourceLoader resourceLoader;
+
+    public FcmConfig(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
     @PostConstruct
     public void initialize() {
         try {
-            //ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
-            // 2025.12.24 KKR]  GCP 설정파일 읽기위함
-            Resource resource = new FileSystemResource(serviceAccountKeyPath);
+//            ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
 
+            // 2025.12.24 KKR]  GCP 설정파일 읽기위함
+            Resource resource = resourceLoader.getResource(serviceAccountKeyPath);
 
             if (!resource.exists()) {
                 throw new RuntimeException("❌ FCM 키 파일을 찾을 수 없습니다. 경로를 확인해주세요: " + serviceAccountKeyPath);

--- a/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/FcmConfig.java
@@ -1,5 +1,8 @@
 package com.fitpet.server.shared.config;
 
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.FileSystemResource;
+
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.firebase.FirebaseApp;
@@ -29,7 +32,10 @@ public class FcmConfig {
     @PostConstruct
     public void initialize() {
         try {
-            ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
+            //ClassPathResource resource = new ClassPathResource(serviceAccountKeyPath);
+            // 2025.12.24 KKR]  GCP 설정파일 읽기위함
+            Resource resource = new FileSystemResource(serviceAccountKeyPath);
+
 
             if (!resource.exists()) {
                 throw new RuntimeException("❌ FCM 키 파일을 찾을 수 없습니다. 경로를 확인해주세요: " + serviceAccountKeyPath);

--- a/src/main/java/com/fitpet/server/shared/config/OpenApiConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/OpenApiConfig.java
@@ -1,0 +1,37 @@
+package com.fitpet.server.shared.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String DEV_USER_HEADER = "dev-user-id";
+
+    @Bean
+    public OpenAPI openAPI() {
+       
+        /* 2025.12.26 MANDARIN] 현재 Swegger 페이지의 origin 기준 API 호출 */
+        return new OpenAPI()
+            .components(
+                new Components().addSecuritySchemes(
+                    DEV_USER_HEADER,
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.APIKEY)
+                        .in(SecurityScheme.In.HEADER)
+                        .name(DEV_USER_HEADER)
+                        .description("개발용 사용자 ID (예: 3)")
+                )
+            )
+          .addSecurityItem(new SecurityRequirement().addList(DEV_USER_HEADER))
+          .servers(List.of(new Server().url("/")));
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -48,9 +48,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
+        http.csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
@@ -77,26 +75,5 @@ public class SecurityConfig {
         return web -> web.ignoring()
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
             .requestMatchers(SWAGGER_WHITELIST);
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-
-        // GCP HTTPS 연결을 위하여 추가설정
-        CorsConfiguration config = new CorsConfiguration();
-
-        config.setAllowedOrigins(List.of(
-                "https://back-847805723578.europe-west1.run.app",
-                "http://localhost:3000",
-                "http://localhost:8080"
-        ));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Authorization"));
-        config.setAllowCredentials(false);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -49,14 +49,16 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> {})
+                .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .requestMatchers(SWAGGER_WHITELIST).permitAll()
                 .requestMatchers(HttpMethod.GET, "/swagger-ui/swagger-config").permitAll()
                 .requestMatchers(PERMIT_URL_ARRAY).permitAll()

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -11,6 +11,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -70,5 +75,26 @@ public class SecurityConfig {
         return web -> web.ignoring()
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
             .requestMatchers(SWAGGER_WHITELIST);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        // GCP HTTPS 연결을 위하여 추가설정
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of(
+                "https://back-847805723578.europe-west1.run.app",
+                "http://localhost:3000",
+                "http://localhost:8080"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -82,11 +82,19 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        // 일단 배포 문제 잡기용(임시). 이후 도메인 고정
-        config.setAllowedOriginPatterns(List.of("*"));
+        // 추후 도메인 고정
+        config.setAllowedOriginPatterns(List.of("https://*.run.app"));
+
+        // Method 허용
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        
+        // Header 허용
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("dev-user-id"));
+        
+        // 응답 Header 허용
+        config.setExposedHeaders(List.of("Authorization", "dev-user-id"));
+        
+        // 쿠키 인증 안 쓸 때
         config.setAllowCredentials(false); // credentials 쓸 거면 Origin을 명시해야 함
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
@@ -76,4 +77,22 @@ public class SecurityConfig {
             .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
             .requestMatchers(SWAGGER_WHITELIST);
     }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 일단 배포 문제 잡기용(임시). 이후 도메인 고정
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("dev-user-id"));
+        config.setAllowCredentials(false); // credentials 쓸 거면 Origin을 명시해야 함
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> {})
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/fitpet/server/termsmaster/infra/TermsAgreementJpaRepository.java
+++ b/src/main/java/com/fitpet/server/termsmaster/infra/TermsAgreementJpaRepository.java
@@ -1,6 +1,6 @@
 package com.fitpet.server.termsmaster.infra;
 
-import com.fitpet.server.terms.domain.entity.TermsAgreement;
+import com.fitpet.server.termsmaster.domain.entity.TermsAgreement;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TermsAgreementJpaRepository extends JpaRepository<TermsAgreement, Long> {

--- a/src/main/java/com/fitpet/server/termsmaster/infra/TermsAgreementRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/termsmaster/infra/TermsAgreementRepositoryAdapter.java
@@ -1,6 +1,6 @@
 package com.fitpet.server.termsmaster.infra;
 
-import com.fitpet.server.terms.domain.entity.TermsAgreement;
+import com.fitpet.server.termsmaster.domain.entity.TermsAgreement;
 import com.fitpet.server.termsmaster.domain.repository.TermsAgreementRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}&unixSocketPath=/cloudsql&cloudSqlRefreshStrategy=lazy

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,3 +1,4 @@
 spring:
   datasource:
-    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}&unixSocketPath=/cloudsql&cloudSqlRefreshStrategy=lazy
+    #url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}&unixSocketPath=/cloudsql&cloudSqlRefreshStrategy=lazy
+    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&cloudSqlRefreshStrategy=lazy

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: ${DB_URL}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,7 +61,6 @@ jwt:
     secret: ${JWT_REFRESH_SECRET}
     expiration-ms: ${JWT_REFRESH_EXPIRATION_MS}
 
-
 oauth:
   google:
     client-id: ${spring.security.oauth2.client.registration.google.client-id}
@@ -71,7 +70,6 @@ oauth:
 logging:
   level:
     org.springframework.security: DEBUG
-
 
 cloud:
   aws:
@@ -90,3 +88,8 @@ aws:
 fcm:
   service-account-key-path: ${FCM_PATH}
   project-id: fitp-9e7ad
+
+# 2025.12.26 MANDARIN] 현재 페이지 기준 origin API 호출 설정
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,12 +3,11 @@ spring:
     active: local
   main:
     web-application-type: servlet
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
+  spring:
+    datasource:
+      url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}
+      username: ${DB_USERNAME}
+      password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,11 +18,6 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
 
-  cloud:
-    gcp:
-      sql:
-        instance-connection-name: ${GCP_SQL_CONNECTION_NAME}
-        database-name: ${DB_NAME}
   data:
     redis:
       host: localhost

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,5 +82,5 @@ aws:
     bucket: fitpet-bucket
 
 fcm:
-  service-account-key-path: "/fcm/firebase-service-account-key.json"
+  service-account-key-path: ${FCM_PATH}
   project-id: fitp-9e7ad

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,11 +3,10 @@ spring:
     active: local
   main:
     web-application-type: servlet
-  spring:
-    datasource:
-      url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}
-      username: ${DB_USERNAME}
-      password: ${DB_PASSWORD}
+  datasource:
+    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,5 +82,5 @@ aws:
     bucket: fitpet-bucket
 
 fcm:
-  service-account-key-path: "fcm/firebase-service-account-key.json"
+  service-account-key-path: "/fcm/firebase-service-account-key.json"
   project-id: fitp-9e7ad

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,10 +1,9 @@
 spring:
   profiles:
-    active: local
+    active:  ${ACTIVE_PROFILE}
   main:
     web-application-type: servlet
   datasource:
-    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,12 +3,12 @@ spring:
     active: local
   main:
     web-application-type: servlet
-
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -17,6 +17,12 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+  cloud:
+    gcp:
+      sql:
+        instance-connection-name: ${GCP_SQL_CONNECTION_NAME}
+        database-name: ${DB_NAME}
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 📌 PR 요약

- 이 PR은 무엇을 해결하거나 개선합니까?
Google Cloud 서비스의 GCP Run, GCP와 연동합니다.

## ✅ 작업 상세 내용

- [x] GCP Run, GCP SQL 서비스와 연결하였습니다.
- [x] GCP 연결을 위하여 dev, local 용 application.yml을 분리했습니다. 
- [x] swegger에 Authorize 기능을 추가했습니다.
<img width="935" height="237" alt="Screenshot 2025-12-26 at 8 06 31 PM" src="https://github.com/user-attachments/assets/33156b6e-555f-4fd9-8c9a-398faa34426f" />

## 🧪 테스트 방법

- 기능 테스트 방식 또는 실행 방법을 설명해주세요.
1. http://localhost:8080/swagger-ui/index.html#/ 에서 Authorize 버튼을 통해 수행합니다.
<img width="935" height="237" alt="Screenshot 2025-12-26 at 8 06 31 PM" src="https://github.com/user-attachments/assets/33156b6e-555f-4fd9-8c9a-398faa34426f" />
<img width="744" height="428" alt="Screenshot 2025-12-26 at 8 08 51 PM" src="https://github.com/user-attachments/assets/43980fe7-6621-4e1b-a478-5a2abff41af2" />

2. 개발자도구 > Network 탭에서 상세관찰할 수 있습니다.
<img width="909" height="521" alt="Screenshot 2025-12-26 at 8 10 41 PM" src="https://github.com/user-attachments/assets/e94c890f-97c0-4029-9612-acedc262577f" />






## 📎 관련 이슈

- Close #123

## 추가 전달 사항
- localhost 서비스가 제대로 DB 연동이 되기 위해선 GCP SQL 서비스에서 IP 등록이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OpenAPI 기반 API 문서화 추가
  * CORS(Cross-Origin Resource Sharing) 지원 추가
  * Google Cloud SQL 연결 지원 추가

* **개선 사항**
  * 환경 변수 기반 설정으로 프로파일 및 DB/FCM 경로 유연성 향상
  * FCM 서비스 계정 키 로딩 로직 개선
  * 개발 환경에서 SQL 로깅 활성화 및 Redis 기본 포트 설정
  * Swagger UI 기본 URL 비활성화 설정 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->