### PR TITLE
[Feat] 미션 완료 기반 배지 지급 및 누적 통계 구조 추가

### DIFF
--- a/src/main/java/com/fitpet/server/badge/application/dto/BadgeCheckCreateCommand.java
+++ b/src/main/java/com/fitpet/server/badge/application/dto/BadgeCheckCreateCommand.java
@@ -1,0 +1,5 @@
+package com.fitpet.server.badge.application.dto;
+
+public record BadgeCheckCreateCommand(Long badgeId) {
+}
+

--- a/src/main/java/com/fitpet/server/badge/application/dto/BadgeCheckResult.java
+++ b/src/main/java/com/fitpet/server/badge/application/dto/BadgeCheckResult.java
@@ -1,0 +1,13 @@
+package com.fitpet.server.badge.application.dto;
+
+import java.time.LocalDateTime;
+
+public record BadgeCheckResult(
+        Long badgeCheckId,
+        Long userId,
+        Long badgeId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}
+

--- a/src/main/java/com/fitpet/server/badge/application/dto/BadgeCreateCommand.java
+++ b/src/main/java/com/fitpet/server/badge/application/dto/BadgeCreateCommand.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.badge.application.dto;
+
+import com.fitpet.server.badge.domain.entity.BadgeType;
+
+public record BadgeCreateCommand(
+        String title,
+        BadgeType type,
+        Integer conditionDuration,
+        Long conditionGoal,
+        String description,
+        Long missionId
+) {
+}
+

--- a/src/main/java/com/fitpet/server/badge/application/dto/BadgeResult.java
+++ b/src/main/java/com/fitpet/server/badge/application/dto/BadgeResult.java
@@ -1,0 +1,18 @@
+package com.fitpet.server.badge.application.dto;
+
+import com.fitpet.server.badge.domain.entity.BadgeType;
+import java.time.LocalDateTime;
+
+public record BadgeResult(
+        Long badgeId,
+        String title,
+        BadgeType type,
+        Integer conditionDuration,
+        Long conditionGoal,
+        String description,
+        Long missionId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}
+

--- a/src/main/java/com/fitpet/server/badge/application/dto/BadgeUpdateCommand.java
+++ b/src/main/java/com/fitpet/server/badge/application/dto/BadgeUpdateCommand.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.badge.application.dto;
+
+import com.fitpet.server.badge.domain.entity.BadgeType;
+
+public record BadgeUpdateCommand(
+        String title,
+        BadgeType type,
+        Integer conditionDuration,
+        Long conditionGoal,
+        String description,
+        Long missionId
+) {
+}
+

--- a/src/main/java/com/fitpet/server/badge/application/mapper/BadgeCheckMapper.java
+++ b/src/main/java/com/fitpet/server/badge/application/mapper/BadgeCheckMapper.java
@@ -1,8 +1,8 @@
 package com.fitpet.server.badge.application.mapper;
 
+import com.fitpet.server.badge.application.dto.BadgeCheckResult;
 import com.fitpet.server.badge.domain.entity.Badge;
 import com.fitpet.server.badge.domain.entity.BadgeCheck;
-import com.fitpet.server.badge.presentation.dto.BadgeCheckDto;
 import com.fitpet.server.user.domain.entity.User;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -21,7 +21,7 @@ public interface BadgeCheckMapper {
     @Mapping(target = "badgeCheckId", source = "id")
     @Mapping(target = "userId", source = "user.id")
     @Mapping(target = "badgeId", source = "badge.id")
-    BadgeCheckDto toDto(BadgeCheck badgeCheck);
+    BadgeCheckResult toResult(BadgeCheck badgeCheck);
 
-    List<BadgeCheckDto> toDtos(List<BadgeCheck> badgeChecks);
+    List<BadgeCheckResult> toResults(List<BadgeCheck> badgeChecks);
 }

--- a/src/main/java/com/fitpet/server/badge/application/mapper/BadgeMapper.java
+++ b/src/main/java/com/fitpet/server/badge/application/mapper/BadgeMapper.java
@@ -1,9 +1,9 @@
 package com.fitpet.server.badge.application.mapper;
 
+import com.fitpet.server.badge.application.dto.BadgeCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeResult;
+import com.fitpet.server.badge.application.dto.BadgeUpdateCommand;
 import com.fitpet.server.badge.domain.entity.Badge;
-import com.fitpet.server.badge.presentation.dto.BadgeCreateRequest;
-import com.fitpet.server.badge.presentation.dto.BadgeDto;
-import com.fitpet.server.badge.presentation.dto.BadgeUpdateRequest;
 import java.util.List;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
