### PR TITLE
Fix/multiple issues

### DIFF
--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryService.java
@@ -8,7 +8,7 @@ import com.fitpet.server.bodyhistory.presentation.dto.response.BodyHistoryRespon
 
 public interface BodyHistoryService {
 
-    BodyHistoryResponse createBodyHistory(BodyHistoryCreateRequest request);
+    BodyHistoryResponse createBodyHistory(Long userId, BodyHistoryCreateRequest request);
 
     BodyHistoryResponse findBodyHistoryById(Long historyId);
 

--- a/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/application/service/BodyHistoryServiceImpl.java
@@ -33,12 +33,12 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
     private final BodyHistoryMapper bodyHistoryMapper;
 
     @Override
-    public BodyHistoryResponse createBodyHistory(BodyHistoryCreateRequest req) {
-        log.debug("[BodyHistoryService] 기록 생성 요청: userId={}", req.userId());
+    public BodyHistoryResponse createBodyHistory(Long userId, BodyHistoryCreateRequest req) {
+        log.debug("[BodyHistoryService] 기록 생성 요청: userId={}",userId);
 
-        User user = userRepository.findById(req.userId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> {
-                    log.warn("[BodyHistoryService] 사용자 조회 실패: userId={}", req.userId());
+                    log.warn("[BodyHistoryService] 사용자 조회 실패: userId={}",userId);
                     return new BusinessException(ErrorCode.USER_NOT_FOUND);
                 });
     
@@ -46,7 +46,7 @@ public class BodyHistoryServiceImpl implements BodyHistoryService {
         BodyHistory savedBodyHistory = bodyHistoryRepository.save(bodyHistory);
 
         log.info("[BodyHistoryService] 기록 생성 완료: historyId={}, userId={}",
-                savedBodyHistory.getId(), req.userId());
+                savedBodyHistory.getId(), userId);
     
         return bodyHistoryMapper.toResponse(savedBodyHistory);
     }

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/controller/BodyHistoryController.java
@@ -54,8 +54,11 @@ public class BodyHistoryController {
     }
 
     @PostMapping
-    public ResponseEntity<BodyHistoryResponse> create(@RequestBody @Valid BodyHistoryCreateRequest request) {
-        BodyHistoryResponse saved = bodyHistoryService.createBodyHistory(request);
+    public ResponseEntity<BodyHistoryResponse> create(
+        @AuthUser Long userId, 
+        @RequestBody @Valid BodyHistoryCreateRequest request
+    ) {
+        BodyHistoryResponse saved = bodyHistoryService.createBodyHistory(userId, request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{id}")

--- a/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
+++ b/src/main/java/com/fitpet/server/bodyhistory/presentation/dto/request/BodyHistoryCreateRequest.java
@@ -10,9 +10,6 @@ import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record BodyHistoryCreateRequest(
-        @NotNull(message = "사용자 ID는 필수입니다.")
-        Long userId,
-
         @NotNull(message = "키는 필수입니다.")
         @PositiveOrZero(message = "키는 0 이상이어야 합니다.")
         BigDecimal heightCm,

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionStartRequest.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/dto/request/SessionStartRequest.java
@@ -9,7 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SessionStartRequest {
     @NotNull
-    private Long userId;
-    @NotNull
     private LocalDateTime startTime;
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/request/UserCreateRequest.java
@@ -22,7 +22,7 @@ public record UserCreateRequest(
         String password,
 
         @NotBlank
-        @Size(min = 5, max = 20)
+        @Size(min = 2, max = 10)
         String nickname,
 
         @NotNull

--- a/src/main/java/com/fitpet/server/user/presentation/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/request/UserUpdateRequest.java
@@ -14,7 +14,7 @@ public record UserUpdateRequest(
                 message = "비밀번호는 영어, 숫자, 특수문자를 포함해야 합니다."
         )
         String password,
-        @Size(min = 5, max = 20)
+        @Size(min = 2, max = 10)
         String nickname,
         Integer age,
         Gender gender,


### PR DESCRIPTION
## 📌 PR 요약

- 이 PR은 무엇을 해결하거나 개선합니까?
- 닉네임 길이 제약 조건 수정
- BodyHistory 생성 API에서 AuthUser 기반 userId 처리로 변경
- gps-start API에서 userId 필수 요청값 제거
## ✅ 작업 상세 내용

- [x] 닉네임 길이 제한 정책 수정
- [x] BodyHistoryCreateRequest에서 userId 제거
- [x] @AuthUser 기반 userId 주입 방식으로 변경
- [x] BodyHistoryService 시그니처 수정 (Long userId 추가)
- [x] gps-start API에서 userId 요청 필수값 제거
- [x] 컨트롤러/서비스 호출부 수정

## 🧪 테스트 방법

- 기능 테스트 방식 또는 실행 방법을 설명해주세요.

## 📎 관련 이슈

- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 신체 정보 생성 시 사용자 인증 기반 처리로 개선되었습니다.
  * 닉네임 길이 제한이 완화되었습니다 (기존 5-20자에서 2-10자로 변경).
  * API 요청 본문에서 불필요한 사용자 ID 필드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->