### PR TITLE
[📌Feature] GPS 세션 종료 시 운동 데이터(거리, 속도, 칼로리) 자동 계산 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,9 @@ dependencies {
     // Lombok & MapStruct
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     // Configuration Processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -87,13 +87,12 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.20.41')
     implementation 'software.amazon.awssdk:s3'
 
-    //FCM
+    // FCM
     implementation 'com.google.firebase:firebase-admin:9.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     // GCP
     implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.27.1"
-
 }
 
 tasks.named('test') { useJUnitPlatform() }

--- a/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
@@ -196,14 +196,15 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     private void handleDailyStepUpdate(User user, int newStep, LocalDate date, int delta) {
         user.updateDailyStepCount(newStep);
 
-        rankingService.updateScore(user.getId(), newStep);
-
         Integer target = user.getTargetStepCount();
         if (target != null && newStep >= target) {
             petExpressionService.updateExpression(user.getId(), PetExpression.PROUD);
         }
+
         if (delta > 0 && date.equals(LocalDate.now())) {
             missionCheckService.updateStepMissions(user.getId(), date, BigDecimal.valueOf(delta));
         }
+
+        rankingService.updateScore(user.getId(), newStep);
     }
 }

--- a/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
@@ -10,6 +10,7 @@ import com.fitpet.server.dailywalk.presentation.dto.response.DailyStepSummaryRes
 import com.fitpet.server.dailywalk.presentation.dto.response.DailyWalkResponse;
 import com.fitpet.server.pet.application.service.PetExpressionService;
 import com.fitpet.server.pet.domain.entity.PetExpression;
+import com.fitpet.server.ranking.application.service.RankingService;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.exception.ErrorCode;
 import com.fitpet.server.user.domain.entity.User;
@@ -38,6 +39,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     private final UserRepository userRepository;
     private final DailyWalkMapper dailyWalkMapper;
     private final PetExpressionService petExpressionService;
+    private final RankingService rankingService;
 
     @Override
     @Transactional(readOnly = true)