@@ -18,13 +18,14 @@ public interface BadgeMapper {
     @Mapping(target = "mission", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    Badge toEntity(BadgeCreateRequest request);
+    Badge toEntity(BadgeCreateCommand command);
 
     @Mapping(target = "badgeId", source = "id")
-    BadgeDto toDto(Badge badge);
+    @Mapping(target = "missionId", source = "mission.id")
+    BadgeResult toResult(Badge badge);
 
-    List<BadgeDto> toDtos(List<Badge> badges);
+    List<BadgeResult> toResults(List<Badge> badges);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
-    void update(@MappingTarget Badge badge, BadgeUpdateRequest request);
+    void update(@MappingTarget Badge badge, BadgeUpdateCommand command);
 }

--- a/src/main/java/com/fitpet/server/badge/application/mapper/BadgeMapper.java
+++ b/src/main/java/com/fitpet/server/badge/application/mapper/BadgeMapper.java
@@ -15,6 +15,7 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 public interface BadgeMapper {
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "mission", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     Badge toEntity(BadgeCreateRequest request);

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeCheckService.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeCheckService.java
@@ -1,13 +1,13 @@
 package com.fitpet.server.badge.application.service;
 
-import com.fitpet.server.badge.presentation.dto.BadgeCheckCreateRequest;
-import com.fitpet.server.badge.presentation.dto.BadgeCheckDto;
+import com.fitpet.server.badge.application.dto.BadgeCheckCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeCheckResult;
 import java.util.List;
 
 public interface BadgeCheckService {
-    BadgeCheckDto assignBadge(Long userId, BadgeCheckCreateRequest request);
+    BadgeCheckResult assignBadge(Long userId, BadgeCheckCreateCommand command);
 
-    List<BadgeCheckDto> getUserBadges(Long userId);
+    List<BadgeCheckResult> getUserBadges(Long userId);
 
     void revokeBadge(Long badgeCheckId);
 }

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeCheckServiceImpl.java
@@ -1,5 +1,7 @@
 package com.fitpet.server.badge.application.service;
 
+import com.fitpet.server.badge.application.dto.BadgeCheckCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeCheckResult;
 import com.fitpet.server.badge.application.mapper.BadgeCheckMapper;
 import com.fitpet.server.badge.domain.entity.Badge;
 import com.fitpet.server.badge.domain.entity.BadgeCheck;
@@ -7,8 +9,6 @@ import com.fitpet.server.badge.domain.exception.BadgeCheckNotFoundException;
 import com.fitpet.server.badge.domain.exception.BadgeNotFoundException;
 import com.fitpet.server.badge.domain.repository.BadgeCheckRepository;
 import com.fitpet.server.badge.domain.repository.BadgeRepository;
-import com.fitpet.server.badge.presentation.dto.BadgeCheckCreateRequest;
-import com.fitpet.server.badge.presentation.dto.BadgeCheckDto;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
@@ -30,11 +30,11 @@ public class BadgeCheckServiceImpl implements BadgeCheckService {
     private final UserRepository userRepository;
 
     @Override
-    public BadgeCheckDto assignBadge(Long userId, BadgeCheckCreateRequest request) {
-        log.info("[BadgeCheckService] 뱃지 부여 요청: userId={}, badgeId={}", userId, request.badgeId());
-        BadgeCheck badgeCheck = badgeCheckRepository.findByUserIdAndBadgeId(userId, request.badgeId())
+    public BadgeCheckResult assignBadge(Long userId, BadgeCheckCreateCommand command) {
+        log.info("[BadgeCheckService] 뱃지 부여 요청: userId={}, badgeId={}", userId, command.badgeId());
+        BadgeCheck badgeCheck = badgeCheckRepository.findByUserIdAndBadgeId(userId, command.badgeId())
                 .orElseGet(() -> {
-                    Badge badge = badgeRepository.findById(request.badgeId())
+                    Badge badge = badgeRepository.findById(command.badgeId())
                             .orElseThrow(BadgeNotFoundException::new);
                     User user = userRepository.findById(userId)
                             .orElseThrow(UserNotFoundException::new);
@@ -43,15 +43,15 @@ public class BadgeCheckServiceImpl implements BadgeCheckService {
 
         BadgeCheck saved = badgeCheckRepository.save(badgeCheck);
         log.info("[BadgeCheckService] 뱃지 부여 완료: badgeCheckId={}, userId={}, badgeId={}",
-                saved.getId(), userId, request.badgeId());
-        return badgeCheckMapper.toDto(saved);
+                saved.getId(), userId, command.badgeId());
+        return badgeCheckMapper.toResult(saved);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<BadgeCheckDto> getUserBadges(Long userId) {
+    public List<BadgeCheckResult> getUserBadges(Long userId) {
         log.info("[BadgeCheckService] 사용자 뱃지 조회 요청: userId={}", userId);
-        return badgeCheckMapper.toDtos(badgeCheckRepository.findAllByUserId(userId));
+        return badgeCheckMapper.toResults(badgeCheckRepository.findAllByUserId(userId));
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeService.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeService.java
@@ -1,18 +1,18 @@
 package com.fitpet.server.badge.application.service;
 
-import com.fitpet.server.badge.presentation.dto.BadgeCreateRequest;
-import com.fitpet.server.badge.presentation.dto.BadgeDto;
-import com.fitpet.server.badge.presentation.dto.BadgeUpdateRequest;
+import com.fitpet.server.badge.application.dto.BadgeCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeResult;
+import com.fitpet.server.badge.application.dto.BadgeUpdateCommand;
 import java.util.List;
 
 public interface BadgeService {
-    BadgeDto createBadge(BadgeCreateRequest request);
+    BadgeResult createBadge(BadgeCreateCommand command);
 
-    BadgeDto getBadge(Long badgeId);
+    BadgeResult getBadge(Long badgeId);
 
-    List<BadgeDto> getBadges();
+    List<BadgeResult> getBadges();
 
-    BadgeDto updateBadge(Long badgeId, BadgeUpdateRequest request);
+    BadgeResult updateBadge(Long badgeId, BadgeUpdateCommand command);
 
     void deleteBadge(Long badgeId);
 }

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
@@ -1,12 +1,12 @@
 package com.fitpet.server.badge.application.service;
 
+import com.fitpet.server.badge.application.dto.BadgeCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeResult;
+import com.fitpet.server.badge.application.dto.BadgeUpdateCommand;
 import com.fitpet.server.badge.application.mapper.BadgeMapper;
 import com.fitpet.server.badge.domain.entity.Badge;
 import com.fitpet.server.badge.domain.exception.BadgeNotFoundException;
 import com.fitpet.server.badge.domain.repository.BadgeRepository;
-import com.fitpet.server.badge.presentation.dto.BadgeCreateRequest;
-import com.fitpet.server.badge.presentation.dto.BadgeDto;
-import com.fitpet.server.badge.presentation.dto.BadgeUpdateRequest;
 import com.fitpet.server.mission.domain.entity.Mission;
 import com.fitpet.server.mission.domain.exception.MissionNotFoundException;
 import com.fitpet.server.mission.domain.repository.MissionRepository;
@@ -28,47 +28,47 @@ public class BadgeServiceImpl implements BadgeService {
 
     // 관리자 전용
     @Override
-    public BadgeDto createBadge(BadgeCreateRequest request) {
-        log.info("[BadgeService] 뱃지 생성 요청: title={}, type={}", request.title(), request.type());
-        Badge badge = badgeMapper.toEntity(request);
-        Mission mission = missionRepository.findById(request.missionId())
+    public BadgeResult createBadge(BadgeCreateCommand command) {
+        log.info("[BadgeService] 뱃지 생성 요청: title={}, type={}", command.title(), command.type());
+        Badge badge = badgeMapper.toEntity(command);
+        Mission mission = missionRepository.findById(command.missionId())
                 .orElseThrow(MissionNotFoundException::new);
         badge.assignMission(mission);
         Badge saved = badgeRepository.save(badge);
         log.info("[BadgeService] 뱃지 생성 완료: id={}", saved.getId());
-        return badgeMapper.toDto(saved);
+        return badgeMapper.toResult(saved);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public BadgeDto getBadge(Long badgeId) {
+    public BadgeResult getBadge(Long badgeId) {
         log.info("[BadgeService] 뱃지 조회 요청: id={}", badgeId);
         Badge badge = badgeRepository.findById(badgeId)
                 .orElseThrow(BadgeNotFoundException::new);
-        return badgeMapper.toDto(badge);
+        return badgeMapper.toResult(badge);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<BadgeDto> getBadges() {
+    public List<BadgeResult> getBadges() {
         log.info("[BadgeService] 뱃지 전체 조회 요청");
-        return badgeMapper.toDtos(badgeRepository.findAll());
+        return badgeMapper.toResults(badgeRepository.findAll());
     }
 
     // 관리자 전용
     @Override
-    public BadgeDto updateBadge(Long badgeId, BadgeUpdateRequest request) {
+    public BadgeResult updateBadge(Long badgeId, BadgeUpdateCommand command) {
         log.info("[BadgeService] 뱃지 수정 요청: id={}", badgeId);
         Badge badge = badgeRepository.findById(badgeId)
                 .orElseThrow(BadgeNotFoundException::new);
         Mission mission = null;
-        if (request.missionId() != null) {
-            mission = missionRepository.findById(request.missionId())
+        if (command.missionId() != null) {
+            mission = missionRepository.findById(command.missionId())
                     .orElseThrow(MissionNotFoundException::new);
         }
-        badge.update(request.title(), request.type(), request.conditionDuration(), request.conditionGoal(),
-                request.description(), mission);
-        return badgeMapper.toDto(badge);
+        badge.update(command.title(), command.type(), command.conditionDuration(), command.conditionGoal(),
+                command.description(), mission);
+        return badgeMapper.toResult(badge);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
@@ -7,6 +7,9 @@ import com.fitpet.server.badge.domain.repository.BadgeRepository;
 import com.fitpet.server.badge.presentation.dto.BadgeCreateRequest;
 import com.fitpet.server.badge.presentation.dto.BadgeDto;
 import com.fitpet.server.badge.presentation.dto.BadgeUpdateRequest;
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.exception.MissionNotFoundException;
+import com.fitpet.server.mission.domain.repository.MissionRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,11 +24,16 @@ public class BadgeServiceImpl implements BadgeService {
 
     private final BadgeRepository badgeRepository;
     private final BadgeMapper badgeMapper;
+    private final MissionRepository missionRepository;
 
+    // 관리자 전용
     @Override
     public BadgeDto createBadge(BadgeCreateRequest request) {
         log.info("[BadgeService] 뱃지 생성 요청: title={}, type={}", request.title(), request.type());
         Badge badge = badgeMapper.toEntity(request);
+        Mission mission = missionRepository.findById(request.missionId())
+                .orElseThrow(MissionNotFoundException::new);
+        badge.update(null, null, null, null, null, mission);
         Badge saved = badgeRepository.save(badge);
         log.info("[BadgeService] 뱃지 생성 완료: id={}", saved.getId());
         return badgeMapper.toDto(saved);
@@ -47,13 +55,19 @@ public class BadgeServiceImpl implements BadgeService {
         return badgeMapper.toDtos(badgeRepository.findAll());
     }
 
+    // 관리자 전용
     @Override
     public BadgeDto updateBadge(Long badgeId, BadgeUpdateRequest request) {
         log.info("[BadgeService] 뱃지 수정 요청: id={}", badgeId);
         Badge badge = badgeRepository.findById(badgeId)
                 .orElseThrow(BadgeNotFoundException::new);
+        Mission mission = null;
+        if (request.missionId() != null) {
+            mission = missionRepository.findById(request.missionId())
+                    .orElseThrow(MissionNotFoundException::new);
+        }
         badge.update(request.title(), request.type(), request.conditionDuration(), request.conditionGoal(),
-                request.description());
+                request.description(), mission);
         return badgeMapper.toDto(badge);
     }
 

--- a/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
+++ b/src/main/java/com/fitpet/server/badge/application/service/BadgeServiceImpl.java
@@ -33,7 +33,7 @@ public class BadgeServiceImpl implements BadgeService {
         Badge badge = badgeMapper.toEntity(request);
         Mission mission = missionRepository.findById(request.missionId())
                 .orElseThrow(MissionNotFoundException::new);
-        badge.update(null, null, null, null, null, mission);
+        badge.assignMission(mission);
         Badge saved = badgeRepository.save(badge);
         log.info("[BadgeService] 뱃지 생성 완료: id={}", saved.getId());
         return badgeMapper.toDto(saved);

--- a/src/main/java/com/fitpet/server/badge/domain/entity/Badge.java
+++ b/src/main/java/com/fitpet/server/badge/domain/entity/Badge.java
@@ -18,6 +18,11 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import com.fitpet.server.mission.domain.entity.Mission;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Getter
 @Entity
@@ -49,6 +54,12 @@ public class Badge {
     @Column(name = "description", length = 255)
     private String description;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "mission_id", nullable = false,
+        unique = true,
+        foreignKey = @ForeignKey(name = "fk_badge_mission"))
+    private Mission mission;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -58,7 +69,7 @@ public class Badge {
     private LocalDateTime updatedAt;
 
     public void update(String title, BadgeType type, Integer conditionDuration, Long conditionGoal,
-                       String description) {
+                       String description, Mission mission) {
         if (title != null && !title.isBlank()) {
             this.title = title;
         }
@@ -73,6 +84,9 @@ public class Badge {
         }
         if (description != null) {
             this.description = description;
+        }
+        if (mission != null) {
+            this.mission = mission;
         }
     }
 }

--- a/src/main/java/com/fitpet/server/badge/domain/entity/Badge.java
+++ b/src/main/java/com/fitpet/server/badge/domain/entity/Badge.java
@@ -89,4 +89,11 @@ public class Badge {
             this.mission = mission;
         }
     }
+
+    public void assignMission(Mission mission) {
+        if (mission == null) {
+            throw new IllegalArgumentException("mission은 null일 수 없습니다.");
+        }
+        this.mission = mission;
+    }
 }

--- a/src/main/java/com/fitpet/server/badge/domain/entity/BadgeType.java
+++ b/src/main/java/com/fitpet/server/badge/domain/entity/BadgeType.java
@@ -5,5 +5,6 @@ public enum BadgeType {
     RUN,
     MISSION,
     ATTENDANCE,
-    EAT_KCAL
+    EAT_KCAL,
+    MEAL
 }

--- a/src/main/java/com/fitpet/server/badge/domain/repository/BadgeCheckRepository.java
+++ b/src/main/java/com/fitpet/server/badge/domain/repository/BadgeCheckRepository.java
@@ -6,8 +6,14 @@ import java.util.Optional;
 
 public interface BadgeCheckRepository {
     BadgeCheck save(BadgeCheck badgeCheck);
+
     Optional<BadgeCheck> findById(Long badgeCheckId);
+
     Optional<BadgeCheck> findByUserIdAndBadgeId(Long userId, Long badgeId);
+
     List<BadgeCheck> findAllByUserId(Long userId);
+
+    boolean existsByUserIdAndBadgeId(Long userId, Long badgeId);
+
     void delete(BadgeCheck badgeCheck);
 }

--- a/src/main/java/com/fitpet/server/badge/domain/repository/BadgeRepository.java
+++ b/src/main/java/com/fitpet/server/badge/domain/repository/BadgeRepository.java
@@ -6,7 +6,12 @@ import java.util.Optional;
 
 public interface BadgeRepository {
     Badge save(Badge badge);
+
     Optional<Badge> findById(Long badgeId);
+
     List<Badge> findAll();
+
     void delete(Badge badge);
+
+    List<Badge> findEligibleByMissionId(Long missionId, Long clearCount);
 }

--- a/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeCheckJpaRepository.java
+++ b/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeCheckJpaRepository.java
@@ -7,5 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BadgeCheckJpaRepository extends JpaRepository<BadgeCheck, Long> {
     Optional<BadgeCheck> findByUser_IdAndBadge_Id(Long userId, Long badgeId);
+
     List<BadgeCheck> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
+
+    boolean existsByUser_IdAndBadge_Id(Long userId, Long badgeId);
 }

--- a/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeCheckRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeCheckRepositoryAdapter.java
@@ -37,4 +37,9 @@ public class BadgeCheckRepositoryAdapter implements BadgeCheckRepository {
     public void delete(BadgeCheck badgeCheck) {
         badgeCheckJpaRepository.delete(badgeCheck);
     }
+
+    @Override
+    public boolean existsByUserIdAndBadgeId(Long userId, Long badgeId) {
+        return badgeCheckJpaRepository.existsByUser_IdAndBadge_Id(userId, badgeId);
+    }
 }

--- a/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeJpaRepository.java
+++ b/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeJpaRepository.java
@@ -1,7 +1,21 @@
 package com.fitpet.server.badge.infra.jpa;
 
 import com.fitpet.server.badge.domain.entity.Badge;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BadgeJpaRepository extends JpaRepository<Badge, Long> {
+    
+    @Query("""
+            select b
+            from Badge b
+            where b.mission.id = :missionId
+              and b.conditionGoal <= :clearCount
+            order by b.conditionGoal desc
+            """)
+    List<Badge> findEligibleByMissionIdAndClearCount(
+            @Param("missionId") Long missionId,
+            @Param("clearCount") Long clearCount);
 }

--- a/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/badge/infra/jpa/BadgeRepositoryAdapter.java
@@ -32,4 +32,9 @@ public class BadgeRepositoryAdapter implements BadgeRepository {
     public void delete(Badge badge) {
         badgeJpaRepository.delete(badge);
     }
+
+    @Override
+    public List<Badge> findEligibleByMissionId(Long missionId, Long clearCount) {
+        return badgeJpaRepository.findEligibleByMissionIdAndClearCount(missionId, clearCount);
+    }
 }

--- a/src/main/java/com/fitpet/server/badge/presentation/controller/BadgeController.java
+++ b/src/main/java/com/fitpet/server/badge/presentation/controller/BadgeController.java
@@ -2,6 +2,11 @@ package com.fitpet.server.badge.presentation.controller;
 
 import com.fitpet.server.badge.application.service.BadgeCheckService;
 import com.fitpet.server.badge.application.service.BadgeService;
+import com.fitpet.server.badge.application.dto.BadgeCheckCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeCheckResult;
+import com.fitpet.server.badge.application.dto.BadgeCreateCommand;
+import com.fitpet.server.badge.application.dto.BadgeResult;
+import com.fitpet.server.badge.application.dto.BadgeUpdateCommand;
 import com.fitpet.server.badge.presentation.dto.BadgeCheckCreateRequest;
 import com.fitpet.server.badge.presentation.dto.BadgeCheckDto;
 import com.fitpet.server.badge.presentation.dto.BadgeCreateRequest;
@@ -36,28 +41,31 @@ public class BadgeController {
     @PostMapping
     public ResponseEntity<BadgeDto> createBadge(
             @Valid @RequestBody BadgeCreateRequest request) {
-        BadgeDto created = badgeService.createBadge(request);
+        BadgeResult created = badgeService.createBadge(toCommand(request));
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{badgeId}")
                 .buildAndExpand(created.badgeId())
                 .toUri();
-        return ResponseEntity.created(location).body(created);
+        return ResponseEntity.created(location).body(toBadgeDto(created));
     }
 
     @GetMapping
     public ResponseEntity<List<BadgeDto>> getBadges() {
-        return ResponseEntity.ok(badgeService.getBadges());
+        List<BadgeDto> badges = badgeService.getBadges().stream()
+                .map(BadgeController::toBadgeDto)
+                .toList();
+        return ResponseEntity.ok(badges);
     }
 
     @GetMapping("/{badgeId}")
     public ResponseEntity<BadgeDto> getBadge(@PathVariable Long badgeId) {
-        return ResponseEntity.ok(badgeService.getBadge(badgeId));
+        return ResponseEntity.ok(toBadgeDto(badgeService.getBadge(badgeId)));
     }
 
     @PatchMapping("/{badgeId}")
     public ResponseEntity<BadgeDto> updateBadge(@PathVariable Long badgeId,
                                                 @Valid @RequestBody BadgeUpdateRequest request) {
-        return ResponseEntity.ok(badgeService.updateBadge(badgeId, request));
+        return ResponseEntity.ok(toBadgeDto(badgeService.updateBadge(badgeId, toCommand(request))));
     }
 
     @DeleteMapping("/{badgeId}")
@@ -71,20 +79,68 @@ public class BadgeController {
             @AuthUser Long userId,
             @Valid @RequestBody BadgeCheckCreateRequest request) {
 
-        BadgeCheckDto response = badgeCheckService.assignBadge(userId, request);
-        return ResponseEntity.ok(response);
+        BadgeCheckResult response = badgeCheckService.assignBadge(userId, new BadgeCheckCreateCommand(request.badgeId()));
+        return ResponseEntity.ok(toBadgeCheckDto(response));
     }
 
     @GetMapping("/users")
     public ResponseEntity<List<BadgeCheckDto>> getUserBadges(
             @AuthUser Long userId
     ) {
-        return ResponseEntity.ok(badgeCheckService.getUserBadges(userId));
+        List<BadgeCheckDto> checks = badgeCheckService.getUserBadges(userId).stream()
+                .map(BadgeController::toBadgeCheckDto)
+                .toList();
+        return ResponseEntity.ok(checks);
     }
 
     @DeleteMapping("/checks/{badgeCheckId}")
     public ResponseEntity<Void> revokeBadge(@PathVariable Long badgeCheckId) {
         badgeCheckService.revokeBadge(badgeCheckId);
         return ResponseEntity.noContent().build();
+    }
+
+    private static BadgeCreateCommand toCommand(BadgeCreateRequest request) {
+        return new BadgeCreateCommand(
+                request.title(),
+                request.type(),
+                request.conditionDuration(),
+                request.conditionGoal(),
+                request.description(),
+                request.missionId()
+        );
+    }
+
+    private static BadgeUpdateCommand toCommand(BadgeUpdateRequest request) {
+        return new BadgeUpdateCommand(
+                request.title(),
+                request.type(),
+                request.conditionDuration(),
+                request.conditionGoal(),
+                request.description(),
+                request.missionId()
+        );
+    }
+
+    private static BadgeDto toBadgeDto(BadgeResult result) {
+        return new BadgeDto(
+                result.badgeId(),
+                result.title(),
+                result.type(),
+                result.conditionDuration(),
+                result.conditionGoal(),
+                result.description(),
+                result.createdAt(),
+                result.updatedAt()
+        );
+    }
+
+    private static BadgeCheckDto toBadgeCheckDto(BadgeCheckResult result) {
+        return new BadgeCheckDto(
+                result.badgeCheckId(),
+                result.userId(),
+                result.badgeId(),
+                result.createdAt(),
+                result.updatedAt()
+        );
     }
 }

--- a/src/main/java/com/fitpet/server/badge/presentation/dto/BadgeCreateRequest.java
+++ b/src/main/java/com/fitpet/server/badge/presentation/dto/BadgeCreateRequest.java
@@ -9,6 +9,7 @@ public record BadgeCreateRequest(
         @NotNull BadgeType type,
         Integer conditionDuration,
         Long conditionGoal,
-        String description
+        String description,
+        @NotNull Long missionId
 ) {
 }

--- a/src/main/java/com/fitpet/server/badge/presentation/dto/BadgeUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/badge/presentation/dto/BadgeUpdateRequest.java
@@ -7,6 +7,7 @@ public record BadgeUpdateRequest(
     BadgeType type,
     Integer conditionDuration,
     Long conditionGoal,
-    String description
+    String description,
+    Long missionId
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckBatchService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckBatchService.java
@@ -13,6 +13,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -104,7 +105,7 @@ public class MissionCheckBatchService {
                 missionCheckRepository.findExistingKeys(userIds, missionIds, type, period.start())
         );
 
-        List<MissionCheck> toSave = new java.util.ArrayList<>();
+        List<MissionCheck> toSave = new ArrayList<>();
         for (User user : users) {
             for (Mission mission : missions) {
                 if (existingKeys.contains(new MissionCheckKey(mission.getId(), user.getId()))) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
@@ -12,7 +12,6 @@ import com.fitpet.server.mission.domain.entity.MissionCategory;
 import com.fitpet.server.mission.domain.entity.MissionCheck;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import com.fitpet.server.mission.domain.exception.MissionCheckAccessDeniedException;
-import com.fitpet.server.mission.domain.exception.MissionCheckNotCompletableException;
 import com.fitpet.server.mission.domain.exception.MissionCheckNotFoundException;
 import com.fitpet.server.mission.domain.exception.MissionNotFoundException;
 import com.fitpet.server.mission.domain.repository.MissionCheckRepository;
@@ -46,6 +45,7 @@ public class MissionCheckServiceImpl implements MissionCheckService {
     private final MealRepository mealRepository;
     private final UserRepository userRepository;
     private final PetExpressionService petExpressionService;
+    private final MissionCompletionService missionCompletionService;
 
     @Override
     public MissionCheckResult upsertMissionCheck(Long missionId, Long userId, MissionCheckCommand request) {
@@ -88,29 +88,10 @@ public class MissionCheckServiceImpl implements MissionCheckService {
 
     @Override
     public MissionCheckResult completeMissionCheck(Long userId, Long missionCheckId) {
-        MissionCheck missionCheck = missionCheckRepository.findById(missionCheckId)
-                .orElseThrow(MissionCheckNotFoundException::new);
-
-        if (!missionCheck.getUser().getId().equals(userId)) {
-            log.warn("[MissionCheckService] 완료 권한 없음: 요청자 userId={}, 기록 소유자 userId={}, checkId={}",
-                    userId, missionCheck.getUser().getId(), missionCheckId);
-            throw new MissionCheckAccessDeniedException();
-        }
-
-        if (missionCheck.isCompleted()) {
-            return missionCheckMapper.toDto(missionCheck);
-        }
-
-        Mission mission = missionCheck.getMission();
-        if (!isCompleted(missionCheck.getProgressValue(), mission.getGoal())) {
-            throw new MissionCheckNotCompletableException();
-        }
-
-        missionCheck.updateProgress(missionCheck.getProgressValue(), true, LocalDateTime.now());
-        MissionCheck saved = missionCheckRepository.save(missionCheck);
+        MissionCheck completed = missionCompletionService.completeMission(userId, missionCheckId);
         petExpressionService.updateExpression(userId, PetExpression.HAPPY);
         log.info("[MissionCheckService] 수행 완료 처리: missionCheckId={}, userId={}", missionCheckId, userId);
-        return missionCheckMapper.toDto(saved);
+        return missionCheckMapper.toDto(completed);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionService.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.mission.application.service;
+
+import com.fitpet.server.mission.domain.entity.MissionCheck;
+
+public interface MissionCompletionService {
+
+    MissionCheck completeMission(Long userId, Long missionCheckId);
+}

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
@@ -37,9 +37,7 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
         MissionCheck missionCheck = missionCheckRepository.findByIdForUpdate(missionCheckId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_CHECK_NOT_FOUND));
 
-        if (!missionCheck.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.MISSION_CHECK_ACCESS_DENIED);
-        }
+        validateOwner(missionCheck, userId);
 
         if (missionCheck.isCompleted()) {
             return missionCheck;
@@ -55,6 +53,16 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
         UserMissionStat stat = adjustClearCount(missionCheck);
         awardBadges(missionCheck.getUser(), missionCheck.getMission(), stat.getClearCount());
         return missionCheck;
+    }
+
+    private void validateOwner(MissionCheck missionCheck, Long userId) {
+        if (!isOwner(missionCheck, userId)) {
+            throw new BusinessException(ErrorCode.MISSION_CHECK_ACCESS_DENIED);
+        }
+    }
+
+    private boolean isOwner(MissionCheck missionCheck, Long userId) {
+        return missionCheck.getUser().getId().equals(userId);
     }
 
     private boolean isGoalReached(MissionCheck missionCheck) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
@@ -27,6 +27,7 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
 
     private final MissionCheckRepository missionCheckRepository;
     private final UserMissionStatRepository userMissionStatRepository;
+    private final UserMissionStatCreateService userMissionStatCreateService;
     private final BadgeRepository badgeRepository;
     private final BadgeCheckRepository badgeCheckRepository;
 
@@ -64,34 +65,28 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
     }
 
     private UserMissionStat adjustClearCount(MissionCheck missionCheck) {
-        return userMissionStatRepository.findWithLockByUserAndMission(
-                        missionCheck.getUser(),
-                        missionCheck.getMission()
-                )
+        User user = missionCheck.getUser();
+        Mission mission = missionCheck.getMission();
+
+        return userMissionStatRepository.findWithLockByUserAndMission(user, mission)
                 .map(stat -> {
                     stat.incrementClearCount();
                     return stat;
                 })
-                .orElseGet(() -> createStat(missionCheck));
+                .orElseGet(() -> createOrIncrementStat(user, mission));
     }
 
-    private UserMissionStat createStat(MissionCheck missionCheck) {
-        try {
-            UserMissionStat stat = UserMissionStat.builder()
-                    .user(missionCheck.getUser())
-                    .mission(missionCheck.getMission())
-                    .clearCount(1)
-                    .build();
-            return userMissionStatRepository.save(stat);
-        } catch (DataIntegrityViolationException ex) {
-            UserMissionStat stat = userMissionStatRepository.findWithLockByUserAndMission(
-                            missionCheck.getUser(),
-                            missionCheck.getMission()
-                    )
-                    .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_STAT_DUPLICATE));
+    private UserMissionStat createOrIncrementStat(User user, Mission mission) {
+        boolean created = userMissionStatCreateService.tryCreate(user, mission);
+
+        UserMissionStat stat = userMissionStatRepository.findWithLockByUserAndMission(user, mission)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_STAT_DUPLICATE));
+
+        if (!created) {
             stat.incrementClearCount();
-            return stat;
         }
+
+        return stat;
     }
 
     private void awardBadges(User user, Mission mission, Integer clearCount) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
@@ -1,0 +1,123 @@
+package com.fitpet.server.mission.application.service;
+
+import com.fitpet.server.badge.domain.entity.Badge;
+import com.fitpet.server.badge.domain.entity.BadgeCheck;
+import com.fitpet.server.badge.domain.repository.BadgeCheckRepository;
+import com.fitpet.server.badge.domain.repository.BadgeRepository;
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.entity.MissionCheck;
+import com.fitpet.server.mission.domain.entity.UserMissionStat;
+import com.fitpet.server.mission.domain.repository.MissionCheckRepository;
+import com.fitpet.server.mission.domain.repository.UserMissionStatRepository;
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.user.domain.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MissionCompletionServiceImpl implements MissionCompletionService {
+
+    private final MissionCheckRepository missionCheckRepository;
+    private final UserMissionStatRepository userMissionStatRepository;
+    private final BadgeRepository badgeRepository;
+    private final BadgeCheckRepository badgeCheckRepository;
+
+    @Transactional
+    @Override
+    public MissionCheck completeMission(Long userId, Long missionCheckId) {
+        MissionCheck missionCheck = missionCheckRepository.findByIdForUpdate(missionCheckId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_CHECK_NOT_FOUND));
+
+        if (!missionCheck.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.MISSION_CHECK_ACCESS_DENIED);
+        }
+
+        if (missionCheck.isCompleted()) {
+            return missionCheck;
+        }
+
+        if (!isGoalReached(missionCheck)) {
+            throw new BusinessException(ErrorCode.MISSION_CHECK_NOT_COMPLETABLE);
+        }
+
+        missionCheck.updateProgress(missionCheck.getProgressValue(), true, LocalDateTime.now());
+        missionCheckRepository.save(missionCheck);
+
+        UserMissionStat stat = adjustClearCount(missionCheck);
+        awardBadges(missionCheck.getUser(), missionCheck.getMission(), stat.getClearCount());
+        return missionCheck;
+    }
+
+    private boolean isGoalReached(MissionCheck missionCheck) {
+        if (missionCheck.getProgressValue() == null || missionCheck.getMission().getGoal() == null) {
+            return false;
+        }
+        return missionCheck.getProgressValue().compareTo(missionCheck.getMission().getGoal()) >= 0;
+    }
+
+    private UserMissionStat adjustClearCount(MissionCheck missionCheck) {
+        return userMissionStatRepository.findWithLockByUserAndMission(
+                        missionCheck.getUser(),
+                        missionCheck.getMission()
+                )
+                .map(stat -> {
+                    stat.incrementClearCount();
+                    return stat;
+                })
+                .orElseGet(() -> createStat(missionCheck));
+    }
+
+    private UserMissionStat createStat(MissionCheck missionCheck) {
+        try {
+            UserMissionStat stat = UserMissionStat.builder()
+                    .user(missionCheck.getUser())
+                    .mission(missionCheck.getMission())
+                    .clearCount(1)
+                    .build();
+            return userMissionStatRepository.save(stat);
+        } catch (DataIntegrityViolationException ex) {
+            UserMissionStat stat = userMissionStatRepository.findWithLockByUserAndMission(
+                            missionCheck.getUser(),
+                            missionCheck.getMission()
+                    )
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_STAT_DUPLICATE));
+            stat.incrementClearCount();
+            return stat;
+        }
+    }
+
+    private void awardBadges(User user, Mission mission, Integer clearCount) {
+        if (clearCount == null) {
+            return;
+        }
+
+        List<Badge> badges = badgeRepository.findEligibleByMissionId(
+                mission.getId(),
+                clearCount.longValue()
+        );
+
+        for (Badge badge : badges) {
+            // TODO: conditionDuration 기반 "N일 이내 M회" 조건 확장 지점.
+            if (badgeCheckRepository.existsByUserIdAndBadgeId(user.getId(), badge.getId())) {
+                continue;
+            }
+            try {
+                BadgeCheck badgeCheck = BadgeCheck.builder()
+                        .user(user)
+                        .badge(badge)
+                        .build();
+                badgeCheckRepository.save(badgeCheck);
+            } catch (DataIntegrityViolationException ignored) {
+                log.debug("이미 부여된 뱃지입니다. userId={} badgeId={}", user.getId(), badge.getId());
+            }
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/application/service/UserMissionStatCreateService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/UserMissionStatCreateService.java
@@ -1,0 +1,35 @@
+package com.fitpet.server.mission.application.service;
+
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.entity.UserMissionStat;
+import com.fitpet.server.mission.domain.repository.UserMissionStatRepository;
+import com.fitpet.server.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserMissionStatCreateService {
+
+    private final UserMissionStatRepository userMissionStatRepository;
+
+    //user_mission_stat 생성은 UNIQUE(user_id, mission_id) 충돌이 발생할 수 있어, 외부 트랜잭션과 분리
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean tryCreate(User user, Mission mission) {
+        try {
+            UserMissionStat stat = UserMissionStat.builder()
+                    .user(user)
+                    .mission(mission)
+                    .clearCount(1)
+                    .build();
+            userMissionStatRepository.save(stat);
+            return true;
+        } catch (DataIntegrityViolationException ignored) {
+            return false;
+        }
+    }
+}
+

--- a/src/main/java/com/fitpet/server/mission/domain/entity/UserMissionStat.java
+++ b/src/main/java/com/fitpet/server/mission/domain/entity/UserMissionStat.java
@@ -1,0 +1,67 @@
+package com.fitpet.server.mission.domain.entity;
+
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Entity
+@Table(name = "user_mission_stat",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_mission_stat", columnNames = {"user_id", "mission_id"})
+    })
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserMissionStat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stat_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false,
+        foreignKey = @ForeignKey(name = "fk_user_mission_stat_user"))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "mission_id", nullable = false,
+        foreignKey = @ForeignKey(name = "fk_user_mission_stat_mission"))
+    private Mission mission;
+
+    @Column(name = "clear_count", nullable = false)
+    private Integer clearCount;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public void incrementClearCount() {
+        this.clearCount = (this.clearCount == null ? 0 : this.clearCount) + 1;
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/domain/repository/MissionCheckRepository.java
+++ b/src/main/java/com/fitpet/server/mission/domain/repository/MissionCheckRepository.java
@@ -15,6 +15,8 @@ public interface MissionCheckRepository {
 
     Optional<MissionCheck> findById(Long missionCheckId);
 
+    Optional<MissionCheck> findByIdForUpdate(Long missionCheckId);
+
     Optional<MissionCheck> findByPeriodKey(
         Long missionId,
         Long userId,

--- a/src/main/java/com/fitpet/server/mission/domain/repository/UserMissionStatRepository.java
+++ b/src/main/java/com/fitpet/server/mission/domain/repository/UserMissionStatRepository.java
@@ -1,0 +1,13 @@
+package com.fitpet.server.mission.domain.repository;
+
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.entity.UserMissionStat;
+import com.fitpet.server.user.domain.entity.User;
+import java.util.Optional;
+
+public interface UserMissionStatRepository {
+
+    Optional<UserMissionStat> findWithLockByUserAndMission(User user, Mission mission);
+
+    UserMissionStat save(UserMissionStat stat);
+}

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/MissionCheckJpaRepository.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/MissionCheckJpaRepository.java
@@ -7,7 +7,9 @@ import com.fitpet.server.mission.domain.repository.MissionCheckKey;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,6 +29,14 @@ public interface MissionCheckJpaRepository extends JpaRepository<MissionCheck, L
             @Param("periodType") MissionType periodType,
             @Param("periodStart") LocalDate periodStart
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select mc
+            from MissionCheck mc
+            where mc.id = :missionCheckId
+            """)
+    Optional<MissionCheck> findByIdForUpdate(@Param("missionCheckId") Long missionCheckId);
 
     @Query("""
             select new com.fitpet.server.mission.domain.repository.MissionCheckKey(mc.mission.id, mc.user.id)

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/MissionCheckRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/MissionCheckRepositoryAdapter.java
@@ -33,6 +33,11 @@ public class MissionCheckRepositoryAdapter implements MissionCheckRepository {
     }
 
     @Override
+    public Optional<MissionCheck> findByIdForUpdate(Long missionCheckId) {
+        return missionCheckJpaRepository.findByIdForUpdate(missionCheckId);
+    }
+
+    @Override
     public Optional<MissionCheck> findByPeriodKey(
         Long missionId,
         Long userId,

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatJpaRepository.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatJpaRepository.java
@@ -1,0 +1,15 @@
+package com.fitpet.server.mission.infra.jpa;
+
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.entity.UserMissionStat;
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface UserMissionStatJpaRepository extends JpaRepository<UserMissionStat, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<UserMissionStat> findWithLockByUserAndMission(User user, Mission mission);
+}

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package com.fitpet.server.mission.infra.jpa;
+
+import com.fitpet.server.mission.domain.entity.Mission;
+import com.fitpet.server.mission.domain.entity.UserMissionStat;
+import com.fitpet.server.mission.domain.repository.UserMissionStatRepository;
+import com.fitpet.server.user.domain.entity.User;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserMissionStatRepositoryAdapter implements UserMissionStatRepository {
+
+    private final UserMissionStatJpaRepository userMissionStatJpaRepository;
+
+    @Override
+    public Optional<UserMissionStat> findWithLockByUserAndMission(User user, Mission mission) {
+        return userMissionStatJpaRepository.findWithLockByUserAndMission(user, mission);
+    }
+
+    @Override
+    public UserMissionStat save(UserMissionStat stat) {
+        return userMissionStatJpaRepository.save(stat);
+    }
+
+}

--- a/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
+++ b/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
@@ -25,9 +25,11 @@ public enum ErrorCode {
     MISSION_CHECK_NOT_FOUND(HttpStatus.NOT_FOUND, "MI003", "해당 미션 수행 기록을 찾을 수 없습니다."),
     MISSION_CHECK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MI004", "해당 미션 수행 기록에 대한 권한이 없습니다."),
     MISSION_CHECK_NOT_COMPLETABLE(HttpStatus.BAD_REQUEST, "MI005", "목표 달성 후 완료할 수 있습니다."),
+    MISSION_STAT_DUPLICATE(HttpStatus.CONFLICT, "MI006", "해당 미션 통계가 이미 존재합니다."),
 
     BADGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BA001", "해당 뱃지를 찾을 수 없습니다."),
     BADGE_CHECK_NOT_FOUND(HttpStatus.NOT_FOUND, "BA002", "해당 뱃지 획득 기록을 찾을 수 없습니다."),
+    BADGE_ALREADY_GRANTED(HttpStatus.CONFLICT, "BA003", "이미 해당 뱃지를 보유하고 있습니다."),
 
     PET_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "사용자의 펫을 찾을 수 없습니다."),
     PET_ALREADY_EXISTS(HttpStatus.CONFLICT, "P002", "사용자는 이미 펫을 보유하고 있습니다."),


### PR DESCRIPTION
## 📌 PR 요약
- 미션 완료 시 누적 통계(user_mission_stat)를 갱신하고, 조건 충족 시 배지를 자동 지급하도록 미션–뱃지 구조를 1:1로 연결했습니다.

## ✅ 작업 상세 내용

- [ ] 주요 기능 구현
    - 미션 완료 유스케이스 분리 (MissionCompletionService)
    - 완료 시 clear_count 증가 및 배지 지급 처리
    - 중복 지급 방지 및 동시성 대응
- [ ] 관련 API 변경
    - 뱃지 생성/수정 시 missionId 필수 반영
- [ ] 기타 리팩터링
    - 배지 조회 쿼리 리네이밍 및 @Query 적용
    - user_mission_stat 레포지토리 분리

## 🧪 테스트 방법

- Postman 미션 완료 후 벳지체크 조회
<img width="1476" height="781" alt="image" src="https://github.com/user-attachments/assets/c6812db3-3c8c-47b8-8070-79a8377a2440" />
<img width="1476" height="727" alt="image" src="https://github.com/user-attachments/assets/84030f5a-cd1a-4303-b6ac-7296ebf965e2" />

## 📎 관련 이슈

- Close #49 

## 추가 전달 사항
- 동시 완료 요청을 고려해 mission_check, user_mission_stat에 PESSIMISTIC_WRITE 락 적용했습니다.
- BadgeType에 MEAL이 추가되어야 DB의 MEAL 값과 매핑 오류가 발생하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 미션 완료 시 클리어 횟수에 따라 배지를 자동 지급하도록 보상 로직 도입
  * 사용자별 미션 통계(UserMissionStat) 도입으로 미션별 클리어 횟수 추적 가능
  * 새로운 배지 유형 'MEAL' 추가
  * 배지와 미션 연관(미션 기반 배지 관리) 강화하여 미션 조건에 따른 배지 선별/지급 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->