@@ -198,6 +200,9 @@ public class DailyWalkServiceImpl implements DailyWalkService {
 
     private void handleDailyStepUpdate(User user, int newStep) {
         user.updateDailyStepCount(newStep);
+
+        rankingService.updateScore(user.getId(), newStep);
+
         Integer target = user.getTargetStepCount();
         if (target != null && newStep >= target) {
             petExpressionService.updateExpression(user.getId(), PetExpression.PROUD);

--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsLogJpaRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsLogJpaRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GpsLogJpaRepository extends JpaRepository<GpsLog, Long> {
     List<GpsLog> findByGpsSessionOrderByRecordedAtAsc(GpsSession gpsSession);
-    
+
+    GpsLog findTopByGpsSessionOrderByRecordedAtDesc(GpsSession gpsSession);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsLogRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsLogRepositoryAdapter.java
@@ -22,4 +22,9 @@ public class GpsLogRepositoryAdapter implements GpsLogRepository {
     public List<GpsLog> findByGpsSessionOrderByRecordedAtAsc(GpsSession gpsSession) {
         return gpsLogJpaRepository.findByGpsSessionOrderByRecordedAtAsc(gpsSession);
     }
+
+    @Override
+    public GpsLog findTopByGpsSessionOrderByRecordedAtDesc(GpsSession gpsSession) {
+        return gpsLogJpaRepository.findTopByGpsSessionOrderByRecordedAtDesc(gpsSession);
+    }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/mapper/GpsMapper.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/mapper/GpsMapper.java
@@ -3,13 +3,11 @@ package com.fitpet.server.dailyworkout.application.mapper;
 import com.fitpet.server.dailyworkout.domain.entity.GpsLog;
 import com.fitpet.server.dailyworkout.domain.entity.GpsSession;
 import com.fitpet.server.dailyworkout.presentation.dto.request.GpsLogRequest;
-import com.fitpet.server.dailyworkout.presentation.dto.request.SessionEndRequest;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsLogResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionStartResponse;
 import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.mapstruct.ReportingPolicy;
 
 @Mapper(
@@ -36,12 +34,4 @@ public interface GpsMapper {
     @Mapping(source = "id", target = "sessionId")
     @Mapping(target = "message", constant = "GPS session ended")
     SessionEndResponse toSessionEndResponse(GpsSession session);
-
-
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "totalDistance", ignore = true)
-    @Mapping(source = "endTime", target = "endTime")
-    @Mapping(source = "stepCount", target = "stepCount")
-    @Mapping(source = "burnCalories", target = "burnCalories")
-    void updateSessionFromEndRequest(SessionEndRequest request, @MappingTarget GpsSession session);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/mapper/GpsMapper.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/mapper/GpsMapper.java
@@ -19,6 +19,7 @@ import org.mapstruct.ReportingPolicy;
 public interface GpsMapper {
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "gpsSession", source = "session")
     @Mapping(target = "user", source = "session.user")
     GpsLog toGpsLogEntity(GpsLogRequest request, GpsSession session);
@@ -28,6 +29,7 @@ public interface GpsMapper {
     GpsSessionStartResponse toSessionStartResponse(GpsSession session);
 
     @Mapping(source = "id", target = "logId")
+    @Mapping(source = "gpsSession.id", target = "sessionId")
     @Mapping(target = "message", constant = "GPS log saved")
     GpsLogResponse toGpsLogResponse(GpsLog log);
 
@@ -35,8 +37,11 @@ public interface GpsMapper {
     @Mapping(target = "message", constant = "GPS session ended")
     SessionEndResponse toSessionEndResponse(GpsSession session);
 
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "totalDistance", ignore = true)
     @Mapping(source = "endTime", target = "endTime")
     @Mapping(source = "stepCount", target = "stepCount")
-    @Mapping(source = "distance", target = "totalDistance")
-    void updateSessionFromEndRequest(SessionEndRequest dto, @MappingTarget GpsSession session);
+    @Mapping(source = "burnCalories", target = "burnCalories")
+    void updateSessionFromEndRequest(SessionEndRequest request, @MappingTarget GpsSession session);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
@@ -14,9 +14,9 @@ public interface GpsSessionService {
 
     GpsSessionStartResponse startSession(Long userId, SessionStartRequest request);
 
-    GpsLogResponse logGps(GpsLogRequest request);
+    GpsLogResponse logGps(Long userId, GpsLogRequest request);
 
-    SessionEndResponse endSession(SessionEndRequest request);
+    SessionEndResponse endSession(Long userId, SessionEndRequest request);
 
     List<GpsSessionSummaryResponse> getMonthlySessions(Long userId, int year, int month);
 

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
@@ -42,7 +42,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     private final UserRepository userRepository;
     private final GpsMapper gpsMapper;
 
-    // GPS 필터링 상수
+    // GPS 필터링용 상수 추가
     private static final double MIN_DISTANCE_METER = 2.0;       // 2m 미만 이동은 노이즈로 간주하고 무시
     private static final double MAX_HUMAN_SPEED_KMH = 45.0;     // 시속 45km 이상은 차량/오류
     private static final double MAX_NOISE_SPEED_KMH = 150.0;    // 시속 150km 이상은 명백한 GPS 튐
@@ -77,6 +77,12 @@ public class GpsSessionServiceImpl implements GpsSessionService {
                     return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
                 });
 
+        if (!session.isOwnedBy(userId)) {
+            log.warn("권한 없는 세션 접근 시도: requester={}, owner={}, sessionId={}",
+                    userId, session.getUser().getId(), session.getId());
+            throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
+        }
+
         GpsLog lastLog = gpsLogRepository.findTopByGpsSessionOrderByRecordedAtDesc(session);
 
         if (lastLog != null) {
@@ -102,7 +108,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
             // 속도 계산 (km/h)
             double speedKmh = (distanceMeters / timeDeltaSeconds) * 3.6;
 
-            // 필터링: 45km/h 이상 무시
+            // 필터링: 45km/h 이상 무시 (차량 및 GPS 튀어오름 방지)
             if (speedKmh > MAX_HUMAN_SPEED_KMH) {
                 if (speedKmh > MAX_NOISE_SPEED_KMH) {
                     log.warn("GPS Noise Detected: speed={}km/h, dist={}m", speedKmh, distanceMeters);
@@ -113,7 +119,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
                 return gpsMapper.toGpsLogResponse(lastLog);
             }
 
-            // 정상 데이터 처리
+            // 정상 데이터 처리: 세션 엔티티에 거리 누적
             session.addDistance(distance);
         }
 
@@ -133,6 +139,11 @@ public class GpsSessionServiceImpl implements GpsSessionService {
                     log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
                     return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
                 });
+
+        if (!session.isOwnedBy(userId)) {
+            log.warn("권한 없는 세션 종료 시도: requester={}, owner={}", userId, session.getUser().getId());
+            throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
+        }
 
         gpsMapper.updateSessionFromEndRequest(request, session);
         session.setEndTime(request.getEndTime());
@@ -177,8 +188,8 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     public GpsSessionDetailResponse getSessionDetail(Long userId, Long sessionId) {
         GpsSession session = gpsSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-
-        if (!session.getUser().getId().equals(userId)) {
+        
+        if (!session.isOwnedBy(userId)) {
             log.warn("세션 조회 권한 없음: userId={}, ownerId={}", userId, session.getUser().getId());
             throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
         }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
@@ -42,7 +42,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     private final UserRepository userRepository;
     private final GpsMapper gpsMapper;
 
-    // GPS 필터링용 상수 추가
+    // GPS 필터링 상수
     private static final double MIN_DISTANCE_METER = 2.0;       // 2m 미만 이동은 노이즈로 간주하고 무시
     private static final double MAX_HUMAN_SPEED_KMH = 45.0;     // 시속 45km 이상은 차량/오류
     private static final double MAX_NOISE_SPEED_KMH = 150.0;    // 시속 150km 이상은 명백한 GPS 튐
@@ -145,11 +145,15 @@ public class GpsSessionServiceImpl implements GpsSessionService {
             throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
         }
 
-        gpsMapper.updateSessionFromEndRequest(request, session);
-        session.setEndTime(request.getEndTime());
+        //  내부 로직으로 '소모 칼로리(체중 기반 METs)'와 '평균 속도'를 자동 계산
+        session.endSession(
+                request.getEndTime(),
+                request.getStepCount(),
+                request.getBurnCalories()
+        );
 
-        log.info("GPS 세션 종료 완료: sessionId={}, totalDistance={}",
-                session.getId(), session.getTotalDistance());
+        log.info("GPS 세션 종료 완료: sessionId={}, totalDistance={}, burnCalories={}",
+                session.getId(), session.getTotalDistance(), session.getBurnCalories());
 
         return gpsMapper.toSessionEndResponse(session);
     }
@@ -188,7 +192,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     public GpsSessionDetailResponse getSessionDetail(Long userId, Long sessionId) {
         GpsSession session = gpsSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-        
+
         if (!session.isOwnedBy(userId)) {
             log.warn("세션 조회 권한 없음: userId={}, ownerId={}", userId, session.getUser().getId());
             throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
@@ -16,11 +16,14 @@ import com.fitpet.server.dailyworkout.presentation.dto.response.GpsSessionSummar
 import com.fitpet.server.dailyworkout.presentation.dto.response.SessionEndResponse;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.shared.util.GeometryUtil;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -39,20 +42,25 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     private final UserRepository userRepository;
     private final GpsMapper gpsMapper;
 
+    // GPS 필터링 상수
+    private static final double MIN_DISTANCE_METER = 2.0;       // 2m 미만 이동은 노이즈로 간주하고 무시
+    private static final double MAX_HUMAN_SPEED_KMH = 45.0;     // 시속 45km 이상은 차량/오류
+    private static final double MAX_NOISE_SPEED_KMH = 150.0;    // 시속 150km 이상은 명백한 GPS 튐
+
     @Override
     public GpsSessionStartResponse startSession(Long userId, SessionStartRequest request) {
         log.info("GPS 세션 시작 요청: userId={}", userId);
 
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> {
-                log.warn("사용자를 찾을 수 없음: userId={}", userId);
-                return new BusinessException(ErrorCode.USER_NOT_FOUND);
-            });
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: userId={}", userId);
+                    return new BusinessException(ErrorCode.USER_NOT_FOUND);
+                });
 
         GpsSession newSession = GpsSession.builder()
-            .user(user)
-            .startTime(request.getStartTime())
-            .build();
+                .user(user)
+                .startTime(request.getStartTime())
+                .build();
 
         GpsSession savedSession = gpsSessionRepository.save(newSession);
         log.info("GPS 세션 생성 완료: sessionId={}", savedSession.getId());
@@ -61,44 +69,83 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     }
 
     @Override
-    public GpsLogResponse logGps(GpsLogRequest request) {
-        log.debug("GPS 로그 기록 요청: sessionId={}", request.getSessionId());
+    public GpsLogResponse logGps(Long userId, GpsLogRequest request) {
 
         GpsSession session = gpsSessionRepository.findById(request.getSessionId())
-            .orElseThrow(() -> {
-                log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
-                return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
-            });
+                .orElseThrow(() -> {
+                    log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
+                    return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+                });
 
+        GpsLog lastLog = gpsLogRepository.findTopByGpsSessionOrderByRecordedAtDesc(session);
+
+        if (lastLog != null) {
+            // 시간 차이 계산 (초 단위)
+            long timeDeltaSeconds = ChronoUnit.SECONDS.between(lastLog.getRecordedAt(), request.getRecordedAt());
+
+            if (timeDeltaSeconds <= 0) {
+                return gpsMapper.toGpsLogResponse(lastLog);
+            }
+
+            // 거리 계산 - 미터 단위
+            BigDecimal distance = GeometryUtil.calculateDistance(
+                    lastLog.getLatitude(), lastLog.getLongitude(),
+                    request.getLatitude(), request.getLongitude()
+            );
+            double distanceMeters = distance.doubleValue();
+
+            // 필터링: 2m 미만 이동은 무시
+            if (distanceMeters < MIN_DISTANCE_METER) {
+                return gpsMapper.toGpsLogResponse(lastLog);
+            }
+
+            // 속도 계산 (km/h)
+            double speedKmh = (distanceMeters / timeDeltaSeconds) * 3.6;
+
+            // 필터링: 45km/h 이상 무시
+            if (speedKmh > MAX_HUMAN_SPEED_KMH) {
+                if (speedKmh > MAX_NOISE_SPEED_KMH) {
+                    log.warn("GPS Noise Detected: speed={}km/h, dist={}m", speedKmh, distanceMeters);
+                } else {
+                    log.warn("Vehicle Detected: speed={}km/h. Ignore log.", speedKmh);
+                }
+                // 이상 데이터는 저장하지 않고 이전 로그 상태 반환
+                return gpsMapper.toGpsLogResponse(lastLog);
+            }
+
+            // 정상 데이터 처리
+            session.addDistance(distance);
+        }
+
+        // 로그 저장
         GpsLog newLog = gpsMapper.toGpsLogEntity(request, session);
         GpsLog savedLog = gpsLogRepository.save(newLog);
-        log.debug("GPS 로그 저장 완료: logId={}", savedLog.getId());
 
         return gpsMapper.toGpsLogResponse(savedLog);
     }
 
     @Override
-    public SessionEndResponse endSession(SessionEndRequest request) {
+    public SessionEndResponse endSession(Long userId, SessionEndRequest request) {
         log.info("GPS 세션 종료 요청: sessionId={}", request.getSessionId());
 
         GpsSession session = gpsSessionRepository.findById(request.getSessionId())
-            .orElseThrow(() -> {
-                log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
-                return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
-            });
+                .orElseThrow(() -> {
+                    log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
+                    return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+                });
 
         gpsMapper.updateSessionFromEndRequest(request, session);
         session.setEndTime(request.getEndTime());
-        log.info("GPS 세션 종료 완료: sessionId={}", session.getId());
+
+        log.info("GPS 세션 종료 완료: sessionId={}, totalDistance={}",
+                session.getId(), session.getTotalDistance());
 
         return gpsMapper.toSessionEndResponse(session);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<GpsSessionSummaryResponse> getMonthlySessions(
-        Long userId, int year, int month
-    ) {
+    public List<GpsSessionSummaryResponse> getMonthlySessions(Long userId, int year, int month) {
         LocalDate startDate;
         try {
             startDate = LocalDate.of(year, month, 1);
@@ -111,53 +158,46 @@ public class GpsSessionServiceImpl implements GpsSessionService {
         LocalDateTime end = startDate.plusMonths(1).atStartOfDay();
 
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> {
-                log.warn("사용자를 찾을 수 없음: userId={}", userId);
-                return new BusinessException(ErrorCode.USER_NOT_FOUND);
-            });
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         List<GpsSession> sessions = gpsSessionRepository.findMonthlySessions(user, start, end);
 
         return sessions.stream()
-            .map(session -> GpsSessionSummaryResponse.of(
-                session.getId(),
-                session.getStartTime(),
-                session.getEndTime(),
-                session.getTotalDistance()
-            ))
-            .collect(Collectors.toList());
+                .map(session -> GpsSessionSummaryResponse.of(
+                        session.getId(),
+                        session.getStartTime(),
+                        session.getEndTime(),
+                        session.getTotalDistance()
+                ))
+                .collect(Collectors.toList());
     }
 
     @Override
     @Transactional(readOnly = true)
     public GpsSessionDetailResponse getSessionDetail(Long userId, Long sessionId) {
         GpsSession session = gpsSessionRepository.findById(sessionId)
-            .orElseThrow(() -> {
-                log.warn("세션을 찾을 수 없음: sessionId={}", sessionId);
-                return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
-            });
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
 
         if (!session.getUser().getId().equals(userId)) {
-            log.warn("세션 조회 권한 없음: requestUserId={}, ownerId={}, sessionId={}",
-                userId, session.getUser().getId(), sessionId);
+            log.warn("세션 조회 권한 없음: userId={}, ownerId={}", userId, session.getUser().getId());
             throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
         }
 
         List<GpsRouteLogResponse> routeLogs = gpsLogRepository
-            .findByGpsSessionOrderByRecordedAtAsc(session)
-            .stream()
-            .map(log -> GpsRouteLogResponse.of(log.getLatitude(), log.getLongitude(), log.getAltitude()))
-            .collect(Collectors.toList());
+                .findByGpsSessionOrderByRecordedAtAsc(session)
+                .stream()
+                .map(log -> GpsRouteLogResponse.of(log.getLatitude(), log.getLongitude(), log.getAltitude()))
+                .collect(Collectors.toList());
 
         return GpsSessionDetailResponse.of(
-            session.getId(),
-            session.getStartTime(),
-            session.getEndTime(),
-            session.getTotalDistance(),
-            session.getAvgSpeed(),
-            session.getStepCount(),
-            session.getBurnCalories(),
-            routeLogs
+                session.getId(),
+                session.getStartTime(),
+                session.getEndTime(),
+                session.getTotalDistance(),
+                session.getAvgSpeed(),
+                session.getStepCount(),
+                session.getBurnCalories(),
+                routeLogs
         );
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsLog.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsLog.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,7 +23,7 @@ import org.hibernate.annotations.CreationTimestamp;
 @Table(name = "gps_log")
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GpsLog {
 
     @Id
@@ -38,16 +39,16 @@ public class GpsLog {
     @JoinColumn(name = "session_id", nullable = false)
     private GpsSession gpsSession;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(name = "latitude", nullable = false, precision = 10, scale = 6)
     private BigDecimal latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(name = "longitude", nullable = false, precision = 10, scale = 6)
     private BigDecimal longitude;
 
-    @Column(name = "speed")
+    @Column(name = "speed", precision = 5, scale = 2)
     private BigDecimal speed;
 
-    @Column(name = "altitude")
+    @Column(name = "altitude", precision = 7, scale = 2)
     private BigDecimal altitude;
 
     @Column(name = "recorded_at", nullable = false)
@@ -56,4 +57,16 @@ public class GpsLog {
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public GpsLog(User user, GpsSession gpsSession, BigDecimal latitude, BigDecimal longitude, BigDecimal speed,
+                  BigDecimal altitude, LocalDateTime recordedAt) {
+        this.user = user;
+        this.gpsSession = gpsSession;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.speed = speed;
+        this.altitude = altitude;
+        this.recordedAt = recordedAt;
+    }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsLog.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsLog.java
@@ -13,17 +13,21 @@ import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
+
 @Entity
 @Table(name = "gps_log")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class GpsLog {
 
     @Id
@@ -58,7 +62,6 @@ public class GpsLog {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
-    @Builder
     public GpsLog(User user, GpsSession gpsSession, BigDecimal latitude, BigDecimal longitude, BigDecimal speed,
                   BigDecimal altitude, LocalDateTime recordedAt) {
         this.user = user;

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
@@ -68,6 +68,13 @@ public class GpsSession {
     @OneToMany(mappedBy = "gpsSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GpsLog> gpsLogs = new ArrayList<>();
 
+    public boolean isOwnedBy(Long userId) {
+        if (this.user == null || userId == null) {
+            return false;
+        }
+        return this.user.getId().equals(userId);
+    }
+
     public void addDistance(BigDecimal distance) {
         if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
             return;

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
@@ -48,10 +48,10 @@ public class GpsSession {
     @Column(name = "end_time")
     private LocalDateTime endTime;
 
-    @Column(name = "total_distance")
+    @Column(name = "total_distance", precision = 10, scale = 2)
     private BigDecimal totalDistance;
 
-    @Column(name = "avg_speed")
+    @Column(name = "avg_speed", precision = 5, scale = 2)
     private BigDecimal avgSpeed;
 
     @Column(name = "step_count")
@@ -67,4 +67,14 @@ public class GpsSession {
     @Builder.Default
     @OneToMany(mappedBy = "gpsSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GpsLog> gpsLogs = new ArrayList<>();
+
+    public void addDistance(BigDecimal distance) {
+        if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
+            return;
+        }
+        if (this.totalDistance == null) {
+            this.totalDistance = BigDecimal.ZERO;
+        }
+        this.totalDistance = this.totalDistance.add(distance);
+    }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
@@ -67,8 +67,7 @@ public class GpsSession {
     @Builder.Default
     @OneToMany(mappedBy = "gpsSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GpsLog> gpsLogs = new ArrayList<>();
-
-    // [상수] METs 데이터
+    
     private static final double METS_WALKING = 3.8;
     private static final double METS_JOGGING = 7.0;
     private static final double METS_RUNNING = 10.0;
@@ -93,7 +92,7 @@ public class GpsSession {
         this.totalDistance = this.totalDistance.add(distance);
     }
 
-    //세션 종료 및 통계 자동 계산
+    // 세션 종료 및 통계 자동 계산
     public void endSession(LocalDateTime endTime, Integer requestStepCount, Integer requestCalories) {
         this.endTime = endTime;
         this.stepCount = (requestStepCount != null) ? requestStepCount : 0;
@@ -112,12 +111,12 @@ public class GpsSession {
         }
         this.avgSpeed = BigDecimal.valueOf(avgSpeedVal).setScale(2, RoundingMode.HALF_UP);
 
-        // 칼로리 계산
         if (requestCalories != null && requestCalories > 0) {
             this.burnCalories = requestCalories;
         } else {
             Double userWeight = DEFAULT_WEIGHT;
-            if (this.user != null) {
+
+            if (this.user != null && this.user.getWeightKg() != null) {
                 userWeight = this.user.getWeightKg();
             }
 

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
@@ -13,7 +13,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -21,15 +23,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "gps_session")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 public class GpsSession {
 
@@ -68,6 +68,13 @@ public class GpsSession {
     @OneToMany(mappedBy = "gpsSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GpsLog> gpsLogs = new ArrayList<>();
 
+    // [상수] METs 데이터
+    private static final double METS_WALKING = 3.8;
+    private static final double METS_JOGGING = 7.0;
+    private static final double METS_RUNNING = 10.0;
+    private static final double DEFAULT_WEIGHT = 70.0;
+
+    // 소유권 확인 로직
     public boolean isOwnedBy(Long userId) {
         if (this.user == null || userId == null) {
             return false;
@@ -75,6 +82,7 @@ public class GpsSession {
         return this.user.getId().equals(userId);
     }
 
+    // 거리 누적 로직
     public void addDistance(BigDecimal distance) {
         if (distance == null || distance.compareTo(BigDecimal.ZERO) <= 0) {
             return;
@@ -83,5 +91,46 @@ public class GpsSession {
             this.totalDistance = BigDecimal.ZERO;
         }
         this.totalDistance = this.totalDistance.add(distance);
+    }
+
+    //세션 종료 및 통계 자동 계산
+    public void endSession(LocalDateTime endTime, Integer requestStepCount, Integer requestCalories) {
+        this.endTime = endTime;
+        this.stepCount = (requestStepCount != null) ? requestStepCount : 0;
+
+        long durationSeconds = ChronoUnit.SECONDS.between(this.startTime, this.endTime);
+        if (durationSeconds < 1) {
+            durationSeconds = 1;
+        }
+
+        double durationHours = durationSeconds / 3600.0;
+        double totalKm = (this.totalDistance != null ? this.totalDistance.doubleValue() : 0.0) / 1000.0;
+
+        double avgSpeedVal = 0.0;
+        if (durationHours > 0) {
+            avgSpeedVal = totalKm / durationHours;
+        }
+        this.avgSpeed = BigDecimal.valueOf(avgSpeedVal).setScale(2, RoundingMode.HALF_UP);
+
+        // 칼로리 계산
+        if (requestCalories != null && requestCalories > 0) {
+            this.burnCalories = requestCalories;
+        } else {
+            Double userWeight = DEFAULT_WEIGHT;
+            if (this.user != null) {
+                userWeight = this.user.getWeightKg();
+            }
+
+            double mets;
+            if (avgSpeedVal < 6.0) {
+                mets = METS_WALKING;
+            } else if (avgSpeedVal < 8.0) {
+                mets = METS_JOGGING;
+            } else {
+                mets = METS_RUNNING;
+            }
+
+            this.burnCalories = (int) (mets * userWeight * durationHours);
+        }
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsLogRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsLogRepository.java
@@ -8,4 +8,6 @@ public interface GpsLogRepository {
     GpsLog save(GpsLog gpsLog);
 
     List<GpsLog> findByGpsSessionOrderByRecordedAtAsc(GpsSession gpsSession);
+
+    GpsLog findTopByGpsSessionOrderByRecordedAtDesc(GpsSession gpsSession);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -13,6 +13,7 @@ import com.fitpet.server.shared.annotation.AuthUser;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,41 +34,57 @@ public class GpsController {
 
     private final GpsSessionService gpsSessionService;
 
+    // [변경 1] 201 Created 반환
     @PostMapping("/start")
     public ResponseEntity<GpsSessionStartResponse> startSession(
-        @AuthUser Long userId,
-        @Valid @RequestBody SessionStartRequest request
+            @AuthUser Long userId,
+            @Valid @RequestBody SessionStartRequest request
     ) {
         GpsSessionStartResponse response = gpsSessionService.startSession(userId, request);
-        return ResponseEntity.ok(response);
+
+        // 생성된 리소스의 위치를 헤더에 알려주는 것이 정석 (Location Header)
+        return ResponseEntity
+                .created(URI.create("/gps/sessions/" + response.getSessionId()))
+                .body(response);
     }
 
+    // [변경 2] @AuthUser 추가 (보안 강화) 및 201 반환
     @PostMapping("/log")
-    public ResponseEntity<GpsLogResponse> logGps(@Valid @RequestBody GpsLogRequest request) {
-        GpsLogResponse response = gpsSessionService.logGps(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<GpsLogResponse> logGps(
+            @AuthUser Long userId, // 내 세션에만 로그를 남길 수 있어야 함
+            @Valid @RequestBody GpsLogRequest request
+    ) {
+        // Service 메서드 시그니처도 userId를 받도록 수정 필요
+        GpsLogResponse response = gpsSessionService.logGps(userId, request);
+        return ResponseEntity.created(URI.create("")).body(response);
     }
 
+    // [변경 3] @AuthUser 추가 (보안 강화)
     @PostMapping("/end")
-    public ResponseEntity<SessionEndResponse> endSession(@Valid @RequestBody SessionEndRequest request) {
-        SessionEndResponse response = gpsSessionService.endSession(request);
+    public ResponseEntity<SessionEndResponse> endSession(
+            @AuthUser Long userId, // 내 세션만 종료할 수 있어야 함
+            @Valid @RequestBody SessionEndRequest request
+    ) {
+        // Service 메서드 시그니처도 userId를 받도록 수정 필요
+        SessionEndResponse response = gpsSessionService.endSession(userId, request);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/sessions")
     public ResponseEntity<List<GpsSessionSummaryResponse>> getMonthlySessions(
-        @AuthUser Long userId,
-        @RequestParam @Min(2025) @Max(2100) int year,
-        @RequestParam @Min(1) @Max(12) int month
+            @AuthUser Long userId,
+            @RequestParam @Min(2025) @Max(2100) int year,
+            @RequestParam @Min(1) @Max(12) int month
     ) {
         List<GpsSessionSummaryResponse> sessions = gpsSessionService.getMonthlySessions(userId, year, month);
+        // Tip: 실무에서는 List를 바로 리턴하기보다 Result<T> 같은 래퍼 클래스를 사용하는 것을 권장
         return ResponseEntity.ok(sessions);
     }
 
     @GetMapping("/sessions/{sessionId}")
     public ResponseEntity<GpsSessionDetailResponse> getSessionDetail(
-        @AuthUser Long userId,
-        @PathVariable Long sessionId
+            @AuthUser Long userId,
+            @PathVariable Long sessionId
     ) {
         GpsSessionDetailResponse response = gpsSessionService.getSessionDetail(userId, sessionId);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -34,7 +34,6 @@ public class GpsController {
 
     private final GpsSessionService gpsSessionService;
 
-    // [변경 1] 201 Created 반환
     @PostMapping("/start")
     public ResponseEntity<GpsSessionStartResponse> startSession(
             @AuthUser Long userId,
@@ -42,30 +41,25 @@ public class GpsController {
     ) {
         GpsSessionStartResponse response = gpsSessionService.startSession(userId, request);
 
-        // 생성된 리소스의 위치를 헤더에 알려주는 것이 정석 (Location Header)
         return ResponseEntity
                 .created(URI.create("/gps/sessions/" + response.getSessionId()))
                 .body(response);
     }
 
-    // [변경 2] @AuthUser 추가 (보안 강화) 및 201 반환
     @PostMapping("/log")
     public ResponseEntity<GpsLogResponse> logGps(
-            @AuthUser Long userId, // 내 세션에만 로그를 남길 수 있어야 함
+            @AuthUser Long userId,
             @Valid @RequestBody GpsLogRequest request
     ) {
-        // Service 메서드 시그니처도 userId를 받도록 수정 필요
         GpsLogResponse response = gpsSessionService.logGps(userId, request);
         return ResponseEntity.created(URI.create("")).body(response);
     }
 
-    // [변경 3] @AuthUser 추가 (보안 강화)
     @PostMapping("/end")
     public ResponseEntity<SessionEndResponse> endSession(
-            @AuthUser Long userId, // 내 세션만 종료할 수 있어야 함
+            @AuthUser Long userId,
             @Valid @RequestBody SessionEndRequest request
     ) {
-        // Service 메서드 시그니처도 userId를 받도록 수정 필요
         SessionEndResponse response = gpsSessionService.endSession(userId, request);
         return ResponseEntity.ok(response);
     }
@@ -77,7 +71,6 @@ public class GpsController {
             @RequestParam @Min(1) @Max(12) int month
     ) {
         List<GpsSessionSummaryResponse> sessions = gpsSessionService.getMonthlySessions(userId, year, month);
-        // Tip: 실무에서는 List를 바로 리턴하기보다 Result<T> 같은 래퍼 클래스를 사용하는 것을 권장
         return ResponseEntity.ok(sessions);
     }
 

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -52,7 +52,8 @@ public class GpsController {
             @Valid @RequestBody GpsLogRequest request
     ) {
         GpsLogResponse response = gpsSessionService.logGps(userId, request);
-        return ResponseEntity.created(URI.create("")).body(response);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/end")

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionEndRequest.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionEndRequest.java
@@ -18,7 +18,11 @@ public class SessionEndRequest {
 
     @NotNull
     private Integer stepCount;
-    
+
     @NotNull
     private BigDecimal distance;
+
+    private Integer totalDistance;
+
+    private Integer burnCalories;
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionEndRequest.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionEndRequest.java
@@ -1,7 +1,6 @@
 package com.fitpet.server.dailyworkout.presentation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,10 +18,10 @@ public class SessionEndRequest {
     @NotNull
     private Integer stepCount;
 
-    @NotNull
-    private BigDecimal distance;
+    // @NotNull
+    // private BigDecimal distance;
 
-    private Integer totalDistance;
+    // private Integer totalDistance;
 
     private Integer burnCalories;
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionStartRequest.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionStartRequest.java
@@ -8,8 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SessionStartRequest {
-    @NotNull
-    private Long userId;
+
     @NotNull
     private LocalDateTime startTime;
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/response/GpsLogResponse.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/response/GpsLogResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Builder
 public class GpsLogResponse {
+    private Long sessionId;
     private Long logId;
     private BigDecimal latitude;
     private BigDecimal longitude;

--- a/src/main/java/com/fitpet/server/ranking/application/dto/RankingDto.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/RankingDto.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.ranking.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RankingDto {
+    private int rank;
+    private Long userId;
+    private double score;
+}

--- a/src/main/java/com/fitpet/server/ranking/application/dto/RankingDto.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/RankingDto.java
@@ -1,14 +1,22 @@
 package com.fitpet.server.ranking.application.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
 public class RankingDto {
-    private int rank;
     private Long userId;
-    private Long score;
+    private String nickname;
+    private int rank;
+    private long score;
+
+    public static RankingDto of(Long userId, String nickname, int rank, long score) {
+        return RankingDto.builder()
+                .userId(userId)
+                .nickname(nickname)
+                .rank(rank)
+                .score(score)
+                .build();
+    }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/dto/RankingSummaryDto.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/RankingSummaryDto.java
@@ -1,0 +1,19 @@
+package com.fitpet.server.ranking.application.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankingSummaryDto {
+    private List<RankingDto> topRankings;
+    private RankingDto myRanking;
+
+    public static RankingSummaryDto of(List<RankingDto> topRankings, RankingDto myRanking) {
+        return RankingSummaryDto.builder()
+                .topRankings(topRankings)
+                .myRanking(myRanking)
+                .build();
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/dto/RankingSyncContext.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/RankingSyncContext.java
@@ -1,0 +1,17 @@
+package com.fitpet.server.ranking.application.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RankingSyncContext {
+    private final String dateKey;
+    private final String redisKey;
+    private final String dirtyKey;
+
+    public static RankingSyncContext of(String dateKey, String redisKey, String dirtyKey) {
+        return new RankingSyncContext(dateKey, redisKey, dirtyKey);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/event/UserCacheRefreshEvent.java
+++ b/src/main/java/com/fitpet/server/ranking/application/event/UserCacheRefreshEvent.java
@@ -1,0 +1,11 @@
+package com.fitpet.server.ranking.application.event;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserCacheRefreshEvent {
+    private final List<Long> userIds; // 캐시가 비어있는 유저 ID 목록
+}

--- a/src/main/java/com/fitpet/server/ranking/application/facade/RankingFacade.java
+++ b/src/main/java/com/fitpet/server/ranking/application/facade/RankingFacade.java
@@ -1,0 +1,33 @@
+package com.fitpet.server.ranking.application.facade;
+
+import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.application.service.RankingService;
+import com.fitpet.server.ranking.presentation.dto.RankingResponse;
+import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RankingFacade {
+
+    private final RankingService rankingService;
+
+    public RankingSummaryResponse getRankingSummary(Long userId) {
+        List<RankingDto> top10Dtos = rankingService.getTop10();
+        RankingDto myRankDto = rankingService.getMyRank(userId);
+
+        List<RankingResponse> top10Responses = top10Dtos.stream()
+                .map(RankingResponse::from)
+                .toList();
+
+        RankingResponse myRankResponse = RankingResponse.from(myRankDto);
+
+        return RankingSummaryResponse.of(top10Responses, myRankResponse);
+    }
+
+    public void updateScore(Long userId, int steps) {
+        rankingService.updateScore(userId, steps);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/facade/RankingFacade.java
+++ b/src/main/java/com/fitpet/server/ranking/application/facade/RankingFacade.java
@@ -1,9 +1,8 @@
 package com.fitpet.server.ranking.application.facade;
 
 import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.application.dto.RankingSummaryDto;
 import com.fitpet.server.ranking.application.service.RankingService;
-import com.fitpet.server.ranking.presentation.dto.RankingResponse;
-import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,17 +13,11 @@ public class RankingFacade {
 
     private final RankingService rankingService;
 
-    public RankingSummaryResponse getRankingSummary(Long userId) {
+    public RankingSummaryDto getRankingSummary(Long userId) {
         List<RankingDto> top10Dtos = rankingService.getTop10();
         RankingDto myRankDto = rankingService.getMyRank(userId);
-
-        List<RankingResponse> top10Responses = top10Dtos.stream()
-                .map(RankingResponse::from)
-                .toList();
-
-        RankingResponse myRankResponse = RankingResponse.from(myRankDto);
-
-        return RankingSummaryResponse.of(top10Responses, myRankResponse);
+        
+        return RankingSummaryDto.of(top10Dtos, myRankDto);
     }
 
     public void updateScore(Long userId, int steps) {

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 public interface RankingService {
 
-    void updateScore(Long userId, double distance);
+    void updateScore(Long userId, int steps);
 
     List<RankingResponse> getTop10();
-    
+
     RankingResponse getMyRank(Long userId);
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -10,8 +10,4 @@ public interface RankingService {
     List<RankingResponse> getTop10();
 
     RankingResponse getMyRank(Long userId);
-
-    // 모든 Dirty 유저를 한 번에 DB로 동기화
-    void syncRedisToDatabase();
-
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -1,13 +1,13 @@
 package com.fitpet.server.ranking.application.service;
 
-import com.fitpet.server.ranking.presentation.dto.RankingResponse;
+import com.fitpet.server.ranking.application.dto.RankingDto;
 import java.util.List;
 
 public interface RankingService {
 
     void updateScore(Long userId, int steps);
 
-    List<RankingResponse> getTop10();
+    List<RankingDto> getTop10();
 
-    RankingResponse getMyRank(Long userId);
+    RankingDto getMyRank(Long userId);
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -1,0 +1,13 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.dto.RankingDto;
+import java.util.List;
+
+public interface RankingService {
+
+    void updateScore(Long userId, double distance);
+
+    List<RankingDto> getTop10();
+
+    RankingDto getMyRank(Long userId);
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -12,6 +12,6 @@ public interface RankingService {
     RankingResponse getMyRank(Long userId);
 
     // 모든 Dirty 유저를 한 번에 DB로 동기화
-    void syncAllDirtyRanksToDb();
+    void syncRedisToDatabase();
 
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -13,4 +13,5 @@ public interface RankingService {
 
     // 모든 Dirty 유저를 한 번에 DB로 동기화
     void syncAllDirtyRanksToDb();
+
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -10,4 +10,7 @@ public interface RankingService {
     List<RankingResponse> getTop10();
 
     RankingResponse getMyRank(Long userId);
+
+    // 모든 Dirty 유저를 한 번에 DB로 동기화
+    void syncAllDirtyRanksToDb();
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -1,13 +1,13 @@
 package com.fitpet.server.ranking.application.service;
 
-import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.presentation.dto.RankingResponse;
 import java.util.List;
 
 public interface RankingService {
 
     void updateScore(Long userId, double distance);
 
-    List<RankingDto> getTop10();
-
-    RankingDto getMyRank(Long userId);
+    List<RankingResponse> getTop10();
+    
+    RankingResponse getMyRank(Long userId);
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,9 +1,9 @@
 package com.fitpet.server.ranking.application.service;
 
+import com.fitpet.server.ranking.application.dto.RankingDto;
 import com.fitpet.server.ranking.application.event.UserCacheRefreshEvent;
 import com.fitpet.server.ranking.domain.entity.Ranking;
 import com.fitpet.server.ranking.domain.repository.RankingRepository;
-import com.fitpet.server.ranking.presentation.dto.RankingResponse;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.time.LocalDate;
@@ -67,13 +67,13 @@ public class RankingServiceImpl implements RankingService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<RankingResponse> getTop10() {
+    public List<RankingDto> getTop10() {
         return fetchTopRankings(LocalDate.now());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public RankingResponse getMyRank(Long userId) {
+    public RankingDto getMyRank(Long userId) {
         LocalDate now = LocalDate.now();
         String redisKey = getRankingKey(now);
         String userIdStr = String.valueOf(userId);
@@ -86,7 +86,7 @@ public class RankingServiceImpl implements RankingService {
 
         Map<Long, String> nicknameMap = getNicknameMap(Collections.singletonList(userId));
 
-        return RankingResponse.of(userId, nicknameMap.get(userId), finalRank, finalScore);
+        return RankingDto.of(userId, nicknameMap.get(userId), finalRank, finalScore);
     }
 
     private Map<Long, String> getNicknameMap(List<Long> userIds) {
@@ -120,7 +120,7 @@ public class RankingServiceImpl implements RankingService {
         return profileMap;
     }
 
-    private List<RankingResponse> fetchTopRankings(LocalDate now) {
+    private List<RankingDto> fetchTopRankings(LocalDate now) {
         String redisKey = getRankingKey(now);
         Set<ZSetOperations.TypedTuple<String>> tuples =
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
@@ -137,7 +137,7 @@ public class RankingServiceImpl implements RankingService {
         return convertToResponseList(tuples, nicknameMap);
     }
 
-    private List<RankingResponse> recoverRedisFromDatabase(LocalDate now) {
+    private List<RankingDto> recoverRedisFromDatabase(LocalDate now) {
         String dateKey = now.toString();
         log.warn("[RankingService] 캐시 미스 - DB 데이터 복구 시도: {}", dateKey);
 
@@ -166,10 +166,10 @@ public class RankingServiceImpl implements RankingService {
         List<Long> userIds = topRankings.stream().map(r -> r.getUser().getId()).toList();
         Map<Long, String> nicknameMap = getNicknameMap(userIds);
 
-        List<RankingResponse> responses = new ArrayList<>();
+        List<RankingDto> responses = new ArrayList<>();
         int rank = 1;
         for (Ranking r : topRankings) {
-            responses.add(RankingResponse.of(
+            responses.add(RankingDto.of(
                     r.getUser().getId(),
                     nicknameMap.get(r.getUser().getId()),
                     rank++,
@@ -179,13 +179,13 @@ public class RankingServiceImpl implements RankingService {
         return responses;
     }
 
-    private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples,
-                                                        Map<Long, String> nicknameMap) {
-        List<RankingResponse> result = new ArrayList<>();
+    private List<RankingDto> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples,
+                                                   Map<Long, String> nicknameMap) {
+        List<RankingDto> result = new ArrayList<>();
         int rank = 1;
         for (ZSetOperations.TypedTuple<String> tuple : tuples) {
             Long userId = Long.parseLong(Objects.requireNonNull(tuple.getValue()));
-            result.add(RankingResponse.of(userId, nicknameMap.get(userId), rank++,
+            result.add(RankingDto.of(userId, nicknameMap.get(userId), rank++,
                     (long) Math.floor(Objects.requireNonNull(tuple.getScore()))));
         }
         return result;

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -6,6 +6,7 @@ import com.fitpet.server.ranking.presentation.dto.RankingResponse;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -25,7 +26,6 @@ public class RankingServiceImpl implements RankingService {
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
 
-    // 시간 가중치 계산용 상수
     private static final long MAX_TIMESTAMP = 9_999_999_999L;
     private static final double TIME_WEIGHT_DIVIDER = 100_000_000_000.0;
 
@@ -36,15 +36,15 @@ public class RankingServiceImpl implements RankingService {
         String dateKey = getCurrentDateKey();
         String redisKey = getCurrentRankingKey();
 
-        // DB 업데이트
         Ranking ranking = getOrCreateRanking(user, dateKey);
         double finalRealScore = updateDbRanking(ranking, steps);
 
-        // Redis 가중치 점수 계산 및 반영
-        double redisScore = calculateTimeWeightedScore(finalRealScore);
+        long currentTimestamp = System.currentTimeMillis() / 1000;
+        double redisScore = calculateTimeWeightedScore(finalRealScore, currentTimestamp);
+
         redisTemplate.opsForZSet().add(redisKey, String.valueOf(userId), redisScore);
 
-        log.info("Rank Update - User: {}, RealScore: {}, RedisScore: {}", userId, finalRealScore, redisScore);
+        log.info("Rank Update - User: {}, Score: {}", userId, finalRealScore);
     }
 
     @Override
@@ -52,14 +52,101 @@ public class RankingServiceImpl implements RankingService {
     public List<RankingResponse> getTop10() {
         String redisKey = getCurrentRankingKey();
 
-        // 내림차순 10개
         Set<ZSetOperations.TypedTuple<String>> tuples =
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, 9);
 
         if (tuples == null || tuples.isEmpty()) {
-            return refreshRankingFromDb(); // 복구 로직
+            return refreshRankingFromDb();
         }
 
+        List<RankingResponse> result = convertToResponseList(tuples);
+
+        return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RankingResponse getMyRank(Long userId) {
+        String redisKey = getCurrentRankingKey();
+        String userIdStr = String.valueOf(userId);
+
+        Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
+        Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
+
+        if (rankIndex == null || redisScore == null) {
+            Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
+            int myDefaultRank = (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
+
+            return RankingResponse.builder()
+                    .rank(myDefaultRank)
+                    .userId(userId)
+                    .score(0L)
+                    .build();
+        }
+
+        long realScore = (long) Math.floor(redisScore);
+
+        return RankingResponse.builder()
+                .rank(rankIndex.intValue() + 1)
+                .userId(userId)
+                .score(realScore)
+                .build();
+    }
+
+    private List<RankingResponse> refreshRankingFromDb() {
+        log.warn("Redis 유실 감지: DB의 원본 시각(updatedAt)을 기준으로 랭킹을 복구합니다.");
+
+        List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());
+        String redisKey = getCurrentRankingKey();
+
+        for (Ranking r : rankings) {
+            // ranking table의 updated_at을 이용해 순위 재측정
+            long originalTimestamp = (r.getUpdatedAt() != null)
+                    ? r.getUpdatedAt().atZone(ZoneId.systemDefault()).toEpochSecond()
+                    : System.currentTimeMillis() / 1000; // null일 경우 현재시간 사용
+
+            double redisScore = calculateTimeWeightedScore(r.getScore(), originalTimestamp);
+            redisTemplate.opsForZSet().add(redisKey, String.valueOf(r.getUser().getId()), redisScore);
+        }
+
+        return getTop10();
+    }
+
+    private double calculateTimeWeightedScore(double realScore, long timestamp) {
+        double timeWeight = (double) (MAX_TIMESTAMP - timestamp) / TIME_WEIGHT_DIVIDER;
+        return realScore + timeWeight;
+    }
+
+    private Ranking getOrCreateRanking(User user, String dateKey) {
+        return rankingRepository.findByUserAndDateKey(user, dateKey)
+                .orElseGet(() -> Ranking.builder()
+                        .user(user)
+                        .score(0)
+                        .dateKey(dateKey)
+                        .build());
+    }
+
+    private double updateDbRanking(Ranking ranking, int steps) {
+        double newTotalScore = ranking.getScore() + steps;
+        ranking.updateScore(newTotalScore);
+        rankingRepository.save(ranking);
+        return newTotalScore;
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+
+    private String getCurrentRankingKey() {
+        return "ranking:daily:" + LocalDate.now().toString();
+    }
+
+    private String getCurrentDateKey() {
+        return LocalDate.now().toString();
+    }
+
+    private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples) {
         List<RankingResponse> result = new ArrayList<>();
         int rank = 1;
 
@@ -77,101 +164,7 @@ public class RankingServiceImpl implements RankingService {
                         .build());
             }
         }
-        return result;
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public RankingResponse getMyRank(Long userId) {
-        String redisKey = getCurrentRankingKey();
-        String userIdStr = String.valueOf(userId);
-
-        Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
-        Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
-
-        // 오늘 기록이 없는 사용자 처리
-        if (rankIndex == null || redisScore == null) {
-            // 현재 Redis 랭킹(ZSet)에 등록된 총 인원수를 가져옴
-            Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
-
-            // 내 등수 = (현재 참여 인원수) + 1
-            int myDefaultRank = (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
-
-            return RankingResponse.builder()
-                    .rank(myDefaultRank)
-                    .userId(userId)
-                    .score(0L) // 기록이 없으므로 0점 (long 타입) 반환
-                    .build();
-        }
-
-        // 3. 기록이 있는 경우: 점수 복원 및 정수(long) 형변환
-        long realScore = (long) Math.floor(redisScore);
-
-        return RankingResponse.builder()
-                .rank(rankIndex.intValue() + 1) // 0-based index를 1-based 순위로 변환
-                .userId(userId)
-                .score(realScore) // 소수점이 제거된 정수값 반환
-                .build();
-    }
-
-    private String getCurrentRankingKey() {
-        return "ranking:daily:" + LocalDate.now().toString();
-    }
-
-    private String getCurrentDateKey() {
-        return LocalDate.now().toString();
-    }
-
-    private Ranking getOrCreateRanking(User user, String dateKey) {
-        // 오늘 날짜의 랭킹 정보를 조회한다.
-        Ranking result = rankingRepository.findByUserAndDateKey(user, dateKey)
-                .orElseGet(() -> Ranking.builder()
-                        .user(user)
-                        .score(0)
-                        .dateKey(dateKey)
-                        .build());
 
         return result;
-    }
-
-    private double updateRedisRanking(Ranking ranking, int steps) {
-        double realScore = ranking.getScore() + steps;
-        ranking.updateScore(realScore);
-        rankingRepository.save(ranking);
-
-        return realScore;
-    }
-
-    private User getUser(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
-
-        return user;
-    }
-
-    private double calculateTimeWeightedScore(double realScore) {
-        long currentTimestamp = System.currentTimeMillis() / 1000;
-        double timeWeight = (MAX_TIMESTAMP - currentTimestamp) / TIME_WEIGHT_DIVIDER;
-        return realScore + timeWeight;
-    }
-
-    private double updateDbRanking(Ranking ranking, int steps) {
-        double newTotalScore = ranking.getScore() + steps;
-        ranking.updateScore(newTotalScore);
-        rankingRepository.save(ranking);
-        return newTotalScore;
-    }
-
-    // Db에서 랭킹 가져와 Redis에 올리기
-    private List<RankingResponse> refreshRankingFromDb() {
-        log.warn("Recovering Redis from DB...");
-        List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());
-
-        for (Ranking r : rankings) {
-            // 복구 시에는 시간 정보가 소실되어서, 복구 시점 기준으로 순서가 정해질 수 있음
-            // 정확성을 위해 Ranking 엔티티에 'last_updated_at'이 있다면 그걸 활용 가능
-            updateScore(r.getUser().getId(), 0);
-        }
-        return getTop10();
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -47,21 +47,21 @@ public class RankingServiceImpl implements RankingService {
     @Override
     @Transactional
     public void updateScore(Long userId, int steps) {
-        log.debug("[RankingService] 점수 업데이트 요청: userId={}, steps={}", userId, steps);
-
         LocalDate now = LocalDate.now();
-        String redisKey = getRankingKey(now);
+        String rankingKey = getRankingKey(now);
         String dirtyKey = getModifiedUsersKey(now);
-        String ttlInSeconds = "259200"; // 3일
 
-        double redisScore = calculateTimeWeightedScore((double) steps, System.currentTimeMillis() / 1000);
+        double weightedScore = calculateTimeWeightedScore((double) steps, System.currentTimeMillis() / 1000);
+        String ttlInSeconds = "259200";
 
         redisTemplate.execute(updateRankingScript,
-                List.of(redisKey, dirtyKey),
-                String.valueOf(userId), String.valueOf(redisScore), ttlInSeconds
+                List.of(rankingKey, dirtyKey),
+                String.valueOf(userId),
+                String.valueOf(weightedScore),
+                ttlInSeconds
         );
 
-        log.info("[RankingService] 실시간 랭킹 기록 완료: userId={}, steps={}", userId, steps);
+        log.info("[RankingService] 랭킹 업데이트 완료 (Lua): userId={}, score={}", userId, weightedScore);
     }
 
     @Override
@@ -193,7 +193,7 @@ public class RankingServiceImpl implements RankingService {
     private String getRankingKey(LocalDate date) {
         return "ranking:daily:" + date.toString();
     }
-    
+
     private String getModifiedUsersKey(LocalDate date) {
         return "ranking:dirty:" + date.toString();
     }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -33,6 +33,8 @@ public class RankingServiceImpl implements RankingService {
     @Override
     @Transactional
     public void updateScore(Long userId, int steps) {
+        log.debug("[RankingService] 점수 업데이트 요청: userId={}, steps={}", userId, steps);
+
         LocalDate now = LocalDate.now();
         User user = getUser(userId);
         String dateKey = getDateKey(now);
@@ -46,13 +48,19 @@ public class RankingServiceImpl implements RankingService {
 
         redisTemplate.opsForZSet().add(redisKey, String.valueOf(userId), redisScore);
 
-        log.info("Rank Update - User: {}, Score: {}", userId, finalRealScore);
+        log.info("[RankingService] 점수 업데이트 완료: userId={}, dateKey={}, finalScore={}",
+                userId, dateKey, finalRealScore);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<RankingResponse> getTop10() {
-        return getTop10Internal(LocalDate.now());
+        log.debug("[RankingService] 상위 10명 조회 요청");
+
+        List<RankingResponse> result = getTop10Internal(LocalDate.now());
+
+        log.info("[RankingService] 상위 10명 조회 완료: count={}명", result.size());
+        return result;
     }
 
     private List<RankingResponse> getTop10Internal(LocalDate now) {
@@ -71,6 +79,8 @@ public class RankingServiceImpl implements RankingService {
     @Override
     @Transactional(readOnly = true)
     public RankingResponse getMyRank(Long userId) {
+        log.debug("[RankingService] 내 랭킹 조회 요청: userId={}", userId);
+
         LocalDate now = LocalDate.now();
         String redisKey = getRankingKey(now);
         String userIdStr = String.valueOf(userId);
@@ -78,33 +88,41 @@ public class RankingServiceImpl implements RankingService {
         Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
         Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
 
+        int finalRank;
+        long finalScore;
+
         if (rankIndex == null || redisScore == null) {
-            int defaultRank = calculateDefaultRank(redisKey);
-            return buildRankingResponse(userId, defaultRank, 0L);
+            finalRank = calculateDefaultRank(redisKey);
+            finalScore = 0L;
+        } else {
+            finalRank = rankIndex.intValue() + 1;
+            finalScore = (long) Math.floor(redisScore);
         }
 
-        int rank = rankIndex.intValue() + 1;
-        long score = (long) Math.floor(redisScore);
+        log.info("[RankingService] 내 랭킹 조회 완료: userId={}, rank={}, score={}",
+                userId, finalRank, finalScore);
 
-        return buildRankingResponse(userId, rank, score);
+        return buildRankingResponse(userId, finalRank, finalScore);
     }
 
     private List<RankingResponse> refreshRankingFromDb(LocalDate now) {
-        log.warn("Redis 유실 감지: DB의 원본 시각(updatedAt)을 기준으로 랭킹을 복구합니다.");
-
         String dateKey = getDateKey(now);
         String redisKey = getRankingKey(now);
+
+        log.warn("[RankingService] Redis 캐시 미스 - DB 복구 시작: dateKey={}", dateKey);
+
         List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
 
         for (Ranking r : rankings) {
-            // ranking table의 updated_at을 이용해 순위 재측정
             long originalTimestamp = (r.getUpdatedAt() != null)
                     ? r.getUpdatedAt().atZone(ZoneId.systemDefault()).toEpochSecond()
-                    : System.currentTimeMillis() / 1000; // null일 경우 현재시간 사용
+                    : System.currentTimeMillis() / 1000;
 
             double redisScore = calculateTimeWeightedScore(r.getScore(), originalTimestamp);
             redisTemplate.opsForZSet().add(redisKey, String.valueOf(r.getUser().getId()), redisScore);
         }
+
+        log.info("[RankingService] Redis 데이터 복구 완료: 복구된 인원={}명", rankings.size());
 
         return getTop10Internal(now);
     }
@@ -132,7 +150,10 @@ public class RankingServiceImpl implements RankingService {
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> {
+                    log.warn("[RankingService] 사용자 조회 실패: userId={}", userId);
+                    return new IllegalArgumentException("User not found");
+                });
     }
 
     private String getRankingKey(LocalDate date) {
@@ -154,11 +175,7 @@ public class RankingServiceImpl implements RankingService {
             if (userIdStr != null && redisScore != null) {
                 long realScore = (long) Math.floor(redisScore);
 
-                result.add(RankingResponse.builder()
-                        .rank(rank++)
-                        .userId(Long.parseLong(userIdStr))
-                        .score(realScore)
-                        .build());
+                result.add(buildRankingResponse(Long.parseLong(userIdStr), rank++, realScore));
             }
         }
 

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -140,7 +141,7 @@ public class RankingServiceImpl implements RankingService {
         String dateKey = now.toString();
         log.warn("[RankingService] 캐시 미스 - DB 데이터 복구 시도: {}", dateKey);
 
-        List<Ranking> rankings = rankingRepository.findTop20ByDateKeyOrderByScoreDesc(dateKey);
+        List<Ranking> rankings = rankingRepository.findTopRankings(dateKey, PageRequest.of(0, 20));
 
         if (rankings.isEmpty()) {
             log.info("[RankingService] DB에도 데이터가 없어 빈 결과를 반환합니다.");

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -45,13 +45,14 @@ public class RankingServiceImpl implements RankingService {
 
         String dirtyKey = "ranking:dirty:" + now.toString();
         String redisKey = getRankingKey(now);
+        String ttlInSeconds = "259200"; // 3일을 초로 환산
 
         long currentTimestamp = System.currentTimeMillis() / 1000;
         double redisScore = calculateTimeWeightedScore((double) steps, currentTimestamp);
 
         redisTemplate.execute(updateRankingScript,
                 List.of(redisKey, dirtyKey),
-                String.valueOf(userId), String.valueOf(redisScore)
+                String.valueOf(userId), String.valueOf(redisScore), ttlInSeconds
         );
 
         log.info("[RankingService] Redis 업데이트 및 Dirty 플래그 완료: userId={}, finalScore={}", userId, steps);

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.ranking.application.service;
 
+import com.fitpet.server.ranking.application.dto.RankingSyncContext;
 import com.fitpet.server.ranking.domain.entity.Ranking;
 import com.fitpet.server.ranking.domain.repository.RankingRepository;
 import com.fitpet.server.ranking.presentation.dto.RankingResponse;
@@ -8,8 +9,10 @@ import com.fitpet.server.user.domain.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +30,6 @@ public class RankingServiceImpl implements RankingService {
 
     private final RankingRepository rankingRepository;
     private final UserRepository userRepository;
-
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> updateRankingScript;
 
@@ -41,39 +43,29 @@ public class RankingServiceImpl implements RankingService {
         log.debug("[RankingService] 점수 업데이트 요청: userId={}, steps={}", userId, steps);
 
         LocalDate now = LocalDate.now();
-        User user = getUser(userId);
-
-        String dirtyKey = "ranking:dirty:" + now.toString();
         String redisKey = getRankingKey(now);
-        String ttlInSeconds = "259200"; // 3일을 초로 환산
+        String dirtyKey = getModifiedUsersKey(now);
+        String ttlInSeconds = "259200"; // 3일
 
-        long currentTimestamp = System.currentTimeMillis() / 1000;
-        double redisScore = calculateTimeWeightedScore((double) steps, currentTimestamp);
+        double redisScore = calculateTimeWeightedScore((double) steps, System.currentTimeMillis() / 1000);
 
         redisTemplate.execute(updateRankingScript,
                 List.of(redisKey, dirtyKey),
                 String.valueOf(userId), String.valueOf(redisScore), ttlInSeconds
         );
 
-        log.info("[RankingService] Redis 업데이트 및 Dirty 플래그 완료: userId={}, finalScore={}", userId, steps);
+        log.info("[RankingService] 실시간 랭킹 기록 완료: userId={}, steps={}", userId, steps);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<RankingResponse> getTop10() {
-        log.debug("[RankingService] 상위 10명 조회 요청");
-
-        List<RankingResponse> result = getTop10Internal(LocalDate.now());
-
-        log.info("[RankingService] 상위 10명 조회 완료: count={}명", result.size());
-        return result;
+        return fetchTopRankings(LocalDate.now());
     }
 
     @Override
     @Transactional(readOnly = true)
     public RankingResponse getMyRank(Long userId) {
-        log.debug("[RankingService] 내 랭킹 조회 요청: userId={}", userId);
-
         LocalDate now = LocalDate.now();
         String redisKey = getRankingKey(now);
         String userIdStr = String.valueOf(userId);
@@ -81,198 +73,166 @@ public class RankingServiceImpl implements RankingService {
         Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
         Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
 
-        int finalRank;
-        long finalScore;
-
-        if (rankIndex == null || redisScore == null) {
-            finalRank = calculateDefaultRank(redisKey);
-            finalScore = 0L;
-        } else {
-            finalRank = rankIndex.intValue() + 1;
-            finalScore = (long) Math.floor(redisScore);
-        }
-
-        log.info("[RankingService] 내 랭킹 조회 완료: userId={}, rank={}, score={}",
-                userId, finalRank, finalScore);
+        int finalRank = (rankIndex == null) ? calculateDefaultRank(redisKey) : rankIndex.intValue() + 1;
+        long finalScore = (redisScore == null) ? 0L : (long) Math.floor(redisScore);
 
         return buildRankingResponse(userId, finalRank, finalScore);
     }
 
-    // 청크 성공을 위한 @Transactional 제거
     @Override
-    public void syncAllDirtyRanksToDb() {
-        LocalDate now = LocalDate.now();
-        String dateKey = now.toString();
-        String dirtyKey = "ranking:dirty:" + dateKey;
-        String redisKey = getRankingKey(now);
+    public void syncRedisToDatabase() {
+        RankingSyncContext context = createSyncContext(LocalDate.now());
+        List<String> modifiedUserIds = getModifiedUserIds(context.getDirtyKey());
 
-        Set<String> dirtyUserIds = redisTemplate.opsForSet().members(dirtyKey);
-        if (dirtyUserIds == null || dirtyUserIds.isEmpty()) {
+        if (modifiedUserIds.isEmpty()) {
             return;
         }
 
-        List<String> userIdList = new ArrayList<>(dirtyUserIds);
-        int batchSize = 100;
+        log.info("[RankingSync] DB 동기화 시작: 대상={}명", modifiedUserIds.size());
+        transferInChunks(modifiedUserIds, context);
+    }
 
-        log.info("[RankingService] DB 영속화 시작: 대상 유저={}명", userIdList.size());
-
-        for (int i = 0; i < userIdList.size(); i += batchSize) {
-            int end = Math.min(i + batchSize, userIdList.size());
-            List<String> chunkIds = userIdList.subList(i, end);
-
+    // Chunk 단위로 나누어 동기화 작업 분배
+    private void transferInChunks(List<String> userIds, RankingSyncContext context) {
+        int chunkSize = 100;
+        for (int i = 0; i < userIds.size(); i += chunkSize) {
+            List<String> chunk = userIds.subList(i, Math.min(i + chunkSize, userIds.size()));
             try {
-                processBatchSync(chunkIds, redisKey, dirtyKey, dateKey);
+                flushChunkToDatabase(chunk, context);
             } catch (Exception e) {
-                log.error("[RankingService] 배치 처리 중 오류 (Index: {}): {}", i, e.getMessage());
+                log.error("[RankingSync] 덩어리 처리 중 오류 (Index: {}): {}", i, e.getMessage());
             }
         }
     }
 
+    // 실제 DB 저장 및 Redis 상태 정리 (트랜잭션 단위)
     @Transactional
-    public void processBatchSync(List<String> userIds, String redisKey, String dirtyKey, String dateKey) {
-        List<Long> longUserIds = userIds.stream().map(Long::parseLong).toList();
+    public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
+        List<Long> longUserIds = convertToLongIds(userIds);
+        Map<Long, Ranking> existingRankings = loadExistingRankings(longUserIds, context.getDateKey());
 
-        Map<Long, Ranking> existingRankings = rankingRepository.findAllByUserIdInAndDateKey(longUserIds, dateKey)
-                .stream()
-                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
+        List<Ranking> rankingsToSave = userIds.stream()
+                .map(id -> mapToRankingEntity(id, context, existingRankings))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
 
-        List<Ranking> toSave = new ArrayList<>();
-
-        for (Long userId : longUserIds) {
-            Double redisScore = redisTemplate.opsForZSet().score(redisKey, String.valueOf(userId));
-
-            if (redisScore != null) {
-                int totalSteps = (int) Math.floor(redisScore);
-                Ranking ranking = existingRankings.get(userId);
-
-                if (ranking == null) {
-                    User userProxy = userRepository.getReferenceById(userId);
-                    ranking = Ranking.builder()
-                            .user(userProxy)
-                            .score(0)
-                            .dateKey(dateKey)
-                            .build();
-                }
-
-                ranking.updateScore((double) totalSteps);
-                toSave.add(ranking);
-            }
-        }
-
-        if (!toSave.isEmpty()) {
-            rankingRepository.saveAll(toSave);
-        }
-
-        redisTemplate.opsForSet().remove(dirtyKey, userIds.toArray());
-
-        log.debug("[RankingService] 배치 동기화 완료: {}명", toSave.size());
+        saveAndClearModifiedFlags(rankingsToSave, userIds, context.getDirtyKey());
     }
 
-    private Set<String> getDirtyUserIds(String dirtyKey) {
-        return redisTemplate.opsForSet().members(dirtyKey);
+    // Redis 정보를 바탕으로 DB 엔티티로 변환
+    private Optional<Ranking> mapToRankingEntity(String userIdStr, RankingSyncContext context,
+                                                 Map<Long, Ranking> existingMap) {
+        Double redisScore = redisTemplate.opsForZSet().score(context.getRedisKey(), userIdStr);
+        if (redisScore == null) {
+            return Optional.empty();
+        }
+
+        Long userId = Long.parseLong(userIdStr);
+        Ranking ranking = existingMap.getOrDefault(userId, createProxyRanking(userId, context.getDateKey()));
+
+        ranking.updateScore(Math.floor(redisScore));
+        return Optional.of(ranking);
     }
 
+    // 유저 테이블 조회를 방지하기 위한 Proxy 생성
+    private Ranking createProxyRanking(Long userId, String dateKey) {
+        return Ranking.builder()
+                .user(userRepository.getReferenceById(userId))
+                .score(0)
+                .dateKey(dateKey)
+                .build();
+    }
 
-    private List<RankingResponse> getTop10Internal(LocalDate now) {
+    // DB 저장 후 성공 시에만 Redis의 수정 플래그 삭제
+    private void saveAndClearModifiedFlags(List<Ranking> rankings, List<String> userIds, String dirtyKey) {
+        if (!rankings.isEmpty()) {
+            rankingRepository.saveAll(rankings);
+            redisTemplate.opsForSet().remove(dirtyKey, userIds.toArray());
+            log.debug("[RankingSync] {}명 동기화 완료", rankings.size());
+        }
+    }
+
+    private List<RankingResponse> fetchTopRankings(LocalDate now) {
         String redisKey = getRankingKey(now);
-
         Set<ZSetOperations.TypedTuple<String>> tuples =
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
 
         if (tuples == null || tuples.isEmpty()) {
-            return refreshRankingFromDb(now);
+            return recoverRedisFromDatabase(now);
         }
-
         return convertToResponseList(tuples);
     }
 
-    private List<RankingResponse> refreshRankingFromDb(LocalDate now) {
-        String dateKey = getDateKey(now);
-        String redisKey = getRankingKey(now);
-
-        log.warn("[RankingService] Redis 캐시 미스 - DB 복구 시작: dateKey={}", dateKey);
+    private List<RankingResponse> recoverRedisFromDatabase(LocalDate now) {
+        String dateKey = now.toString();
+        log.warn("[RankingService] 캐시 미스 - DB 데이터 복구: {}", dateKey);
 
         List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
-
         for (Ranking r : rankings) {
-            long originalTimestamp = (r.getUpdatedAt() != null)
+            long timestamp = (r.getUpdatedAt() != null)
                     ? r.getUpdatedAt().atZone(ZoneId.systemDefault()).toEpochSecond()
                     : System.currentTimeMillis() / 1000;
 
-            double redisScore = calculateTimeWeightedScore(r.getScore(), originalTimestamp);
-            redisTemplate.opsForZSet().add(redisKey, String.valueOf(r.getUser().getId()), redisScore);
+            double score = calculateTimeWeightedScore(r.getScore(), timestamp);
+            redisTemplate.opsForZSet().add(getRankingKey(now), String.valueOf(r.getUser().getId()), score);
         }
-
-        log.info("[RankingService] Redis 데이터 복구 완료: 복구된 인원={}명", rankings.size());
-
-        return getTop10Internal(now);
+        return fetchTopRankings(now);
     }
 
-    private double calculateTimeWeightedScore(double realScore, long timestamp) {
-        double timeWeight = (double) (MAX_TIMESTAMP - timestamp) / TIME_WEIGHT_DIVIDER;
-        return realScore + timeWeight;
+    private List<String> getModifiedUserIds(String dirtyKey) {
+        Set<String> members = redisTemplate.opsForSet().members(dirtyKey);
+        return (members != null) ? new ArrayList<>(members) : Collections.emptyList();
     }
 
-    private Ranking getOrCreateRanking(User user, String dateKey) {
-        return rankingRepository.findByUserAndDateKey(user, dateKey)
-                .orElseGet(() -> Ranking.builder()
-                        .user(user)
-                        .score(0)
-                        .dateKey(dateKey)
-                        .build());
+    private RankingSyncContext createSyncContext(LocalDate date) {
+        return RankingSyncContext.of(date.toString(), getRankingKey(date), getModifiedUsersKey(date));
     }
 
-    private double updateDbRanking(Ranking ranking, int steps) {
-        double newTotalScore = (double) steps;
-        ranking.updateScore(newTotalScore);
-        rankingRepository.save(ranking);
-        return newTotalScore;
-    }
-
-    private User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.warn("[RankingService] 사용자 조회 실패: userId={}", userId);
-                    return new IllegalArgumentException("User not found");
-                });
+    private Map<Long, Ranking> loadExistingRankings(List<Long> userIds, String dateKey) {
+        return rankingRepository.findAllByUserIdInAndDateKey(userIds, dateKey)
+                .stream()
+                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
     }
 
     private String getRankingKey(LocalDate date) {
         return "ranking:daily:" + date.toString();
     }
 
-    private String getDateKey(LocalDate date) {
-        return date.toString();
+    private String getModifiedUsersKey(LocalDate date) {
+        return "ranking:dirty:" + date.toString();
+    }
+
+    private List<Long> convertToLongIds(List<String> userIds) {
+        return userIds.stream().map(Long::parseLong).toList();
+    }
+
+    private double calculateTimeWeightedScore(double score, long ts) {
+        return score + (double) (MAX_TIMESTAMP - ts) / TIME_WEIGHT_DIVIDER;
+    }
+
+    private int calculateDefaultRank(String key) {
+        Long size = redisTemplate.opsForZSet().size(key);
+        return (size != null ? size.intValue() : 0) + 1;
+    }
+
+    private RankingResponse buildRankingResponse(Long userId, int rank, long score) {
+        return RankingResponse.builder().rank(rank).userId(userId).score(score).build();
     }
 
     private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples) {
         List<RankingResponse> result = new ArrayList<>();
         int rank = 1;
-
         for (ZSetOperations.TypedTuple<String> tuple : tuples) {
-            String userIdStr = tuple.getValue();
-            Double redisScore = tuple.getScore();
-
-            if (userIdStr != null && redisScore != null) {
-                long realScore = (long) Math.floor(redisScore);
-
-                result.add(buildRankingResponse(Long.parseLong(userIdStr), rank++, realScore));
+            if (tuple.getValue() != null && tuple.getScore() != null) {
+                result.add(buildRankingResponse(Long.parseLong(tuple.getValue()), rank++,
+                        (long) Math.floor(tuple.getScore())));
             }
         }
-
         return result;
     }
 
-    private int calculateDefaultRank(String redisKey) {
-        Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
-        return (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
-    }
-
-    private RankingResponse buildRankingResponse(Long userId, int rank, long score) {
-        return RankingResponse.builder()
-                .rank(rank)
-                .userId(userId)
-                .score(score)
-                .build();
+    private User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -142,7 +142,7 @@ public class RankingServiceImpl implements RankingService {
     }
 
     private double updateDbRanking(Ranking ranking, int steps) {
-        double newTotalScore = ranking.getScore() + steps;
+        double newTotalScore = (double) steps;
         ranking.updateScore(newTotalScore);
         rankingRepository.save(ranking);
         return newTotalScore;

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,0 +1,118 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingServiceImpl implements RankingService {
+
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+    
+    private static final String RANKING_KEY = "ranking:weekly";
+
+    @Override
+    @Transactional
+    public void updateScore(Long userId, double distance) {
+        // 1. 사용자 조회 (User가 점수의 주체)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // 2. DB 업데이트 (User 엔티티 직접 수정)
+        // ⚠️ [중요] User 엔티티에 점수(또는 거리)를 누적하는 메서드가 필요합니다.
+        // 예: user.addTotalDistance(distance); 또는 user.updateScore(...);
+        // 아래는 예시 로직입니다. 상황에 맞는 User 메서드를 호출하세요.
+        /* double currentScore = user.getTotalScore(); // User 엔티티의 Getter
+           double newScore = currentScore + distance;
+           user.updateScore(newScore); // User 엔티티의 Setter/Update 메서드
+        */
+
+        // (임시) User 엔티티의 내부 로직으로 점수가 변경되었다고 가정하고 저장
+        userRepository.save(user);
+
+        // 3. Redis ZSet 업데이트 (실시간 랭킹용) ⚡️
+        // User 엔티티에서 최신 점수를 가져와서 Redis에 반영
+        // (여기서는 distance가 더해진 최종 점수를 넣어야 합니다. 편의상 user.getScore()라고 가정)
+        // 만약 User에 getter가 없다면, Redis Increment 기능을 써도 됩니다.
+
+        // 방법 A: Redis에 점수 누적 (Increment) - 가장 간단!
+        Double totalScore = redisTemplate.opsForZSet().incrementScore(RANKING_KEY, String.valueOf(userId), distance);
+
+        log.info("[Ranking] User: {}, NewScore: {}", userId, totalScore);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RankingDto> getTop10() {
+        // Redis에서 점수가 높은 순(Reverse)으로 0등~9등 조회
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(RANKING_KEY, 0, 9);
+
+        // Redis 데이터가 없으면 DB에서 복구 시도
+        if (tuples == null || tuples.isEmpty()) {
+            return refreshRankingFromDb();
+        }
+
+        List<RankingDto> result = new ArrayList<>();
+        int rank = 1;
+
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            String userIdStr = tuple.getValue();
+            Double score = tuple.getScore();
+            if (userIdStr != null) {
+                result.add(new RankingDto(rank++, Long.parseLong(userIdStr), score));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RankingDto getMyRank(Long userId) {
+        String key = String.valueOf(userId);
+
+        // 내 순위 조회 (0부터 시작하므로 +1)
+        Long rank = redisTemplate.opsForZSet().reverseRank(RANKING_KEY, key);
+        // 내 점수 조회
+        Double score = redisTemplate.opsForZSet().score(RANKING_KEY, key);
+
+        if (rank == null) {
+            // Redis에 없으면 DB 확인 후 Redis에 넣는 로직이 있을 수도 있음
+            return null;
+        }
+
+        return new RankingDto(rank.intValue() + 1, userId, score);
+    }
+
+    // 🚨 Redis 데이터 유실 시 DB에서 복구하는 메서드
+    private List<RankingDto> refreshRankingFromDb() {
+        log.warn("[Ranking] Redis 데이터 유실 감지! DB에서 복구합니다.");
+
+        // UserRepositoryAdapter에 있는 'findTopRankers'를 활용하여 상위 랭커들을 가져옵니다.
+        // 혹은 전체 유저를 가져와야 한다면 findAll() 등을 사용해야 합니다.
+        // 여기서는 캐시 워밍업을 위해 상위 100명 정도만 먼저 복구하거나, 전체를 복구합니다.
+        List<User> topUsers = userRepository.findTopRankers(100);
+
+        for (User u : topUsers) {
+            // User 엔티티에서 랭킹에 쓰이는 점수 필드를 가져옵니다. (예: getDailyStepCount or getScore)
+            // 여기서는 getDailyStepCount()를 예시로 듭니다. 상황에 맞게 변경하세요.
+            // double score = u.getDailyStepCount();
+
+            // redisTemplate.opsForZSet().add(RANKING_KEY, String.valueOf(u.getId()), score);
+        }
+
+        return getTop10(); // 복구 후 다시 조회
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -27,46 +27,24 @@ public class RankingServiceImpl implements RankingService {
 
     // 시간 가중치 계산용 상수
     private static final long MAX_TIMESTAMP = 9_999_999_999L;
+    private static final double TIME_WEIGHT_DIVIDER = 100_000_000_000.0;
 
-    private String getCurrentRankingKey() {
-        return "ranking:daily:" + LocalDate.now().toString();
-    }
-
-    private String getCurrentDateKey() {
-        return LocalDate.now().toString();
-    }
-
-    // 동점자 처리: 선착순
     @Override
     @Transactional
-    public void updateScore(Long userId, double distance) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
-
+    public void updateScore(Long userId, int steps) {
+        User user = getUser(userId);
         String dateKey = getCurrentDateKey();
         String redisKey = getCurrentRankingKey();
 
-        // 디비 저장
-        Ranking ranking = rankingRepository.findByUserAndDateKey(user, dateKey)
-                .orElseGet(() -> Ranking.builder()
-                        .user(user)
-                        .score(0)
-                        .dateKey(dateKey)
-                        .build());
+        // DB 업데이트
+        Ranking ranking = getOrCreateRanking(user, dateKey);
+        double finalRealScore = updateDbRanking(ranking, steps);
 
-        double realScore = ranking.getScore() + distance;
-        ranking.updateScore(realScore);
-        rankingRepository.save(ranking);
-
-        // 걸음수 뒤에 분별용 실수 더하기(시간이 오래될수록 숫자가 커서 순위가 밀림)
-        long currentTimestamp = System.currentTimeMillis() / 1000;
-        double timeWeight = (double) (MAX_TIMESTAMP - currentTimestamp) / 100_000_000_000L;
-
-        double redisScore = realScore + timeWeight;
-
+        // Redis 가중치 점수 계산 및 반영
+        double redisScore = calculateTimeWeightedScore(finalRealScore);
         redisTemplate.opsForZSet().add(redisKey, String.valueOf(userId), redisScore);
 
-        log.info("Rank Update - User: {}, Real: {}, Redis: {}", userId, realScore, redisScore);
+        log.info("Rank Update - User: {}, RealScore: {}, RedisScore: {}", userId, finalRealScore, redisScore);
     }
 
     @Override
@@ -113,32 +91,85 @@ public class RankingServiceImpl implements RankingService {
 
         // 오늘 기록이 없는 사용자 처리
         if (rankIndex == null || redisScore == null) {
+            // 현재 Redis 랭킹(ZSet)에 등록된 총 인원수를 가져옴
             Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
 
+            // 내 등수 = (현재 참여 인원수) + 1
             int myDefaultRank = (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
 
             return RankingResponse.builder()
                     .rank(myDefaultRank)
                     .userId(userId)
-                    .score(0L)
+                    .score(0L) // 기록이 없으므로 0점 (long 타입) 반환
                     .build();
         }
 
-        // 기록이 있는 경우
+        // 3. 기록이 있는 경우: 점수 복원 및 정수(long) 형변환
         long realScore = (long) Math.floor(redisScore);
 
         return RankingResponse.builder()
-                .rank(rankIndex.intValue() + 1)
+                .rank(rankIndex.intValue() + 1) // 0-based index를 1-based 순위로 변환
                 .userId(userId)
-                .score(realScore)
+                .score(realScore) // 소수점이 제거된 정수값 반환
                 .build();
     }
 
+    private String getCurrentRankingKey() {
+        return "ranking:daily:" + LocalDate.now().toString();
+    }
+
+    private String getCurrentDateKey() {
+        return LocalDate.now().toString();
+    }
+
+    private Ranking getOrCreateRanking(User user, String dateKey) {
+        // 오늘 날짜의 랭킹 정보를 조회한다.
+        Ranking result = rankingRepository.findByUserAndDateKey(user, dateKey)
+                .orElseGet(() -> Ranking.builder()
+                        .user(user)
+                        .score(0)
+                        .dateKey(dateKey)
+                        .build());
+
+        return result;
+    }
+
+    private double updateRedisRanking(Ranking ranking, int steps) {
+        double realScore = ranking.getScore() + steps;
+        ranking.updateScore(realScore);
+        rankingRepository.save(ranking);
+
+        return realScore;
+    }
+
+    private User getUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return user;
+    }
+
+    private double calculateTimeWeightedScore(double realScore) {
+        long currentTimestamp = System.currentTimeMillis() / 1000;
+        double timeWeight = (MAX_TIMESTAMP - currentTimestamp) / TIME_WEIGHT_DIVIDER;
+        return realScore + timeWeight;
+    }
+
+    private double updateDbRanking(Ranking ranking, int steps) {
+        double newTotalScore = ranking.getScore() + steps;
+        ranking.updateScore(newTotalScore);
+        rankingRepository.save(ranking);
+        return newTotalScore;
+    }
+
+    // DB 복구 로직 (Redis 데이터 유실 시)
     private List<RankingResponse> refreshRankingFromDb() {
         log.warn("Recovering Redis from DB...");
         List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());
 
         for (Ranking r : rankings) {
+            // 복구 시에는 시간 정보가 소실되어서, 복구 시점 기준으로 순서가 정해질 수 있음
+            // 정확성을 위해 Ranking 엔티티에 'last_updated_at'이 있다면 그걸 활용 가능
             updateScore(r.getUser().getId(), 0);
         }
         return getTop10();

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +25,9 @@ public class RankingServiceImpl implements RankingService {
 
     private final RankingRepository rankingRepository;
     private final UserRepository userRepository;
+
     private final StringRedisTemplate redisTemplate;
+    private final RedisScript<Long> updateRankingScript;
 
     private static final long MAX_TIMESTAMP = 9_999_999_999L;
     private static final double TIME_WEIGHT_DIVIDER = 100_000_000_000.0;
@@ -37,19 +40,19 @@ public class RankingServiceImpl implements RankingService {
 
         LocalDate now = LocalDate.now();
         User user = getUser(userId);
-        String dateKey = getDateKey(now);
+
+        String dirtyKey = "ranking:dirty:" + now.toString();
         String redisKey = getRankingKey(now);
 
-        Ranking ranking = getOrCreateRanking(user, dateKey);
-        double finalRealScore = updateDbRanking(ranking, steps);
-
         long currentTimestamp = System.currentTimeMillis() / 1000;
-        double redisScore = calculateTimeWeightedScore(finalRealScore, currentTimestamp);
+        double redisScore = calculateTimeWeightedScore((double) steps, currentTimestamp);
 
-        redisTemplate.opsForZSet().add(redisKey, String.valueOf(userId), redisScore);
+        redisTemplate.execute(updateRankingScript,
+                List.of(redisKey, dirtyKey),
+                String.valueOf(userId), String.valueOf(redisScore)
+        );
 
-        log.info("[RankingService] 점수 업데이트 완료: userId={}, dateKey={}, finalScore={}",
-                userId, dateKey, finalRealScore);
+        log.info("[RankingService] Redis 업데이트 및 Dirty 플래그 완료: userId={}, finalScore={}", userId, steps);
     }
 
     @Override
@@ -61,19 +64,6 @@ public class RankingServiceImpl implements RankingService {
 
         log.info("[RankingService] 상위 10명 조회 완료: count={}명", result.size());
         return result;
-    }
-
-    private List<RankingResponse> getTop10Internal(LocalDate now) {
-        String redisKey = getRankingKey(now);
-
-        Set<ZSetOperations.TypedTuple<String>> tuples =
-                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
-
-        if (tuples == null || tuples.isEmpty()) {
-            return refreshRankingFromDb(now);
-        }
-
-        return convertToResponseList(tuples);
     }
 
     @Override
@@ -103,6 +93,74 @@ public class RankingServiceImpl implements RankingService {
                 userId, finalRank, finalScore);
 
         return buildRankingResponse(userId, finalRank, finalScore);
+    }
+
+
+    @Override
+    @Transactional
+    public void syncAllDirtyRanksToDb() {
+        LocalDate now = LocalDate.now();
+        String dateKey = now.toString();
+        String dirtyKey = "ranking:dirty:" + dateKey;
+        String redisKey = getRankingKey(now);
+
+        Set<String> dirtyUserIds = getDirtyUserIds(dirtyKey);
+        if (dirtyUserIds == null || dirtyUserIds.isEmpty()) {
+            return;
+        }
+
+        log.info("[RankingService] DB 영속화 시작: 대상 유저 수={}명", dirtyUserIds.size());
+        flushDirtyRanksToDb(dirtyUserIds, redisKey, dirtyKey, dateKey);
+    }
+
+    private Set<String> getDirtyUserIds(String dirtyKey) {
+        return redisTemplate.opsForSet().members(dirtyKey);
+    }
+
+    private void flushDirtyRanksToDb(Set<String> dirtyUserIds, String redisKey, String dirtyKey, String dateKey) {
+
+        for (String userIdStr : dirtyUserIds) {
+            try {
+                Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
+                if (redisScore != null) {
+                    Long userId = Long.parseLong(userIdStr);
+                    int totalSteps = (int) Math.floor(redisScore);
+
+                    // 내부 DB 저장 로직 호출
+                    this.syncToDb(userId, dateKey, totalSteps);
+
+                    // 성공 시 Dirty 플래그 제거
+                    redisTemplate.opsForSet().remove(dirtyKey, userIdStr);
+                }
+            } catch (Exception e) {
+                log.error("[RankingService] 유저 {} 영속화 실패: {}", userIdStr, e.getMessage());
+            }
+        }
+    }
+
+
+    private void syncToDb(Long userId, String dateKey, int totalSteps) {
+        log.debug("[RankingService] DB 동기화 실행: userId={}, dateKey={}, steps={}", userId, dateKey, totalSteps);
+
+        User user = getUser(userId);
+        Ranking ranking = getOrCreateRanking(user, dateKey);
+
+        updateDbRanking(ranking, totalSteps);
+
+        log.info("[RankingService] DB 동기화 완료: userId={}, score={}", userId, totalSteps);
+    }
+
+    private List<RankingResponse> getTop10Internal(LocalDate now) {
+        String redisKey = getRankingKey(now);
+
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
+
+        if (tuples == null || tuples.isEmpty()) {
+            return refreshRankingFromDb(now);
+        }
+
+        return convertToResponseList(tuples);
     }
 
     private List<RankingResponse> refreshRankingFromDb(LocalDate now) {

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,8 +1,11 @@
 package com.fitpet.server.ranking.application.service;
 
-import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.domain.entity.Ranking;
+import com.fitpet.server.ranking.domain.repository.RankingRepository;
+import com.fitpet.server.ranking.presentation.dto.RankingResponse;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -18,61 +21,82 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RankingServiceImpl implements RankingService {
 
+    private final RankingRepository rankingRepository;
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
-    
-    private static final String RANKING_KEY = "ranking:weekly";
 
+    // 시간 가중치 계산용 상수
+    private static final long MAX_TIMESTAMP = 9_999_999_999L;
+
+    private String getCurrentRankingKey() {
+        return "ranking:daily:" + LocalDate.now().toString();
+    }
+
+    private String getCurrentDateKey() {
+        return LocalDate.now().toString();
+    }
+
+    // 동점자 처리: 선착순
     @Override
     @Transactional
     public void updateScore(Long userId, double distance) {
-        // 1. 사용자 조회 (User가 점수의 주체)
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        // 2. DB 업데이트 (User 엔티티 직접 수정)
-        // ⚠️ [중요] User 엔티티에 점수(또는 거리)를 누적하는 메서드가 필요합니다.
-        // 예: user.addTotalDistance(distance); 또는 user.updateScore(...);
-        // 아래는 예시 로직입니다. 상황에 맞는 User 메서드를 호출하세요.
-        /* double currentScore = user.getTotalScore(); // User 엔티티의 Getter
-           double newScore = currentScore + distance;
-           user.updateScore(newScore); // User 엔티티의 Setter/Update 메서드
-        */
+        String dateKey = getCurrentDateKey();
+        String redisKey = getCurrentRankingKey();
 
-        // (임시) User 엔티티의 내부 로직으로 점수가 변경되었다고 가정하고 저장
-        userRepository.save(user);
+        // 디비 저장
+        Ranking ranking = rankingRepository.findByUserAndDateKey(user, dateKey)
+                .orElseGet(() -> Ranking.builder()
+                        .user(user)
+                        .score(0)
+                        .dateKey(dateKey)
+                        .build());
 
-        // 3. Redis ZSet 업데이트 (실시간 랭킹용) ⚡️
-        // User 엔티티에서 최신 점수를 가져와서 Redis에 반영
-        // (여기서는 distance가 더해진 최종 점수를 넣어야 합니다. 편의상 user.getScore()라고 가정)
-        // 만약 User에 getter가 없다면, Redis Increment 기능을 써도 됩니다.
+        double realScore = ranking.getScore() + distance;
+        ranking.updateScore(realScore);
+        rankingRepository.save(ranking);
 
-        // 방법 A: Redis에 점수 누적 (Increment) - 가장 간단!
-        Double totalScore = redisTemplate.opsForZSet().incrementScore(RANKING_KEY, String.valueOf(userId), distance);
+        // 걸음수 뒤에 분별용 실수 더하기(시간이 오래될수록 숫자가 커서 순위가 밀림)
+        long currentTimestamp = System.currentTimeMillis() / 1000;
+        double timeWeight = (double) (MAX_TIMESTAMP - currentTimestamp) / 100_000_000_000L;
 
-        log.info("[Ranking] User: {}, NewScore: {}", userId, totalScore);
+        double redisScore = realScore + timeWeight;
+
+        redisTemplate.opsForZSet().add(redisKey, String.valueOf(userId), redisScore);
+
+        log.info("Rank Update - User: {}, Real: {}, Redis: {}", userId, realScore, redisScore);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<RankingDto> getTop10() {
-        // Redis에서 점수가 높은 순(Reverse)으로 0등~9등 조회
-        Set<ZSetOperations.TypedTuple<String>> tuples =
-                redisTemplate.opsForZSet().reverseRangeWithScores(RANKING_KEY, 0, 9);
+    public List<RankingResponse> getTop10() {
+        String redisKey = getCurrentRankingKey();
 
-        // Redis 데이터가 없으면 DB에서 복구 시도
+        // 내림차순 10개
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, 9);
+
         if (tuples == null || tuples.isEmpty()) {
-            return refreshRankingFromDb();
+            return refreshRankingFromDb(); // 복구 로직
         }
 
-        List<RankingDto> result = new ArrayList<>();
+        List<RankingResponse> result = new ArrayList<>();
         int rank = 1;
 
         for (ZSetOperations.TypedTuple<String> tuple : tuples) {
             String userIdStr = tuple.getValue();
-            Double score = tuple.getScore();
-            if (userIdStr != null) {
-                result.add(new RankingDto(rank++, Long.parseLong(userIdStr), score));
+            Double redisScore = tuple.getScore();
+
+            if (userIdStr != null && redisScore != null) {
+                long realScore = (long) Math.floor(redisScore);
+
+                result.add(RankingResponse.builder()
+                        .rank(rank++)
+                        .userId(Long.parseLong(userIdStr))
+                        .score(realScore)
+                        .build());
             }
         }
         return result;
@@ -80,39 +104,43 @@ public class RankingServiceImpl implements RankingService {
 
     @Override
     @Transactional(readOnly = true)
-    public RankingDto getMyRank(Long userId) {
-        String key = String.valueOf(userId);
+    public RankingResponse getMyRank(Long userId) {
+        String redisKey = getCurrentRankingKey();
+        String userIdStr = String.valueOf(userId);
 
-        // 내 순위 조회 (0부터 시작하므로 +1)
-        Long rank = redisTemplate.opsForZSet().reverseRank(RANKING_KEY, key);
-        // 내 점수 조회
-        Double score = redisTemplate.opsForZSet().score(RANKING_KEY, key);
+        Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
+        Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
 
-        if (rank == null) {
-            // Redis에 없으면 DB 확인 후 Redis에 넣는 로직이 있을 수도 있음
-            return null;
+        // 오늘 기록이 없는 사용자 처리
+        if (rankIndex == null || redisScore == null) {
+            Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
+
+            int myDefaultRank = (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
+
+            return RankingResponse.builder()
+                    .rank(myDefaultRank)
+                    .userId(userId)
+                    .score(0L)
+                    .build();
         }
 
-        return new RankingDto(rank.intValue() + 1, userId, score);
+        // 기록이 있는 경우
+        long realScore = (long) Math.floor(redisScore);
+
+        return RankingResponse.builder()
+                .rank(rankIndex.intValue() + 1)
+                .userId(userId)
+                .score(realScore)
+                .build();
     }
 
-    // 🚨 Redis 데이터 유실 시 DB에서 복구하는 메서드
-    private List<RankingDto> refreshRankingFromDb() {
-        log.warn("[Ranking] Redis 데이터 유실 감지! DB에서 복구합니다.");
+    private List<RankingResponse> refreshRankingFromDb() {
+        log.warn("Recovering Redis from DB...");
+        List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());
 
-        // UserRepositoryAdapter에 있는 'findTopRankers'를 활용하여 상위 랭커들을 가져옵니다.
-        // 혹은 전체 유저를 가져와야 한다면 findAll() 등을 사용해야 합니다.
-        // 여기서는 캐시 워밍업을 위해 상위 100명 정도만 먼저 복구하거나, 전체를 복구합니다.
-        List<User> topUsers = userRepository.findTopRankers(100);
-
-        for (User u : topUsers) {
-            // User 엔티티에서 랭킹에 쓰이는 점수 필드를 가져옵니다. (예: getDailyStepCount or getScore)
-            // 여기서는 getDailyStepCount()를 예시로 듭니다. 상황에 맞게 변경하세요.
-            // double score = u.getDailyStepCount();
-
-            // redisTemplate.opsForZSet().add(RANKING_KEY, String.valueOf(u.getId()), score);
+        for (Ranking r : rankings) {
+            updateScore(r.getUser().getId(), 0);
         }
-
-        return getTop10(); // 복구 후 다시 조회
+        return getTop10();
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -9,7 +9,9 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -95,60 +97,80 @@ public class RankingServiceImpl implements RankingService {
         return buildRankingResponse(userId, finalRank, finalScore);
     }
 
-
+    // 청크 성공을 위한 @Transactional 제거
     @Override
-    @Transactional
     public void syncAllDirtyRanksToDb() {
         LocalDate now = LocalDate.now();
         String dateKey = now.toString();
         String dirtyKey = "ranking:dirty:" + dateKey;
         String redisKey = getRankingKey(now);
 
-        Set<String> dirtyUserIds = getDirtyUserIds(dirtyKey);
+        Set<String> dirtyUserIds = redisTemplate.opsForSet().members(dirtyKey);
         if (dirtyUserIds == null || dirtyUserIds.isEmpty()) {
             return;
         }
 
-        log.info("[RankingService] DB 영속화 시작: 대상 유저 수={}명", dirtyUserIds.size());
-        flushDirtyRanksToDb(dirtyUserIds, redisKey, dirtyKey, dateKey);
+        List<String> userIdList = new ArrayList<>(dirtyUserIds);
+        int batchSize = 100;
+
+        log.info("[RankingService] DB 영속화 시작: 대상 유저={}명", userIdList.size());
+
+        for (int i = 0; i < userIdList.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, userIdList.size());
+            List<String> chunkIds = userIdList.subList(i, end);
+
+            try {
+                processBatchSync(chunkIds, redisKey, dirtyKey, dateKey);
+            } catch (Exception e) {
+                log.error("[RankingService] 배치 처리 중 오류 (Index: {}): {}", i, e.getMessage());
+            }
+        }
+    }
+
+    @Transactional
+    public void processBatchSync(List<String> userIds, String redisKey, String dirtyKey, String dateKey) {
+        List<Long> longUserIds = userIds.stream().map(Long::parseLong).toList();
+
+        Map<Long, Ranking> existingRankings = rankingRepository.findAllByUserIdInAndDateKey(longUserIds, dateKey)
+                .stream()
+                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
+
+        List<Ranking> toSave = new ArrayList<>();
+
+        for (Long userId : longUserIds) {
+            Double redisScore = redisTemplate.opsForZSet().score(redisKey, String.valueOf(userId));
+
+            if (redisScore != null) {
+                int totalSteps = (int) Math.floor(redisScore);
+                Ranking ranking = existingRankings.get(userId);
+
+                if (ranking == null) {
+                    User userProxy = userRepository.getReferenceById(userId);
+                    ranking = Ranking.builder()
+                            .user(userProxy)
+                            .score(0)
+                            .dateKey(dateKey)
+                            .build();
+                }
+
+                ranking.updateScore((double) totalSteps);
+                toSave.add(ranking);
+            }
+        }
+
+        if (!toSave.isEmpty()) {
+            rankingRepository.saveAll(toSave);
+        }
+
+        redisTemplate.opsForSet().remove(dirtyKey, userIds.toArray());
+
+        log.debug("[RankingService] 배치 동기화 완료: {}명", toSave.size());
     }
 
     private Set<String> getDirtyUserIds(String dirtyKey) {
         return redisTemplate.opsForSet().members(dirtyKey);
     }
 
-    private void flushDirtyRanksToDb(Set<String> dirtyUserIds, String redisKey, String dirtyKey, String dateKey) {
-
-        for (String userIdStr : dirtyUserIds) {
-            try {
-                Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
-                if (redisScore != null) {
-                    Long userId = Long.parseLong(userIdStr);
-                    int totalSteps = (int) Math.floor(redisScore);
-
-                    // 내부 DB 저장 로직 호출
-                    this.syncToDb(userId, dateKey, totalSteps);
-
-                    // 성공 시 Dirty 플래그 제거
-                    redisTemplate.opsForSet().remove(dirtyKey, userIdStr);
-                }
-            } catch (Exception e) {
-                log.error("[RankingService] 유저 {} 영속화 실패: {}", userIdStr, e.getMessage());
-            }
-        }
-    }
-
-
-    private void syncToDb(Long userId, String dateKey, int totalSteps) {
-        log.debug("[RankingService] DB 동기화 실행: userId={}, dateKey={}, steps={}", userId, dateKey, totalSteps);
-
-        User user = getUser(userId);
-        Ranking ranking = getOrCreateRanking(user, dateKey);
-
-        updateDbRanking(ranking, totalSteps);
-
-        log.info("[RankingService] DB 동기화 완료: userId={}, score={}", userId, totalSteps);
-    }
 
     private List<RankingResponse> getTop10Internal(LocalDate now) {
         String redisKey = getRankingKey(now);

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -33,9 +33,10 @@ public class RankingServiceImpl implements RankingService {
     @Override
     @Transactional
     public void updateScore(Long userId, int steps) {
+        LocalDate now = LocalDate.now();
         User user = getUser(userId);
-        String dateKey = getCurrentDateKey();
-        String redisKey = getCurrentRankingKey();
+        String dateKey = getDateKey(now);
+        String redisKey = getRankingKey(now);
 
         Ranking ranking = getOrCreateRanking(user, dateKey);
         double finalRealScore = updateDbRanking(ranking, steps);
@@ -51,24 +52,27 @@ public class RankingServiceImpl implements RankingService {
     @Override
     @Transactional(readOnly = true)
     public List<RankingResponse> getTop10() {
-        String redisKey = getCurrentRankingKey();
+        return getTop10Internal(LocalDate.now());
+    }
+
+    private List<RankingResponse> getTop10Internal(LocalDate now) {
+        String redisKey = getRankingKey(now);
 
         Set<ZSetOperations.TypedTuple<String>> tuples =
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
 
         if (tuples == null || tuples.isEmpty()) {
-            return refreshRankingFromDb();
+            return refreshRankingFromDb(now);
         }
 
-        List<RankingResponse> result = convertToResponseList(tuples);
-
-        return result;
+        return convertToResponseList(tuples);
     }
 
     @Override
     @Transactional(readOnly = true)
     public RankingResponse getMyRank(Long userId) {
-        String redisKey = getCurrentRankingKey();
+        LocalDate now = LocalDate.now();
+        String redisKey = getRankingKey(now);
         String userIdStr = String.valueOf(userId);
 
         Long rankIndex = redisTemplate.opsForZSet().reverseRank(redisKey, userIdStr);
@@ -85,11 +89,12 @@ public class RankingServiceImpl implements RankingService {
         return buildRankingResponse(userId, rank, score);
     }
 
-    private List<RankingResponse> refreshRankingFromDb() {
+    private List<RankingResponse> refreshRankingFromDb(LocalDate now) {
         log.warn("Redis 유실 감지: DB의 원본 시각(updatedAt)을 기준으로 랭킹을 복구합니다.");
 
-        List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());
-        String redisKey = getCurrentRankingKey();
+        String dateKey = getDateKey(now);
+        String redisKey = getRankingKey(now);
+        List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
 
         for (Ranking r : rankings) {
             // ranking table의 updated_at을 이용해 순위 재측정
@@ -101,7 +106,7 @@ public class RankingServiceImpl implements RankingService {
             redisTemplate.opsForZSet().add(redisKey, String.valueOf(r.getUser().getId()), redisScore);
         }
 
-        return getTop10();
+        return getTop10Internal(now);
     }
 
     private double calculateTimeWeightedScore(double realScore, long timestamp) {
@@ -130,12 +135,12 @@ public class RankingServiceImpl implements RankingService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
     }
 
-    private String getCurrentRankingKey() {
-        return "ranking:daily:" + LocalDate.now().toString();
+    private String getRankingKey(LocalDate date) {
+        return "ranking:daily:" + date.toString();
     }
 
-    private String getCurrentDateKey() {
-        return LocalDate.now().toString();
+    private String getDateKey(LocalDate date) {
+        return date.toString();
     }
 
     private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples) {

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -28,6 +28,7 @@ public class RankingServiceImpl implements RankingService {
 
     private static final long MAX_TIMESTAMP = 9_999_999_999L;
     private static final double TIME_WEIGHT_DIVIDER = 100_000_000_000.0;
+    private static final int TOP_RANK_LIMIT = 10;
 
     @Override
     @Transactional
@@ -53,7 +54,7 @@ public class RankingServiceImpl implements RankingService {
         String redisKey = getCurrentRankingKey();
 
         Set<ZSetOperations.TypedTuple<String>> tuples =
-                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, 9);
+                redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
 
         if (tuples == null || tuples.isEmpty()) {
             return refreshRankingFromDb();
@@ -74,23 +75,14 @@ public class RankingServiceImpl implements RankingService {
         Double redisScore = redisTemplate.opsForZSet().score(redisKey, userIdStr);
 
         if (rankIndex == null || redisScore == null) {
-            Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
-            int myDefaultRank = (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
-
-            return RankingResponse.builder()
-                    .rank(myDefaultRank)
-                    .userId(userId)
-                    .score(0L)
-                    .build();
+            int defaultRank = calculateDefaultRank(redisKey);
+            return buildRankingResponse(userId, defaultRank, 0L);
         }
 
-        long realScore = (long) Math.floor(redisScore);
+        int rank = rankIndex.intValue() + 1;
+        long score = (long) Math.floor(redisScore);
 
-        return RankingResponse.builder()
-                .rank(rankIndex.intValue() + 1)
-                .userId(userId)
-                .score(realScore)
-                .build();
+        return buildRankingResponse(userId, rank, score);
     }
 
     private List<RankingResponse> refreshRankingFromDb() {
@@ -166,5 +158,18 @@ public class RankingServiceImpl implements RankingService {
         }
 
         return result;
+    }
+
+    private int calculateDefaultRank(String redisKey) {
+        Long totalParticipants = redisTemplate.opsForZSet().size(redisKey);
+        return (totalParticipants != null ? totalParticipants.intValue() : 0) + 1;
+    }
+
+    private RankingResponse buildRankingResponse(Long userId, int rank, long score) {
+        return RankingResponse.builder()
+                .rank(rank)
+                .userId(userId)
+                .score(score)
+                .build();
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,6 +1,5 @@
 package com.fitpet.server.ranking.application.service;
 
-import com.fitpet.server.ranking.application.dto.RankingSyncContext;
 import com.fitpet.server.ranking.application.event.UserCacheRefreshEvent;
 import com.fitpet.server.ranking.domain.entity.Ranking;
 import com.fitpet.server.ranking.domain.repository.RankingRepository;
@@ -16,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +33,10 @@ public class RankingServiceImpl implements RankingService {
 
     private final RankingRepository rankingRepository;
     private final UserRepository userRepository;
+
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> updateRankingScript;
+
     private final ApplicationEventPublisher eventPublisher;
 
     private static final String USER_PROFILE_KEY = "user:profiles";
@@ -119,80 +119,12 @@ public class RankingServiceImpl implements RankingService {
         return profileMap;
     }
 
-    @Override
-    public void syncRedisToDatabase() {
-        RankingSyncContext context = createSyncContext(LocalDate.now());
-        List<String> modifiedUserIds = getModifiedUserIds(context.getDirtyKey());
-
-        if (modifiedUserIds.isEmpty()) {
-            return;
-        }
-
-        log.info("[RankingSync] DB 동기화 시작: 대상={}명", modifiedUserIds.size());
-        transferInChunks(modifiedUserIds, context);
-    }
-
-    private void transferInChunks(List<String> userIds, RankingSyncContext context) {
-        int chunkSize = 100;
-        for (int i = 0; i < userIds.size(); i += chunkSize) {
-            List<String> chunk = userIds.subList(i, Math.min(i + chunkSize, userIds.size()));
-            try {
-                flushChunkToDatabase(chunk, context);
-            } catch (Exception e) {
-                log.error("[RankingSync] 덩어리 처리 중 오류: {}", e.getMessage());
-            }
-        }
-    }
-
-    @Transactional
-    public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
-        List<Long> longUserIds = convertToLongIds(userIds);
-        Map<Long, Ranking> existingRankings = loadExistingRankings(longUserIds, context.getDateKey());
-
-        List<Ranking> rankingsToSave = userIds.stream()
-                .map(id -> mapToRankingEntity(id, context, existingRankings))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .toList();
-
-        saveAndClearModifiedFlags(rankingsToSave, userIds, context.getDirtyKey());
-    }
-
-    private Optional<Ranking> mapToRankingEntity(String userIdStr, RankingSyncContext context,
-                                                 Map<Long, Ranking> existingMap) {
-        Double redisScore = redisTemplate.opsForZSet().score(context.getRedisKey(), userIdStr);
-        if (redisScore == null) {
-            return Optional.empty();
-        }
-
-        Long userId = Long.parseLong(userIdStr);
-        Ranking ranking = existingMap.getOrDefault(userId, createProxyRanking(userId, context.getDateKey()));
-        ranking.updateScore(Math.floor(redisScore));
-        return Optional.of(ranking);
-    }
-
-    private Ranking createProxyRanking(Long userId, String dateKey) {
-        return Ranking.builder()
-                .user(userRepository.getReferenceById(userId))
-                .score(0)
-                .dateKey(dateKey)
-                .build();
-    }
-
-    private void saveAndClearModifiedFlags(List<Ranking> rankings, List<String> userIds, String dirtyKey) {
-        if (!rankings.isEmpty()) {
-            rankingRepository.saveAll(rankings);
-            redisTemplate.opsForSet().remove(dirtyKey, userIds.toArray());
-        }
-    }
-
     private List<RankingResponse> fetchTopRankings(LocalDate now) {
         String redisKey = getRankingKey(now);
         Set<ZSetOperations.TypedTuple<String>> tuples =
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
 
         if (tuples == null || tuples.isEmpty()) {
-            // Redis가 비어있으면 DB에서 복구 시도
             return recoverRedisFromDatabase(now);
         }
 
@@ -208,7 +140,7 @@ public class RankingServiceImpl implements RankingService {
         String dateKey = now.toString();
         log.warn("[RankingService] 캐시 미스 - DB 데이터 복구 시도: {}", dateKey);
 
-        List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
+        List<Ranking> rankings = rankingRepository.findTop20ByDateKeyOrderByScoreDesc(dateKey);
 
         if (rankings.isEmpty()) {
             log.info("[RankingService] DB에도 데이터가 없어 빈 결과를 반환합니다.");
@@ -261,27 +193,9 @@ public class RankingServiceImpl implements RankingService {
     private String getRankingKey(LocalDate date) {
         return "ranking:daily:" + date.toString();
     }
-
+    
     private String getModifiedUsersKey(LocalDate date) {
         return "ranking:dirty:" + date.toString();
-    }
-
-    private RankingSyncContext createSyncContext(LocalDate date) {
-        return RankingSyncContext.of(date.toString(), getRankingKey(date), getModifiedUsersKey(date));
-    }
-
-    private List<String> getModifiedUserIds(String dirtyKey) {
-        Set<String> members = redisTemplate.opsForSet().members(dirtyKey);
-        return (members != null) ? new ArrayList<>(members) : Collections.emptyList();
-    }
-
-    private Map<Long, Ranking> loadExistingRankings(List<Long> ids, String key) {
-        return rankingRepository.findAllByUserIdInAndDateKey(ids, key).stream()
-                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
-    }
-
-    private List<Long> convertToLongIds(List<String> ids) {
-        return ids.stream().map(Long::parseLong).toList();
     }
 
     private double calculateTimeWeightedScore(double s, long ts) {

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -162,7 +162,7 @@ public class RankingServiceImpl implements RankingService {
         return newTotalScore;
     }
 
-    // DB 복구 로직 (Redis 데이터 유실 시)
+    // Db에서 랭킹 가져와 Redis에 올리기
     private List<RankingResponse> refreshRankingFromDb() {
         log.warn("Recovering Redis from DB...");
         List<Ranking> rankings = rankingRepository.findAllByDateKey(getCurrentDateKey());

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.ranking.application.service;
 
 import com.fitpet.server.ranking.application.dto.RankingSyncContext;
+import com.fitpet.server.ranking.application.event.UserCacheRefreshEvent;
 import com.fitpet.server.ranking.domain.entity.Ranking;
 import com.fitpet.server.ranking.domain.repository.RankingRepository;
 import com.fitpet.server.ranking.presentation.dto.RankingResponse;
@@ -10,13 +11,17 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -32,7 +37,9 @@ public class RankingServiceImpl implements RankingService {
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> updateRankingScript;
+    private final ApplicationEventPublisher eventPublisher;
 
+    private static final String USER_PROFILE_KEY = "user:profiles";
     private static final long MAX_TIMESTAMP = 9_999_999_999L;
     private static final double TIME_WEIGHT_DIVIDER = 100_000_000_000.0;
     private static final int TOP_RANK_LIMIT = 10;
@@ -76,7 +83,40 @@ public class RankingServiceImpl implements RankingService {
         int finalRank = (rankIndex == null) ? calculateDefaultRank(redisKey) : rankIndex.intValue() + 1;
         long finalScore = (redisScore == null) ? 0L : (long) Math.floor(redisScore);
 
-        return buildRankingResponse(userId, finalRank, finalScore);
+        Map<Long, String> nicknameMap = getNicknameMap(Collections.singletonList(userId));
+
+        return RankingResponse.of(userId, nicknameMap.get(userId), finalRank, finalScore);
+    }
+
+    private Map<Long, String> getNicknameMap(List<Long> userIds) {
+        if (userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<String> userIdsStr = userIds.stream().map(String::valueOf).toList();
+        List<Object> cachedNames = redisTemplate.opsForHash().multiGet(USER_PROFILE_KEY, new ArrayList<>(userIdsStr));
+
+        Map<Long, String> profileMap = new HashMap<>();
+        List<Long> missIds = new ArrayList<>();
+
+        for (int i = 0; i < userIds.size(); i++) {
+            Long userId = userIds.get(i);
+            String nickname = (String) cachedNames.get(i);
+
+            if (nickname == null) {
+                missIds.add(userId);
+            } else {
+                profileMap.put(userId, nickname);
+            }
+        }
+
+        if (!missIds.isEmpty()) {
+            List<User> missingUsers = userRepository.findAllById(missIds);
+            missingUsers.forEach(u -> profileMap.put(u.getId(), u.getNickname()));
+            eventPublisher.publishEvent(new UserCacheRefreshEvent(missIds));
+        }
+
+        return profileMap;
     }
 
     @Override
@@ -92,7 +132,6 @@ public class RankingServiceImpl implements RankingService {
         transferInChunks(modifiedUserIds, context);
     }
 
-    // Chunk 단위로 나누어 동기화 작업 분배
     private void transferInChunks(List<String> userIds, RankingSyncContext context) {
         int chunkSize = 100;
         for (int i = 0; i < userIds.size(); i += chunkSize) {
@@ -100,12 +139,11 @@ public class RankingServiceImpl implements RankingService {
             try {
                 flushChunkToDatabase(chunk, context);
             } catch (Exception e) {
-                log.error("[RankingSync] 덩어리 처리 중 오류 (Index: {}): {}", i, e.getMessage());
+                log.error("[RankingSync] 덩어리 처리 중 오류: {}", e.getMessage());
             }
         }
     }
 
-    // 실제 DB 저장 및 Redis 상태 정리 (트랜잭션 단위)
     @Transactional
     public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
         List<Long> longUserIds = convertToLongIds(userIds);
@@ -120,7 +158,6 @@ public class RankingServiceImpl implements RankingService {
         saveAndClearModifiedFlags(rankingsToSave, userIds, context.getDirtyKey());
     }
 
-    // Redis 정보를 바탕으로 DB 엔티티로 변환
     private Optional<Ranking> mapToRankingEntity(String userIdStr, RankingSyncContext context,
                                                  Map<Long, Ranking> existingMap) {
         Double redisScore = redisTemplate.opsForZSet().score(context.getRedisKey(), userIdStr);
@@ -130,12 +167,10 @@ public class RankingServiceImpl implements RankingService {
 
         Long userId = Long.parseLong(userIdStr);
         Ranking ranking = existingMap.getOrDefault(userId, createProxyRanking(userId, context.getDateKey()));
-
         ranking.updateScore(Math.floor(redisScore));
         return Optional.of(ranking);
     }
 
-    // 유저 테이블 조회를 방지하기 위한 Proxy 생성
     private Ranking createProxyRanking(Long userId, String dateKey) {
         return Ranking.builder()
                 .user(userRepository.getReferenceById(userId))
@@ -144,12 +179,10 @@ public class RankingServiceImpl implements RankingService {
                 .build();
     }
 
-    // DB 저장 후 성공 시에만 Redis의 수정 플래그 삭제
     private void saveAndClearModifiedFlags(List<Ranking> rankings, List<String> userIds, String dirtyKey) {
         if (!rankings.isEmpty()) {
             rankingRepository.saveAll(rankings);
             redisTemplate.opsForSet().remove(dirtyKey, userIds.toArray());
-            log.debug("[RankingSync] {}명 동기화 완료", rankings.size());
         }
     }
 
@@ -159,40 +192,70 @@ public class RankingServiceImpl implements RankingService {
                 redisTemplate.opsForZSet().reverseRangeWithScores(redisKey, 0, TOP_RANK_LIMIT - 1);
 
         if (tuples == null || tuples.isEmpty()) {
+            // Redis가 비어있으면 DB에서 복구 시도
             return recoverRedisFromDatabase(now);
         }
-        return convertToResponseList(tuples);
+
+        List<Long> userIds = tuples.stream()
+                .map(t -> Long.parseLong(Objects.requireNonNull(t.getValue())))
+                .collect(Collectors.toList());
+        Map<Long, String> nicknameMap = getNicknameMap(userIds);
+
+        return convertToResponseList(tuples, nicknameMap);
     }
 
     private List<RankingResponse> recoverRedisFromDatabase(LocalDate now) {
         String dateKey = now.toString();
-        log.warn("[RankingService] 캐시 미스 - DB 데이터 복구: {}", dateKey);
+        log.warn("[RankingService] 캐시 미스 - DB 데이터 복구 시도: {}", dateKey);
 
         List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
+
+        if (rankings.isEmpty()) {
+            log.info("[RankingService] DB에도 데이터가 없어 빈 결과를 반환합니다.");
+            return Collections.emptyList();
+        }
+
         for (Ranking r : rankings) {
-            long timestamp = (r.getUpdatedAt() != null)
+            long ts = (r.getUpdatedAt() != null)
                     ? r.getUpdatedAt().atZone(ZoneId.systemDefault()).toEpochSecond()
                     : System.currentTimeMillis() / 1000;
 
-            double score = calculateTimeWeightedScore(r.getScore(), timestamp);
-            redisTemplate.opsForZSet().add(getRankingKey(now), String.valueOf(r.getUser().getId()), score);
+            redisTemplate.opsForZSet().add(getRankingKey(now),
+                    String.valueOf(r.getUser().getId()),
+                    calculateTimeWeightedScore(r.getScore(), ts));
         }
-        return fetchTopRankings(now);
+
+        List<Ranking> topRankings = rankings.stream()
+                .sorted(Comparator.comparingDouble(Ranking::getScore).reversed())
+                .limit(TOP_RANK_LIMIT)
+                .toList();
+
+        List<Long> userIds = topRankings.stream().map(r -> r.getUser().getId()).toList();
+        Map<Long, String> nicknameMap = getNicknameMap(userIds);
+
+        List<RankingResponse> responses = new ArrayList<>();
+        int rank = 1;
+        for (Ranking r : topRankings) {
+            responses.add(RankingResponse.of(
+                    r.getUser().getId(),
+                    nicknameMap.get(r.getUser().getId()),
+                    rank++,
+                    (long) Math.floor(r.getScore())));
+        }
+
+        return responses;
     }
 
-    private List<String> getModifiedUserIds(String dirtyKey) {
-        Set<String> members = redisTemplate.opsForSet().members(dirtyKey);
-        return (members != null) ? new ArrayList<>(members) : Collections.emptyList();
-    }
-
-    private RankingSyncContext createSyncContext(LocalDate date) {
-        return RankingSyncContext.of(date.toString(), getRankingKey(date), getModifiedUsersKey(date));
-    }
-
-    private Map<Long, Ranking> loadExistingRankings(List<Long> userIds, String dateKey) {
-        return rankingRepository.findAllByUserIdInAndDateKey(userIds, dateKey)
-                .stream()
-                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
+    private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples,
+                                                        Map<Long, String> nicknameMap) {
+        List<RankingResponse> result = new ArrayList<>();
+        int rank = 1;
+        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
+            Long userId = Long.parseLong(Objects.requireNonNull(tuple.getValue()));
+            result.add(RankingResponse.of(userId, nicknameMap.get(userId), rank++,
+                    (long) Math.floor(Objects.requireNonNull(tuple.getScore()))));
+        }
+        return result;
     }
 
     private String getRankingKey(LocalDate date) {
@@ -203,36 +266,30 @@ public class RankingServiceImpl implements RankingService {
         return "ranking:dirty:" + date.toString();
     }
 
-    private List<Long> convertToLongIds(List<String> userIds) {
-        return userIds.stream().map(Long::parseLong).toList();
+    private RankingSyncContext createSyncContext(LocalDate date) {
+        return RankingSyncContext.of(date.toString(), getRankingKey(date), getModifiedUsersKey(date));
     }
 
-    private double calculateTimeWeightedScore(double score, long ts) {
-        return score + (double) (MAX_TIMESTAMP - ts) / TIME_WEIGHT_DIVIDER;
+    private List<String> getModifiedUserIds(String dirtyKey) {
+        Set<String> members = redisTemplate.opsForSet().members(dirtyKey);
+        return (members != null) ? new ArrayList<>(members) : Collections.emptyList();
     }
 
-    private int calculateDefaultRank(String key) {
-        Long size = redisTemplate.opsForZSet().size(key);
-        return (size != null ? size.intValue() : 0) + 1;
+    private Map<Long, Ranking> loadExistingRankings(List<Long> ids, String key) {
+        return rankingRepository.findAllByUserIdInAndDateKey(ids, key).stream()
+                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
     }
 
-    private RankingResponse buildRankingResponse(Long userId, int rank, long score) {
-        return RankingResponse.builder().rank(rank).userId(userId).score(score).build();
+    private List<Long> convertToLongIds(List<String> ids) {
+        return ids.stream().map(Long::parseLong).toList();
     }
 
-    private List<RankingResponse> convertToResponseList(Set<ZSetOperations.TypedTuple<String>> tuples) {
-        List<RankingResponse> result = new ArrayList<>();
-        int rank = 1;
-        for (ZSetOperations.TypedTuple<String> tuple : tuples) {
-            if (tuple.getValue() != null && tuple.getScore() != null) {
-                result.add(buildRankingResponse(Long.parseLong(tuple.getValue()), rank++,
-                        (long) Math.floor(tuple.getScore())));
-            }
-        }
-        return result;
+    private double calculateTimeWeightedScore(double s, long ts) {
+        return s + (double) (MAX_TIMESTAMP - ts) / TIME_WEIGHT_DIVIDER;
     }
 
-    private User getUser(Long userId) {
-        return userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+    private int calculateDefaultRank(String k) {
+        Long s = redisTemplate.opsForZSet().size(k);
+        return (s != null ? s.intValue() : 0) + 1;
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncService.java
@@ -1,6 +1,11 @@
 package com.fitpet.server.ranking.application.service;
 
+import com.fitpet.server.ranking.application.dto.RankingSyncContext;
+import java.util.List;
+
 public interface RankingSyncService {
 
     void syncRedisToDatabase();
+
+    void flushChunkToDatabase(List<String> userIds, RankingSyncContext context);
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncService.java
@@ -1,0 +1,6 @@
+package com.fitpet.server.ranking.application.service;
+
+public interface RankingSyncService {
+
+    void syncRedisToDatabase();
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
@@ -1,0 +1,163 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.dto.RankingSyncContext;
+import com.fitpet.server.ranking.domain.entity.Ranking;
+import com.fitpet.server.ranking.domain.repository.RankingRepository;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingSyncServiceImpl implements RankingSyncService {
+
+    private final RankingRepository rankingRepository;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void syncRedisToDatabase() {
+        RankingSyncContext context = createSyncContext(LocalDate.now());
+        String dirtyKey = context.getDirtyKey();
+
+        // Non-blocking 방식을 위한 SSCAN 설정 (100개 단위)
+        ScanOptions options = ScanOptions.scanOptions().count(100).build();
+
+        try (Cursor<String> cursor = redisTemplate.opsForSet().scan(dirtyKey, options)) {
+            List<String> chunk = new ArrayList<>();
+
+            while (cursor.hasNext()) {
+                chunk.add(cursor.next());
+
+                // 100개가 모이면 DB에 저장 (Chunking)
+                if (chunk.size() >= 100) {
+                    flushChunkToDatabase(chunk, context);
+                    chunk.clear();
+                }
+            }
+
+            // 남은 자투리 데이터 처리
+            if (!chunk.isEmpty()) {
+                flushChunkToDatabase(chunk, context);
+            }
+
+        } catch (Exception e) {
+            log.error("[RankingSync] 동기화 중 치명적 오류 발생", e);
+        }
+    }
+
+    /**
+     * 청크 단위 데이터를 DB에 영속화하고 Dirty Set에서 제거 - 개선점: Redis Pipelining을 사용하여 점수 조회 시 네트워크 RTT를 획기적으로 줄임
+     */
+    @Transactional
+    public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
+        if (userIds.isEmpty()) {
+            return;
+        }
+
+        // [New] 1. Redis Pipelining: 청크 내 모든 유저의 점수를 한 번에 조회 (RTT 1회)
+        Map<String, Double> scoreMap = fetchScoresInBatch(userIds, context.getRedisKey());
+
+        List<Long> longUserIds = convertToLongIds(userIds);
+
+        // 2. 기존 DB 데이터 조회 (Bulk Select)
+        Map<Long, Ranking> existingRankings = loadExistingRankings(longUserIds, context.getDateKey());
+
+        // 3. 엔티티 매핑 (Update or Create with Proxy)
+        // mapToRankingEntity에 미리 가져온 scoreMap을 전달하여 추가적인 Redis 조회를 방지
+        List<Ranking> rankingsToSave = userIds.stream()
+                .map(id -> mapToRankingEntity(id, context, existingRankings, scoreMap))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
+
+        if (!rankingsToSave.isEmpty()) {
+            // 4. DB 저장 (Batch Insert/Update)
+            rankingRepository.saveAll(rankingsToSave);
+
+            // 5. Redis Dirty Set에서 제거 (처리 완료)
+            redisTemplate.opsForSet().remove(context.getDirtyKey(), userIds.toArray());
+        }
+    }
+
+    /**
+     * [Pipelining 구현부] 여러 유저의 ZScore 명령어를 파이프라인으로 묶어 한 번에 실행합니다. 100번의 네트워크 통신을 1번으로 줄여줍니다.
+     */
+    private Map<String, Double> fetchScoresInBatch(List<String> userIds, String redisKey) {
+        List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            StringRedisConnection stringConn = (StringRedisConnection) connection;
+            for (String userId : userIds) {
+                stringConn.zScore(redisKey, userId);
+            }
+            return null;
+        });
+
+        // 결과 List를 Map<UserId, Score>로 변환 (O(1) 조회를 위함)
+        Map<String, Double> scoreMap = new HashMap<>();
+        for (int i = 0; i < userIds.size(); i++) {
+            Object result = results.get(i);
+            if (result instanceof Double) {
+                scoreMap.put(userIds.get(i), (Double) result);
+            }
+        }
+        return scoreMap;
+    }
+
+    private RankingSyncContext createSyncContext(LocalDate date) {
+        String dateStr = date.toString();
+        return RankingSyncContext.of(
+                dateStr,
+                "ranking:daily:" + dateStr,
+                "ranking:dirty:" + dateStr
+        );
+    }
+
+    private List<Long> convertToLongIds(List<String> ids) {
+        return ids.stream().map(Long::parseLong).toList();
+    }
+
+    private Map<Long, Ranking> loadExistingRankings(List<Long> ids, String key) {
+        return rankingRepository.findAllByUserIdInAndDateKey(ids, key).stream()
+                .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
+    }
+
+    // [Modified] Redis를 직접 호출하지 않고, 전달받은 scoreMap을 사용하도록 변경
+    private Optional<Ranking> mapToRankingEntity(String userIdStr, RankingSyncContext context,
+                                                 Map<Long, Ranking> existingMap,
+                                                 Map<String, Double> scoreMap) {
+
+        // 미리 조회해둔 Map에서 점수 획득 (메모리 연산)
+        Double redisScore = scoreMap.get(userIdStr);
+
+        if (redisScore == null) {
+            return Optional.empty();
+        }
+
+        Long userId = Long.parseLong(userIdStr);
+
+        // Zero-Select 전략: getReferenceById를 사용해 SELECT 없이 Proxy 객체 생성
+        Ranking ranking = existingMap.getOrDefault(userId, Ranking.builder()
+                .user(userRepository.getReferenceById(userId))
+                .score(0)
+                .dateKey(context.getDateKey())
+                .build());
+
+        ranking.updateScore(Math.floor(redisScore));
+        return Optional.of(ranking);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
@@ -35,7 +35,6 @@ public class RankingSyncServiceImpl implements RankingSyncService {
         RankingSyncContext context = createSyncContext(LocalDate.now());
         String dirtyKey = context.getDirtyKey();
 
-        // Non-blocking 방식을 위한 SSCAN 설정 (100개 단위)
         ScanOptions options = ScanOptions.scanOptions().count(100).build();
 
         try (Cursor<String> cursor = redisTemplate.opsForSet().scan(dirtyKey, options)) {
@@ -44,14 +43,12 @@ public class RankingSyncServiceImpl implements RankingSyncService {
             while (cursor.hasNext()) {
                 chunk.add(cursor.next());
 
-                // 100개가 모이면 DB에 저장 (Chunking)
                 if (chunk.size() >= 100) {
                     flushChunkToDatabase(chunk, context);
                     chunk.clear();
                 }
             }
 
-            // 남은 자투리 데이터 처리
             if (!chunk.isEmpty()) {
                 flushChunkToDatabase(chunk, context);
             }
@@ -61,25 +58,18 @@ public class RankingSyncServiceImpl implements RankingSyncService {
         }
     }
 
-    /**
-     * 청크 단위 데이터를 DB에 영속화하고 Dirty Set에서 제거 - 개선점: Redis Pipelining을 사용하여 점수 조회 시 네트워크 RTT를 획기적으로 줄임
-     */
     @Transactional
     public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
         if (userIds.isEmpty()) {
             return;
         }
 
-        // [New] 1. Redis Pipelining: 청크 내 모든 유저의 점수를 한 번에 조회 (RTT 1회)
         Map<String, Double> scoreMap = fetchScoresInBatch(userIds, context.getRedisKey());
 
         List<Long> longUserIds = convertToLongIds(userIds);
 
-        // 2. 기존 DB 데이터 조회 (Bulk Select)
         Map<Long, Ranking> existingRankings = loadExistingRankings(longUserIds, context.getDateKey());
 
-        // 3. 엔티티 매핑 (Update or Create with Proxy)
-        // mapToRankingEntity에 미리 가져온 scoreMap을 전달하여 추가적인 Redis 조회를 방지
         List<Ranking> rankingsToSave = userIds.stream()
                 .map(id -> mapToRankingEntity(id, context, existingRankings, scoreMap))
                 .filter(Optional::isPresent)
@@ -87,17 +77,13 @@ public class RankingSyncServiceImpl implements RankingSyncService {
                 .toList();
 
         if (!rankingsToSave.isEmpty()) {
-            // 4. DB 저장 (Batch Insert/Update)
             rankingRepository.saveAll(rankingsToSave);
 
-            // 5. Redis Dirty Set에서 제거 (처리 완료)
             redisTemplate.opsForSet().remove(context.getDirtyKey(), userIds.toArray());
         }
     }
 
-    /**
-     * [Pipelining 구현부] 여러 유저의 ZScore 명령어를 파이프라인으로 묶어 한 번에 실행합니다. 100번의 네트워크 통신을 1번으로 줄여줍니다.
-     */
+
     private Map<String, Double> fetchScoresInBatch(List<String> userIds, String redisKey) {
         List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
             StringRedisConnection stringConn = (StringRedisConnection) connection;
@@ -107,7 +93,6 @@ public class RankingSyncServiceImpl implements RankingSyncService {
             return null;
         });
 
-        // 결과 List를 Map<UserId, Score>로 변환 (O(1) 조회를 위함)
         Map<String, Double> scoreMap = new HashMap<>();
         for (int i = 0; i < userIds.size(); i++) {
             Object result = results.get(i);
@@ -136,12 +121,10 @@ public class RankingSyncServiceImpl implements RankingSyncService {
                 .collect(Collectors.toMap(r -> r.getUser().getId(), r -> r));
     }
 
-    // [Modified] Redis를 직접 호출하지 않고, 전달받은 scoreMap을 사용하도록 변경
     private Optional<Ranking> mapToRankingEntity(String userIdStr, RankingSyncContext context,
                                                  Map<Long, Ranking> existingMap,
                                                  Map<String, Double> scoreMap) {
 
-        // 미리 조회해둔 Map에서 점수 획득 (메모리 연산)
         Double redisScore = scoreMap.get(userIdStr);
 
         if (redisScore == null) {
@@ -150,7 +133,6 @@ public class RankingSyncServiceImpl implements RankingSyncService {
 
         Long userId = Long.parseLong(userIdStr);
 
-        // Zero-Select 전략: getReferenceById를 사용해 SELECT 없이 Proxy 객체 생성
         Ranking ranking = existingMap.getOrDefault(userId, Ranking.builder()
                 .user(userRepository.getReferenceById(userId))
                 .score(0)

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.connection.StringRedisConnection;
 import org.springframework.data.redis.core.Cursor;
@@ -31,6 +32,7 @@ public class RankingSyncServiceImpl implements RankingSyncService {
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
 
+    @Autowired
     @Lazy
     private RankingSyncService self;
 
@@ -62,6 +64,7 @@ public class RankingSyncServiceImpl implements RankingSyncService {
         }
     }
 
+    @Override
     @Transactional
     public void flushChunkToDatabase(List<String> userIds, RankingSyncContext context) {
         if (userIds.isEmpty()) {

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingSyncServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.redis.connection.StringRedisConnection;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisCallback;
@@ -30,6 +31,9 @@ public class RankingSyncServiceImpl implements RankingSyncService {
     private final UserRepository userRepository;
     private final StringRedisTemplate redisTemplate;
 
+    @Lazy
+    private RankingSyncService self;
+
     @Override
     public void syncRedisToDatabase() {
         RankingSyncContext context = createSyncContext(LocalDate.now());
@@ -44,13 +48,13 @@ public class RankingSyncServiceImpl implements RankingSyncService {
                 chunk.add(cursor.next());
 
                 if (chunk.size() >= 100) {
-                    flushChunkToDatabase(chunk, context);
+                    self.flushChunkToDatabase(chunk, context);
                     chunk.clear();
                 }
             }
 
             if (!chunk.isEmpty()) {
-                flushChunkToDatabase(chunk, context);
+                self.flushChunkToDatabase(chunk, context);
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
@@ -11,10 +11,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Getter
@@ -36,6 +38,10 @@ public class Ranking {
 
     @Column(name = "date_key", nullable = false)
     private String dateKey;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     @Builder
     public Ranking(User user, double score, String dateKey) {

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
@@ -1,0 +1,50 @@
+package com.fitpet.server.ranking.domain.entity;
+
+import com.fitpet.server.user.domain.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ranking", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "date_key"})
+})
+public class Ranking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private double score;
+
+    @Column(name = "date_key", nullable = false)
+    private String dateKey;
+
+    @Builder
+    public Ranking(User user, double score, String dateKey) {
+        this.user = user;
+        this.score = score;
+        this.dateKey = dateKey;
+    }
+
+    public void updateScore(double score) {
+        this.score = score;
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/Ranking.java
@@ -3,6 +3,7 @@ package com.fitpet.server.ranking.domain.entity;
 import com.fitpet.server.user.domain.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,10 +18,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ranking", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "date_key"})
 })

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
@@ -1,19 +1,15 @@
 package com.fitpet.server.ranking.domain.repository;
 
 import com.fitpet.server.ranking.domain.entity.Ranking;
-import com.fitpet.server.user.domain.entity.User;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
-    // 내 랭킹 데이터 찾기
-    Optional<Ranking> findByUserAndDateKey(User user, String dateKey);
-
-    // 오늘 날짜 모든 랭킹 데이터 가져오기
-    List<Ranking> findAllByDateKey(String dateKey);
-
-    //  유저 ID 목록을 통해 해당 날짜의 랭킹 엔티티들을 한 번에 조회
+    // Write-Back 동기화용 (100명씩 Bulk 조회)
     List<Ranking> findAllByUserIdInAndDateKey(List<Long> userIds, String dateKey);
+
+    // Redis 장애 시 Top 10 복구용 (Buffer 포함 20명)
+    List<Ranking> findTop20ByDateKeyOrderByScoreDesc(String dateKey);
+
 }

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.ranking.domain.repository;
+
+import com.fitpet.server.ranking.domain.entity.Ranking;
+import com.fitpet.server.user.domain.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingRepository extends JpaRepository<Ranking, Long> {
+
+    // 내 랭킹 데이터 찾기
+    Optional<Ranking> findByUserAndDateKey(User user, String dateKey);
+
+    // 오늘 날짜 모든 랭킹 데이터 가져오기
+    List<Ranking> findAllByDateKey(String dateKey);
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
@@ -13,4 +13,7 @@ public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
     // 오늘 날짜 모든 랭킹 데이터 가져오기
     List<Ranking> findAllByDateKey(String dateKey);
+
+    //  유저 ID 목록을 통해 해당 날짜의 랭킹 엔티티들을 한 번에 조회
+    List<Ranking> findAllByUserIdInAndDateKey(List<Long> userIds, String dateKey);
 }

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
@@ -2,14 +2,17 @@ package com.fitpet.server.ranking.domain.repository;
 
 import com.fitpet.server.ranking.domain.entity.Ranking;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
     // Write-Back 동기화용 (100명씩 Bulk 조회)
     List<Ranking> findAllByUserIdInAndDateKey(List<Long> userIds, String dateKey);
 
-    // Redis 장애 시 Top 10 복구용 (Buffer 포함 20명)
-    List<Ranking> findTop20ByDateKeyOrderByScoreDesc(String dateKey);
+    @Query("SELECT r FROM Ranking r WHERE r.dateKey = :dateKey ORDER BY r.score DESC, r.updatedAt ASC")
+    List<Ranking> findTopRankings(@Param("dateKey") String dateKey, Pageable pageable);
 
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/event/UserCacheEventListener.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/event/UserCacheEventListener.java
@@ -1,0 +1,29 @@
+package com.fitpet.server.ranking.infra.event;
+
+import com.fitpet.server.ranking.application.event.UserCacheRefreshEvent;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserCacheEventListener {
+    private final UserRepository userRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Async
+    @EventListener
+    public void handleCacheRefresh(UserCacheRefreshEvent event) {
+        List<User> users = userRepository.findAllById(event.getUserIds());
+        Map<String, String> map = users.stream()
+                .collect(Collectors.toMap(u -> String.valueOf(u.getId()), User::getNickname));
+        redisTemplate.opsForHash().putAll("user:profiles", map);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/event/UserCacheEventListener.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/event/UserCacheEventListener.java
@@ -7,11 +7,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserCacheEventListener {
@@ -21,9 +23,20 @@ public class UserCacheEventListener {
     @Async
     @EventListener
     public void handleCacheRefresh(UserCacheRefreshEvent event) {
-        List<User> users = userRepository.findAllById(event.getUserIds());
-        Map<String, String> map = users.stream()
-                .collect(Collectors.toMap(u -> String.valueOf(u.getId()), User::getNickname));
-        redisTemplate.opsForHash().putAll("user:profiles", map);
+        try {
+            List<User> users = userRepository.findAllById(event.getUserIds());
+
+            if (users.isEmpty()) {
+                return;
+            }
+
+            Map<String, String> map = users.stream()
+                    .collect(Collectors.toMap(u -> String.valueOf(u.getId()), User::getNickname));
+            redisTemplate.opsForHash().putAll("user:profiles", map);
+            log.info("[CacheRefresh] 유저 {}명 캐시 갱신 완료", users.size());
+        } catch (Exception e) {
+            log.error("[CacheRefresh] 캐시 갱신 중 오류 발생! 대상 IDs: {}", event.getUserIds(), e);
+        }
+
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
@@ -1,6 +1,8 @@
 package com.fitpet.server.ranking.infra.scheduler;
 
-import com.fitpet.server.ranking.application.service.RankingService;
+// [변경 1] RankingService -> RankingSyncService로 변경
+
+import com.fitpet.server.ranking.application.service.RankingSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -11,10 +13,18 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RankingPersistenceScheduler {
 
-    private final RankingService rankingService;
+    private final RankingSyncService rankingSyncService;
 
     @Scheduled(fixedDelay = 60000) // 1분마다 실행
     public void persistRankingToDb() {
-        rankingService.syncRedisToDatabase();
+        try {
+            log.info("[Scheduler] 랭킹 데이터 DB 동기화 시작");
+
+            rankingSyncService.syncRedisToDatabase();
+
+            log.info("[Scheduler] 랭킹 데이터 DB 동기화 완료");
+        } catch (Exception e) {
+            log.error("[Scheduler] 동기화 중 에러 발생", e);
+        }
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
@@ -15,6 +15,6 @@ public class RankingPersistenceScheduler {
 
     @Scheduled(fixedDelay = 60000) // 1분마다 실행
     public void persistRankingToDb() {
-        rankingService.syncAllDirtyRanksToDb();
+        rankingService.syncRedisToDatabase();
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
@@ -1,0 +1,20 @@
+package com.fitpet.server.ranking.infra.scheduler;
+
+import com.fitpet.server.ranking.application.service.RankingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingPersistenceScheduler {
+
+    private final RankingService rankingService;
+
+    @Scheduled(fixedDelay = 60000) // 1분마다 실행
+    public void persistRankingToDb() {
+        rankingService.syncAllDirtyRanksToDb();
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -1,0 +1,41 @@
+package com.fitpet.server.ranking.presentation;
+
+import com.fitpet.server.ranking.application.service.RankingService;
+import com.fitpet.server.ranking.presentation.dto.RankingResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/ranking")
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @GetMapping("/summary")
+    public Map<String, Object> getRankingSummary(@RequestParam Long userId) {
+        Map<String, Object> response = new HashMap<>();
+
+        List<RankingResponse> top10 = rankingService.getTop10();
+        response.put("topRankings", top10);
+
+        RankingResponse myRank = rankingService.getMyRank(userId);
+        response.put("myRanking", myRank);
+
+        return response;
+    }
+
+    // 테스트용
+    @PostMapping("/score")
+    public String testAddScore(@RequestParam Long userId, @RequestParam double distance) {
+        rankingService.updateScore(userId, distance);
+        return "업데이트 완료: User " + userId + ", 점수 " + distance;
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -1,11 +1,8 @@
 package com.fitpet.server.ranking.presentation;
 
-import com.fitpet.server.ranking.application.dto.RankingDto;
-import com.fitpet.server.ranking.application.service.RankingService;
-import com.fitpet.server.ranking.presentation.dto.RankingResponse;
+import com.fitpet.server.ranking.application.facade.RankingFacade;
 import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
 import com.fitpet.server.shared.annotation.AuthUser;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,29 +15,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/ranking")
 @RequiredArgsConstructor
 public class RankingController {
-
-    private final RankingService rankingService;
+    
+    private final RankingFacade rankingFacade;
 
     @GetMapping("/summary")
     public ResponseEntity<RankingSummaryResponse> getRankingSummary(@AuthUser Long userId) {
-
-        List<RankingDto> top10Dtos = rankingService.getTop10();
-        RankingDto myRankDto = rankingService.getMyRank(userId);
-
-        List<RankingResponse> top10Responses = top10Dtos.stream()
-                .map(RankingResponse::from)
-                .toList();
-
-        RankingResponse myRankResponse = RankingResponse.from(myRankDto);
-
-        return ResponseEntity.ok(
-                RankingSummaryResponse.of(top10Responses, myRankResponse)
-        );
+        return ResponseEntity.ok(rankingFacade.getRankingSummary(userId));
     }
 
     @PostMapping("/score")
     public ResponseEntity<String> updateScore(@AuthUser Long userId, @RequestParam int steps) {
-        rankingService.updateScore(userId, steps);
+        rankingFacade.updateScore(userId, steps);
         return ResponseEntity.ok("success");
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -34,8 +34,8 @@ public class RankingController {
 
     // 테스트용
     @PostMapping("/score")
-    public String testAddScore(@RequestParam Long userId, @RequestParam double distance) {
-        rankingService.updateScore(userId, distance);
-        return "업데이트 완료: User " + userId + ", 점수 " + distance;
+    public String testAddScore(@RequestParam Long userId, @RequestParam int steps) {
+        rankingService.updateScore(userId, steps);
+        return "업데이트 완료: User " + userId + ", 점수 " + steps;
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -1,10 +1,13 @@
 package com.fitpet.server.ranking.presentation;
 
+import com.fitpet.server.ranking.application.dto.RankingSummaryDto;
 import com.fitpet.server.ranking.application.facade.RankingFacade;
 import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
 import com.fitpet.server.shared.annotation.AuthUser;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,17 +17,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/ranking")
 @RequiredArgsConstructor
+@Validated
 public class RankingController {
-    
+
     private final RankingFacade rankingFacade;
 
     @GetMapping("/summary")
     public ResponseEntity<RankingSummaryResponse> getRankingSummary(@AuthUser Long userId) {
-        return ResponseEntity.ok(rankingFacade.getRankingSummary(userId));
+        RankingSummaryDto rankingSummaryDto = rankingFacade.getRankingSummary(userId);
+        return ResponseEntity.ok(RankingSummaryResponse.from(rankingSummaryDto));
     }
 
     @PostMapping("/score")
-    public ResponseEntity<String> updateScore(@AuthUser Long userId, @RequestParam int steps) {
+    public ResponseEntity<String> updateScore(@AuthUser Long userId, @RequestParam @Min(0) int steps) {
         rankingFacade.updateScore(userId, steps);
         return ResponseEntity.ok("success");
     }

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -2,10 +2,11 @@ package com.fitpet.server.ranking.presentation;
 
 import com.fitpet.server.ranking.application.service.RankingService;
 import com.fitpet.server.ranking.presentation.dto.RankingResponse;
-import java.util.HashMap;
+import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
+import com.fitpet.server.shared.annotation.AuthUser;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,22 +21,19 @@ public class RankingController {
     private final RankingService rankingService;
 
     @GetMapping("/summary")
-    public Map<String, Object> getRankingSummary(@RequestParam Long userId) {
-        Map<String, Object> response = new HashMap<>();
-
+    public ResponseEntity<RankingSummaryResponse> getRankingSummary(@AuthUser Long userId) {
         List<RankingResponse> top10 = rankingService.getTop10();
-        response.put("topRankings", top10);
 
         RankingResponse myRank = rankingService.getMyRank(userId);
-        response.put("myRanking", myRank);
 
-        return response;
+        return ResponseEntity.ok(
+                RankingSummaryResponse.of(top10, myRank)
+        );
     }
 
-    // 테스트용
     @PostMapping("/score")
-    public String testAddScore(@RequestParam Long userId, @RequestParam int steps) {
+    public ResponseEntity<String> updateScore(@AuthUser Long userId, @RequestParam int steps) {
         rankingService.updateScore(userId, steps);
-        return "업데이트 완료: User " + userId + ", 점수 " + steps;
+        return ResponseEntity.ok("success");
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/RankingController.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.ranking.presentation;
 
+import com.fitpet.server.ranking.application.dto.RankingDto;
 import com.fitpet.server.ranking.application.service.RankingService;
 import com.fitpet.server.ranking.presentation.dto.RankingResponse;
 import com.fitpet.server.ranking.presentation.dto.RankingSummaryResponse;
@@ -22,12 +23,18 @@ public class RankingController {
 
     @GetMapping("/summary")
     public ResponseEntity<RankingSummaryResponse> getRankingSummary(@AuthUser Long userId) {
-        List<RankingResponse> top10 = rankingService.getTop10();
 
-        RankingResponse myRank = rankingService.getMyRank(userId);
+        List<RankingDto> top10Dtos = rankingService.getTop10();
+        RankingDto myRankDto = rankingService.getMyRank(userId);
+
+        List<RankingResponse> top10Responses = top10Dtos.stream()
+                .map(RankingResponse::from)
+                .toList();
+
+        RankingResponse myRankResponse = RankingResponse.from(myRankDto);
 
         return ResponseEntity.ok(
-                RankingSummaryResponse.of(top10, myRank)
+                RankingSummaryResponse.of(top10Responses, myRankResponse)
         );
     }
 

--- a/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
@@ -1,13 +1,15 @@
-package com.fitpet.server.ranking.application.dto;
+package com.fitpet.server.ranking.presentation.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RankingDto {
+public class RankingResponse {
     private int rank;
     private Long userId;
     private Long score;

--- a/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
@@ -1,26 +1,24 @@
+// Presentation Layer DTO
 package com.fitpet.server.ranking.presentation.dto;
 
-import lombok.AllArgsConstructor;
+import com.fitpet.server.ranking.application.dto.RankingDto;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class RankingResponse {
-    private int rank;
     private Long userId;
     private String nickname;
-    private Long score;
+    private int score;
+    private int rank;
 
-    public static RankingResponse of(Long userId, String nickname, int rank, long score) {
+    public static RankingResponse from(RankingDto dto) {
         return RankingResponse.builder()
-                .userId(userId)
-                .nickname(nickname)
-                .rank(rank)
-                .score(score)
+                .userId(dto.getUserId())
+                .nickname(dto.getNickname())
+                .score((int) dto.getScore())
+                .rank(dto.getRank())
                 .build();
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingResponse.java
@@ -12,5 +12,15 @@ import lombok.NoArgsConstructor;
 public class RankingResponse {
     private int rank;
     private Long userId;
+    private String nickname;
     private Long score;
+
+    public static RankingResponse of(Long userId, String nickname, int rank, long score) {
+        return RankingResponse.builder()
+                .userId(userId)
+                .nickname(nickname)
+                .rank(rank)
+                .score(score)
+                .build();
+    }
 }

--- a/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingSummaryResponse.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.fitpet.server.ranking.presentation.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankingSummaryResponse {
+    private List<RankingResponse> topRankings;
+    private RankingResponse myRanking;
+
+    public static RankingSummaryResponse of(List<RankingResponse> topRankings, RankingResponse myRanking) {
+        return RankingSummaryResponse.builder()
+                .topRankings(topRankings)
+                .myRanking(myRanking)
+                .build();
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingSummaryResponse.java
+++ b/src/main/java/com/fitpet/server/ranking/presentation/dto/RankingSummaryResponse.java
@@ -1,6 +1,8 @@
 package com.fitpet.server.ranking.presentation.dto;
 
+import com.fitpet.server.ranking.application.dto.RankingSummaryDto;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +16,15 @@ public class RankingSummaryResponse {
         return RankingSummaryResponse.builder()
                 .topRankings(topRankings)
                 .myRanking(myRanking)
+                .build();
+    }
+
+    public static RankingSummaryResponse from(RankingSummaryDto dto) {
+        return RankingSummaryResponse.builder()
+                .topRankings(dto.getTopRankings().stream()
+                        .map(RankingResponse::from)
+                        .collect(Collectors.toList()))
+                .myRanking(RankingResponse.from(dto.getMyRanking()))
                 .build();
     }
 }

--- a/src/main/java/com/fitpet/server/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/fitpet/server/security/jwt/JwtTokenProvider.java
@@ -41,23 +41,23 @@ public class JwtTokenProvider {
 
     public String generateAccessToken(Long userId, String email, List<String> roles) {
         return Jwts.builder()
-            .setSubject(email)
-            .claim("userId", userId)
-            .claim("roles", roles)
-            .setIssuedAt(new Date())
-            .setExpiration(new Date(System.currentTimeMillis() + accessExpirationMs))
-            .signWith(accessKey, SignatureAlgorithm.HS256)
-            .compact();
+                .setSubject(email)
+                .claim("userId", userId)
+                .claim("roles", roles)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessExpirationMs))
+                .signWith(accessKey, SignatureAlgorithm.HS256)
+                .compact();
     }
 
     public String generateRefreshToken(Long userId, String email) {
         return Jwts.builder()
-            .setSubject(email)
-            .claim("userId", userId)
-            .setIssuedAt(new Date())
-            .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationMs))
-            .signWith(refreshKey, SignatureAlgorithm.HS256)
-            .compact();
+                .setSubject(email)
+                .claim("userId", userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationMs))
+                .signWith(refreshKey, SignatureAlgorithm.HS256)
+                .compact();
     }
 
     public boolean validateAccessToken(String token) {
@@ -81,7 +81,7 @@ public class JwtTokenProvider {
     public Long getUserId(String token, boolean isRefresh) {
         Key key = isRefresh ? refreshKey : accessKey;
         Claims claims = Jwts.parserBuilder().setSigningKey(key).build()
-            .parseClaimsJws(token).getBody();
+                .parseClaimsJws(token).getBody();
         return claims.get("userId", Long.class);
     }
 

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -1,14 +1,20 @@
 package com.fitpet.server.shared.config;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 
@@ -52,5 +58,23 @@ public class RedisConfig {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
         return stringRedisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+
+                // JSON 직렬화
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
+                // 캐시 수명 60분
+                .entryTtl(Duration.ofMinutes(60));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.fitpet.server.shared.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,20 +67,25 @@ public class RedisConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory cf) {
-        // 기본 설정 = 60분
+        BasicPolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
         RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(60))
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()));
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(redisSerializer));
 
         Map<String, RedisCacheConfiguration> configs = new HashMap<>();
-
-        // 정적 데이터(약관) = 24시간
         configs.put("staticData", defaults.entryTtl(Duration.ofHours(24)));
-
-        // 식단, 프로필 = 30분
         configs.put("meal", defaults.entryTtl(Duration.ofMinutes(30)));
         configs.put("profile", defaults.entryTtl(Duration.ofMinutes(30)));
 

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -11,6 +11,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,6 +19,8 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -45,6 +48,15 @@ public class RedisConfig {
         redisConfig.setPassword(password);
 
         return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisScript<Long> updateRankingScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+
+        script.setLocation(new ClassPathResource("redis/lua/update_ranking_and_dirty.lua"));
+        script.setResultType(Long.class);
+        return script;
     }
 
     @Bean

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -97,7 +97,7 @@ public class RedisConfig {
                         RedisSerializationContext.SerializationPair.fromSerializer(redisSerializer));
 
         Map<String, RedisCacheConfiguration> configs = new HashMap<>();
-        configs.put("staticData", defaults.entryTtl(Duration.ofHours(24)));
+        configs.put("terms", defaults.entryTtl(Duration.ofHours(24)));
         configs.put("meal", defaults.entryTtl(Duration.ofMinutes(30)));
         configs.put("profile", defaults.entryTtl(Duration.ofMinutes(30)));
 

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.fitpet.server.shared.config;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -62,19 +64,27 @@ public class RedisConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory cf) {
-        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+        // 기본 설정 = 60분
+        RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(60))
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-
-                // JSON 직렬화
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()))
-                // 캐시 수명 60분
-                .entryTtl(Duration.ofMinutes(60));
+                        new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+
+        // 정적 데이터(약관) = 24시간
+        configs.put("staticData", defaults.entryTtl(Duration.ofHours(24)));
+
+        // 식단, 프로필 = 30분
+        configs.put("meal", defaults.entryTtl(Duration.ofMinutes(30)));
+        configs.put("profile", defaults.entryTtl(Duration.ofMinutes(30)));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(cf)
-                .cacheDefaults(redisCacheConfiguration)
+                .cacheDefaults(defaults)
+                .withInitialCacheConfigurations(configs)
                 .build();
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -1,0 +1,56 @@
+package com.fitpet.server.shared.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+// valkey는 redis와 똑같기 때문에 Spring Boot에서는 Redis랑 똑같이 사용합니다.
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(host);
+        redisConfig.setPort(port);
+        redisConfig.setPassword(password);
+
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
             "/pets/**",
             "/missions/**",
             "/badges/**",
-            "/terms/**",
+            "/terms",
+            "/terms/agreements",
             "/devices/**",
             "/api/test/**",
             "/ranking/**",
@@ -66,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(PERMIT_URL_ARRAY).permitAll()
                         .anyRequest().authenticated()
                 );
+
         return http.build();
     }
 
@@ -84,26 +86,14 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-
-        // 추후 도메인 고정
         config.setAllowedOriginPatterns(List.of("https://*.run.app"));
-
-        // Method 허용
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-
-        // Header 허용
         config.setAllowedHeaders(List.of("*"));
-
-        // 응답 Header 허용
         config.setExposedHeaders(List.of("Authorization", "dev-user-id"));
-
-        // 쿠키 인증 안 쓸 때
-        config.setAllowCredentials(false); // credentials 쓸 거면 Origin을 명시해야 함
+        config.setAllowCredentials(false);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
     }
-
-
 }

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
             "/terms/**",
             "/devices/**",
             "/api/test/**",
+            "/ranking/**",
     };
 
     @Bean

--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.shared.config;
 
+import java.util.List;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,8 +15,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -45,6 +44,7 @@ public class SecurityConfig {
             "/badges/**",
             "/terms/**",
             "/devices/**",
+            "/api/test/**",
     };
 
     @Bean
@@ -52,19 +52,19 @@ public class SecurityConfig {
 
         http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            )
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                    .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                .requestMatchers(SWAGGER_WHITELIST).permitAll()
-                .requestMatchers(HttpMethod.GET, "/swagger-ui/swagger-config").permitAll()
-                .requestMatchers(PERMIT_URL_ARRAY).permitAll()
-                .anyRequest().authenticated()
-            );
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui/swagger-config").permitAll()
+                        .requestMatchers(PERMIT_URL_ARRAY).permitAll()
+                        .anyRequest().authenticated()
+                );
         return http.build();
     }
 
@@ -89,13 +89,13 @@ public class SecurityConfig {
 
         // Method 허용
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        
+
         // Header 허용
         config.setAllowedHeaders(List.of("*"));
-        
+
         // 응답 Header 허용
         config.setExposedHeaders(List.of("Authorization", "dev-user-id"));
-        
+
         // 쿠키 인증 안 쓸 때
         config.setAllowCredentials(false); // credentials 쓸 거면 Origin을 명시해야 함
 

--- a/src/main/java/com/fitpet/server/shared/config/WebConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/WebConfig.java
@@ -31,7 +31,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "/css/**",
                         "/js/**",
                         "/static/**",
-                        "/images/**"
+                        "/images/**",
+                        "/api/test/**"
                 );
     }
 

--- a/src/main/java/com/fitpet/server/shared/controller/RedisTestController.java
+++ b/src/main/java/com/fitpet/server/shared/controller/RedisTestController.java
@@ -1,0 +1,31 @@
+package com.fitpet.server.shared.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/redis")
+public class RedisTestController {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // 1. 데이터 저장 테스트
+    @PostMapping
+    public String saveData(@RequestParam String key, @RequestParam String value) {
+        redisTemplate.opsForValue().set(key, value);
+        return "저장 완료: " + key + " = " + value;
+    }
+
+    // 2. 데이터 조회 테스트
+    @GetMapping
+    public String getData(@RequestParam String key) {
+        String value = redisTemplate.opsForValue().get(key);
+        return "조회 결과: " + (value != null ? value : "데이터 없음");
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/util/GeometryUtil.java
+++ b/src/main/java/com/fitpet/server/shared/util/GeometryUtil.java
@@ -1,0 +1,40 @@
+package com.fitpet.server.shared.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class GeometryUtil {
+
+    private static final double EARTH_RADIUS_METERS = 6371000; // 지구 반지름 (미터)
+
+    /**
+     * 두 지점 간의 거리 계산 (Haversine Formula)
+     *
+     * @return 거리 (미터 단위, 소수점 2자리 반올림)
+     */
+    public static BigDecimal calculateDistance(BigDecimal lat1, BigDecimal lon1, BigDecimal lat2, BigDecimal lon2) {
+        if (lat1 == null || lon1 == null || lat2 == null || lon2 == null) {
+            return BigDecimal.ZERO;
+        }
+
+        // 계산의 효율성을 위해 double로 변환하여 삼각함수 수행
+        double lat1Rad = Math.toRadians(lat1.doubleValue());
+        double lon1Rad = Math.toRadians(lon1.doubleValue());
+        double lat2Rad = Math.toRadians(lat2.doubleValue());
+        double lon2Rad = Math.toRadians(lon2.doubleValue());
+
+        double dLat = lat2Rad - lat1Rad;
+        double dLon = lon2Rad - lon1Rad;
+
+        double a = Math.pow(Math.sin(dLat / 2), 2) +
+                Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                        Math.pow(Math.sin(dLon / 2), 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        double distanceMeters = EARTH_RADIUS_METERS * c;
+
+        // 결과는 다시 BigDecimal로 변환하여 정밀도 유지 (소수점 2자리, 미터 단위)
+        return BigDecimal.valueOf(distanceMeters).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
+++ b/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
@@ -6,9 +6,12 @@ import com.fitpet.server.termsmaster.domain.repository.TermsRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -16,7 +19,10 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
+    @Cacheable(value = "staticData", key = "'termsList'")
     public List<TermsDto> getActiveTerms() {
+        log.info("[TermsService] DB에서 약관을 조회합니다.");
+        
         List<Terms> activeTerms = termsRepository.findAllActiveTerms(LocalDate.now());
 
         return activeTerms.stream()

--- a/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
+++ b/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
+    @Cacheable(cacheNames = "staticData", key = "'active'")
     public List<TermsDto> getActiveTerms() {
         log.info("[TermsService] DB에서 약관을 조회합니다.");
 

--- a/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
+++ b/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
@@ -4,10 +4,10 @@ import com.fitpet.server.termsmaster.application.dto.TermsDto;
 import com.fitpet.server.termsmaster.domain.entity.Terms;
 import com.fitpet.server.termsmaster.domain.repository.TermsRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +19,13 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
-    @Cacheable(value = "staticData", key = "'termsList'")
     public List<TermsDto> getActiveTerms() {
         log.info("[TermsService] DB에서 약관을 조회합니다.");
-        
+
         List<Terms> activeTerms = termsRepository.findAllActiveTerms(LocalDate.now());
 
-        return activeTerms.stream()
+        return new ArrayList<>(activeTerms.stream()
                 .map(TermsDto::from)
-                .toList();
+                .toList());
     }
 }

--- a/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
+++ b/src/main/java/com/fitpet/server/termsmaster/application/service/TermsService.java
@@ -2,12 +2,14 @@ package com.fitpet.server.termsmaster.application.service;
 
 import com.fitpet.server.termsmaster.application.dto.TermsDto;
 import com.fitpet.server.termsmaster.domain.entity.Terms;
+import com.fitpet.server.termsmaster.domain.entity.TermsType;
 import com.fitpet.server.termsmaster.domain.repository.TermsRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +22,7 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
-    @Cacheable(cacheNames = "staticData", key = "'active'")
+    @Cacheable(cacheNames = "terms", key = "'active'")
     public List<TermsDto> getActiveTerms() {
         log.info("[TermsService] DB에서 약관을 조회합니다.");
 
@@ -29,5 +31,19 @@ public class TermsService {
         return new ArrayList<>(activeTerms.stream()
                 .map(TermsDto::from)
                 .toList());
+    }
+
+    @Transactional
+    @CacheEvict(value = "terms", allEntries = true)
+    public void createTerms(TermsType code, String content, String version) {
+
+        Terms newTerms = Terms.builder()
+                .code(code)
+                .content(content)
+                .version(version)
+                .effectiveDate(LocalDate.now())
+                .build();
+
+        termsRepository.save(newTerms);
     }
 }

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
@@ -6,6 +6,7 @@ import com.fitpet.server.termsmaster.application.dto.TermsDto;
 import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
 import com.fitpet.server.termsmaster.application.service.TermsService;
 import com.fitpet.server.termsmaster.presentation.dto.TermsAgreementRequest;
+import com.fitpet.server.termsmaster.presentation.dto.TermsCreateRequest;
 import com.fitpet.server.termsmaster.presentation.dto.TermsResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -48,5 +49,15 @@ public class TermsController {
         termsAgreementService.saveTermsAgreements(userId, commands);
 
         return ResponseEntity.ok("약관 동의 내역이 저장되었습니다.");
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createTerms(@RequestBody TermsCreateRequest request) {
+        termsService.createTerms(
+                request.code(),
+                request.content(),
+                request.version()
+        );
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
@@ -6,7 +6,6 @@ import com.fitpet.server.termsmaster.application.dto.TermsDto;
 import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
 import com.fitpet.server.termsmaster.application.service.TermsService;
 import com.fitpet.server.termsmaster.presentation.dto.TermsAgreementRequest;
-import com.fitpet.server.termsmaster.presentation.dto.TermsCreateRequest;
 import com.fitpet.server.termsmaster.presentation.dto.TermsResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -51,13 +50,13 @@ public class TermsController {
         return ResponseEntity.ok("약관 동의 내역이 저장되었습니다.");
     }
 
-    @PostMapping
-    public ResponseEntity<Void> createTerms(@RequestBody TermsCreateRequest request) {
-        termsService.createTerms(
-                request.code(),
-                request.content(),
-                request.version()
-        );
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/modify")
+//    public ResponseEntity<Void> createTerms(@RequestBody TermsCreateRequest request) {
+//        termsService.createTerms(
+//                request.code(),
+//                request.content(),
+//                request.version()
+//        );
+//        return ResponseEntity.ok().build();
+//    }
 }

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/TermsController.java
@@ -50,6 +50,7 @@ public class TermsController {
         return ResponseEntity.ok("약관 동의 내역이 저장되었습니다.");
     }
 
+    //TODO : 우선 MDL로 관리 후 추후 관리자만 요청할 수 있게 수정
 //    @PostMapping("/modify")
 //    public ResponseEntity<Void> createTerms(@RequestBody TermsCreateRequest request) {
 //        termsService.createTerms(

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.termsmaster.presentation.dto;
+
+import com.fitpet.server.termsmaster.domain.entity.TermsType;
+
+public record TermsCreateRequest(
+        TermsType code,
+        String content,
+        String version
+) {
+}

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
@@ -2,7 +2,7 @@ package com.fitpet.server.termsmaster.presentation.dto;
 
 import com.fitpet.server.termsmaster.domain.entity.TermsType;
 import jakarta.validation.constraints.NotBlank;
-import org.codehaus.commons.nullanalysis.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public record TermsCreateRequest(
         @NotNull TermsType code,

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsCreateRequest.java
@@ -1,10 +1,12 @@
 package com.fitpet.server.termsmaster.presentation.dto;
 
 import com.fitpet.server.termsmaster.domain.entity.TermsType;
+import jakarta.validation.constraints.NotBlank;
+import org.codehaus.commons.nullanalysis.NotNull;
 
 public record TermsCreateRequest(
-        TermsType code,
-        String content,
-        String version
+        @NotNull TermsType code,
+        @NotBlank String content,
+        @NotBlank String version
 ) {
 }

--- a/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsResponse.java
+++ b/src/main/java/com/fitpet/server/termsmaster/presentation/dto/TermsResponse.java
@@ -3,18 +3,25 @@ package com.fitpet.server.termsmaster.presentation.dto;
 import com.fitpet.server.termsmaster.application.dto.TermsDto;
 import com.fitpet.server.termsmaster.domain.entity.TermsType;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
-public record TermsResponse(
-        Long termsId,
-        TermsType termsCode,
-        String title,
-        String content,
-        boolean isRequired,
-        String version,
-        LocalDate effectiveDate
-) {
+@NoArgsConstructor
+@AllArgsConstructor
+public class TermsResponse {
+
+    private Long termsId;
+    private TermsType termsCode;
+    private String title;
+    private String content;
+    private boolean isRequired;
+    private String version;
+    private LocalDate effectiveDate;
+
     public static TermsResponse from(TermsDto dto) {
         return TermsResponse.builder()
                 .termsId(dto.termsId())

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
@@ -42,4 +42,5 @@ public interface UserRepository {
 
     long countByDailyStepCountGreaterThan(int dailyStepCount);
 
+    List<User> findAllById(Iterable<Long> ids);
 }

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
@@ -101,4 +101,9 @@ public class UserRepositoryAdapter implements UserRepository {
     public List<User> findTopRankersByGender(Gender gender, int limit) {
         return jpa.findTopRankersByGender(gender, PageRequest.of(0, limit));
     }
+
+    @Override
+    public List<User> findAllById(Iterable<Long> ids) {
+        return jpa.findAllById(ids);
+    }
 }

--- a/src/main/resources/redis/lua/update_ranking_and_dirty.lua
+++ b/src/main/resources/redis/lua/update_ranking_and_dirty.lua
@@ -1,7 +1,12 @@
 -- 랭킹 업데이트
+-- KEYS[1]: 랭킹 키 (예: ranking:daily:2026-01-24)
+-- ARGV[2]: 가중치가 적용된 점수 (Score)
+-- ARGV[1]: 유저 ID
 redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
 
 -- DB 영속화
+-- KEYS[2]: Dirty 필래그 키 (예: ranking:dirty:2026-01-24)
+-- ARGV[1]: 유저 ID
 redis.call('SADD', KEYS[2], ARGV[1])
 
 return 1

--- a/src/main/resources/redis/lua/update_ranking_and_dirty.lua
+++ b/src/main/resources/redis/lua/update_ranking_and_dirty.lua
@@ -1,0 +1,7 @@
+-- 랭킹 업데이트
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+
+-- DB 영속화
+redis.call('SADD', KEYS[2], ARGV[1])
+
+return 1

--- a/src/main/resources/redis/lua/update_ranking_and_dirty.lua
+++ b/src/main/resources/redis/lua/update_ranking_and_dirty.lua
@@ -1,12 +1,18 @@
 -- 랭킹 업데이트
--- KEYS[1]: 랭킹 키 (예: ranking:daily:2026-01-24)
--- ARGV[2]: 가중치가 적용된 점수 (Score)
--- ARGV[1]: 유저 ID
+-- KEYS[1]: Ranking ZSet Key (예: ranking:daily:2026-01-25)
+-- KEYS[2]: Dirty Set Key (예: ranking:dirty:2026-01-25)
+-- ARGV[1]: User ID
+-- ARGV[2]: Redis Score (걸음수 + 시간가중치)
+-- ARGV[3]: TTL (초 단위, 예: 259200)
 redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
 
 -- DB 영속화
 -- KEYS[2]: Dirty 필래그 키 (예: ranking:dirty:2026-01-24)
 -- ARGV[1]: 유저 ID
 redis.call('SADD', KEYS[2], ARGV[1])
+
+-- 두 키 모두 TTL 적용 - 이미 존재하면 갱신됨
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+redis.call('EXPIRE', KEYS[2], ARGV[3])
 
 return 1

--- a/src/test/java/com/fitpet/server/ranking/RankingIntegrationTest.java
+++ b/src/test/java/com/fitpet/server/ranking/RankingIntegrationTest.java
@@ -1,0 +1,74 @@
+// 1. 패키지 선언 누락 해결
+package com.fitpet.server.ranking;
+
+// 2. Assertions import 수정 (ClassTypes 대신 일반 Assertions 사용)
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fitpet.server.ranking.application.service.RankingService;
+import com.fitpet.server.ranking.domain.entity.Ranking;
+import com.fitpet.server.ranking.domain.repository.RankingRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+class RankingIntegrationTest {
+
+    @Autowired
+    private RankingService rankingService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    private RankingRepository rankingRepository;
+
+    @Test
+    @DisplayName("랭킹 업데이트 시 Redis 데이터와 Dirty 플래그가 동시에 생성되어야 한다")
+    void redisUpdateTest() {
+        // given
+        Long userId = 1L;
+        int steps = 5000;
+        String dateKey = LocalDate.now().toString();
+
+        // when
+        rankingService.updateScore(userId, steps);
+
+        // then
+        // ZSET 확인
+        Double score = redisTemplate.opsForZSet().score("ranking:daily:" + dateKey, String.valueOf(userId));
+        assertThat(score).isNotNull();
+        assertThat(Math.floor(score)).isEqualTo(steps);
+
+        // Dirty SET 확인
+        Boolean isDirty = redisTemplate.opsForSet().isMember("ranking:dirty:" + dateKey, String.valueOf(userId));
+        assertThat(isDirty).isTrue();
+    }
+
+    @Test
+    @DisplayName("스케줄러 동기화 후 DB에 저장이 되고 Dirty 플래그는 삭제되어야 한다")
+    void syncToDbTest() {
+        // given
+        String dateKey = LocalDate.now().toString();
+        rankingService.updateScore(1L, 7000);
+
+        // when
+        rankingService.syncAllDirtyRanksToDb();
+
+        // then
+        //  DB 확인
+        List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
+        assertThat(rankings).isNotEmpty();
+        assertThat(rankings.get(0).getScore()).isEqualTo(7000);
+
+        //  Dirty 플래그 삭제 확인
+        Set<String> dirty = redisTemplate.opsForSet().members("ranking:dirty:" + dateKey);
+        assertThat(dirty).isNotNull().isEmpty();
+    }
+}

--- a/src/test/java/com/fitpet/server/ranking/RankingIntegrationTest.java
+++ b/src/test/java/com/fitpet/server/ranking/RankingIntegrationTest.java
@@ -6,11 +6,8 @@ package com.fitpet.server.ranking;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fitpet.server.ranking.application.service.RankingService;
-import com.fitpet.server.ranking.domain.entity.Ranking;
 import com.fitpet.server.ranking.domain.repository.RankingRepository;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,24 +48,4 @@ class RankingIntegrationTest {
         assertThat(isDirty).isTrue();
     }
 
-    @Test
-    @DisplayName("스케줄러 동기화 후 DB에 저장이 되고 Dirty 플래그는 삭제되어야 한다")
-    void syncToDbTest() {
-        // given
-        String dateKey = LocalDate.now().toString();
-        rankingService.updateScore(1L, 7000);
-
-        // when
-        rankingService.syncAllDirtyRanksToDb();
-
-        // then
-        //  DB 확인
-        List<Ranking> rankings = rankingRepository.findAllByDateKey(dateKey);
-        assertThat(rankings).isNotEmpty();
-        assertThat(rankings.get(0).getScore()).isEqualTo(7000);
-
-        //  Dirty 플래그 삭제 확인
-        Set<String> dirty = redisTemplate.opsForSet().members("ranking:dirty:" + dateKey);
-        assertThat(dirty).isNotNull().isEmpty();
-    }
 }


### PR DESCRIPTION
## 🚀 PR 요약

- 이 PR은 GPS 세션 종료(`endSession`) 시 클라이언트 데이터에 의존하지 않고**서버가 저장된 로그와 사용자 신체 정보(몸무게)를 기반으로 운동 통계(총 거리, 평균 속도, 소모 칼로리)를 정밀하게 자동 계산**하도록 개선합니다.

## ✅ 작업 상세 내용

- [x] **도메인 로직 강화 (`GpsSession` Entity)**
    - `endSession` 메서드 구현: METs 공식을 활용한 소모 칼로리 계산, Haversine 기반 거리 및 평균 속도 계산 로직을 서비스 계층에서 엔티티 내부로 캡슐화
    - `@Builder` 위치 변경 (생성자 레벨 → 클래스 레벨)로 MapStruct 매핑 에러 해결
- [x] **API 요청 DTO 리팩터링 (`SessionEndRequest`)**
    - `distance`, `totalDistance` 필드 제거 (보안 및 데이터 무결성을 위해 서버 계산 값 사용)
    - `burnCalories` 필드를 선택 값으로 변경 (null 입력 시 서버 자동 계산)
- [x] **서비스 계층 개선 (`GpsSessionService`)**
    - `gpsMapper`에 의존하던 업데이트 로직을 제거하고 `session.endSession()` 비즈니스 메서드 호출로 변경
    - 사용자(`User`)의 `weight_kg` 정보를 조회하여 칼로리 계산에 반영

## 🧪 테스트 방법

**Postman을 이용한 시나리오 테스트**

1.  **세션 시작:** `POST /gps/start` 요청으로 세션 ID 발급
2.  **로그 기록 (시작점):** `POST /gps/log` (강남역 인근 좌표 전송)
3.  **로그 기록 (종료점):** 1시간 뒤 시각으로 약 7km 떨어진 좌표 전송
<img width="683" height="487" alt="image" src="https://github.com/user-attachments/assets/00893b57-3673-4626-964a-8668dcc2b3da" />


4.  **세션 종료:** `POST /gps/end` 요청 시 `burnCalories`를 `null`로 전송
5.  **검증:** 응답(`Response`)에서 다음 항목 확인
    - `totalDistance`: 약 7km (7005m) 측정 여부
    - `avgSpeed`: 약 7km/h 측정 여부
    - `burnCalories`: 사용자 몸무게(170kg 가정)와 METs(7.0) 반영된 **1190kcal** 계산 여부
<img width="608" height="737" alt="image" src="https://github.com/user-attachments/assets/82cb26a4-8ae2-41fb-9e66-3aa92706689f" />


## 📎 관련 이슈


## ## 추가 전달 사항

- **METs 공식 적용:** 소모 칼로리는 `METs * 체중(kg) * 시간(hr)` 공식으로 계산됩니다.
- **예외 처리:** 사용자 프로필에 몸무게 정보가 없을 경우 기본값(`70kg`)이 적용되도록 방어 로직이 구현되어 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **New Features**
  * 사용자 랭킹 시스템 추가 — 일별 점수 집계, 실시간 업데이트, 순위 조회 및 요약 제공
  * 랭킹 동기화 서비스 및 주기적 DB 동기화 스케줄러 추가
  * Redis 설정·스크립트·테스트 엔드포인트 및 지리 계산 유틸 추가

* **Bug Fixes**
  * GPS 로그 필터링 강화 — 거리·속도 기준으로 노이즈/차량 데이터 차단
  * GPS 세션 접근 제어 강화 — 인증 사용자만 기록/종료 가능

* **Refactor**
  * GPS 세션 통계 자동 계산 및 로그에 세션 식별자 포함
  * 일일 걸음수 변경 시 랭킹 점수 자동 갱신

* **Tests**
  * 랭킹 Redis 연동 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->