### PR TITLE
[Feat] GET /users 응답에 반려동물 요약 정보 포함

### DIFF
--- a/src/main/java/com/fitpet/server/user/application/dto/PetSummaryResult.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/PetSummaryResult.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.user.application.dto;
+
+import com.fitpet.server.pet.domain.entity.PetExpression;
+import com.fitpet.server.pet.domain.entity.PetType;
+import lombok.Builder;
+
+@Builder
+public record PetSummaryResult(
+    Long petId,
+    String name,
+    PetType petType,
+    String color,
+    Long exp,
+    PetExpression expression
+) {
+}

--- a/src/main/java/com/fitpet/server/user/application/dto/ProfileImageUpdateResult.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/ProfileImageUpdateResult.java
@@ -1,0 +1,7 @@
+package com.fitpet.server.user.application.dto;
+
+public record ProfileImageUpdateResult(
+    String imageKey,
+    String uploadUrl
+) {
+}

--- a/src/main/java/com/fitpet/server/user/application/dto/UserCreateCommand.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/UserCreateCommand.java
@@ -1,0 +1,18 @@
+package com.fitpet.server.user.application.dto;
+
+import com.fitpet.server.user.domain.entity.Gender;
+
+public record UserCreateCommand(
+    String email,
+    String password,
+    String nickname,
+    Integer age,
+    Gender gender,
+    Double weightKg,
+    Double targetWeightKg,
+    Double heightCm,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount
+) {
+}

--- a/src/main/java/com/fitpet/server/user/application/dto/UserInputInfoCommand.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/UserInputInfoCommand.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.user.application.dto;
+
+import com.fitpet.server.user.domain.entity.Gender;
+
+public record UserInputInfoCommand(
+    String nickname,
+    int age,
+    Gender gender,
+    Double weightKg,
+    Double heightCm,
+    Double targetWeightKg,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount
+) {
+}

--- a/src/main/java/com/fitpet/server/user/application/dto/UserResult.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/UserResult.java
@@ -1,0 +1,67 @@
+package com.fitpet.server.user.application.dto;
+
+import com.fitpet.server.user.domain.entity.Gender;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record UserResult(
+    Long userId,
+    String email,
+    String nickname,
+    String profileImageUrl,
+    Integer age,
+    Gender gender,
+    Double weightKg,
+    Double targetWeightKg,
+    Double heightCm,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount,
+    Integer dailyStepCount,
+    PetSummaryResult pet,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    public UserResult withPet(PetSummaryResult pet) {
+        return new UserResult(
+            userId,
+            email,
+            nickname,
+            profileImageUrl,
+            age,
+            gender,
+            weightKg,
+            targetWeightKg,
+            heightCm,
+            pbf,
+            targetPbf,
+            targetStepCount,
+            dailyStepCount,
+            pet,
+            createdAt,
+            updatedAt
+        );
+    }
+
+    public UserResult withProfileImageUrl(String profileImageUrl) {
+        return new UserResult(
+            userId,
+            email,
+            nickname,
+            profileImageUrl,
+            age,
+            gender,
+            weightKg,
+            targetWeightKg,
+            heightCm,
+            pbf,
+            targetPbf,
+            targetStepCount,
+            dailyStepCount,
+            pet,
+            createdAt,
+            updatedAt
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/user/application/dto/UserUpdateCommand.java
+++ b/src/main/java/com/fitpet/server/user/application/dto/UserUpdateCommand.java
@@ -1,0 +1,18 @@
+package com.fitpet.server.user.application.dto;
+
+import com.fitpet.server.user.domain.entity.Gender;
+
+public record UserUpdateCommand(
+    String email,
+    String password,
+    String nickname,
+    Integer age,
+    Gender gender,
+    Double weightKg,
+    Double targetWeightKg,
+    Double heightCm,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount
+) {
+}

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -1,8 +1,8 @@
 package com.fitpet.server.user.application.mapper;
 
+import com.fitpet.server.user.application.dto.UserCreateCommand;
+import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.domain.entity.User;
-import com.fitpet.server.user.presentation.dto.UserDto;
-import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -27,10 +27,10 @@ public interface UserMapper {
             @Mapping(target = "lastAccessedAt", ignore = true),
             @Mapping(target = "profileImageUrl", ignore = true)
     })
-    User toEntity(UserCreateRequest request);
+    User toEntity(UserCreateCommand command);
  
     @Mapping(source = "id", target = "userId")
     @Mapping(target = "pet", ignore = true)
-    UserDto toDto(User user);
+    UserResult toResult(User user);
 
 }

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -29,6 +29,7 @@ public interface UserMapper {
     User toEntity(UserCreateRequest request);
 
     @Mapping(source = "id", target = "userId")
+    @Mapping(target = "pet", ignore = true)
     UserDto toDto(User user);
 
 }

--- a/src/main/java/com/fitpet/server/user/application/service/UserService.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserService.java
@@ -1,23 +1,23 @@
 package com.fitpet.server.user.application.service;
 
-import com.fitpet.server.user.presentation.dto.UserDto;
-import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
-import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
-import com.fitpet.server.user.presentation.dto.request.UserUpdateRequest;
-import com.fitpet.server.user.presentation.dto.response.ProfileImageUpdateResponse;
+import com.fitpet.server.user.application.dto.ProfileImageUpdateResult;
+import com.fitpet.server.user.application.dto.UserCreateCommand;
+import com.fitpet.server.user.application.dto.UserInputInfoCommand;
+import com.fitpet.server.user.application.dto.UserResult;
+import com.fitpet.server.user.application.dto.UserUpdateCommand;
 
 public interface UserService {
-    UserDto createUser(UserCreateRequest request);
+    UserResult createUser(UserCreateCommand command);
 
-    UserDto findUser(Long userId);
+    UserResult findUser(Long userId);
 
-    UserDto updateUser(Long userId, UserUpdateRequest request);
+    UserResult updateUser(Long userId, UserUpdateCommand command);
 
-    ProfileImageUpdateResponse updateProfileImage(Long userId);
+    ProfileImageUpdateResult updateProfileImage(Long userId);
 
     void deleteUser(Long userId);
 
-    UserDto inputInfo(Long userId, UserInputInfoRequest request);
+    UserResult inputInfo(Long userId, UserInputInfoCommand command);
 
     boolean isRegistrationComplete(Long userId);
 

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.application.service;
 
+import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.shared.s3.type.ImageType;
 import com.fitpet.server.user.application.mapper.UserMapper;
@@ -9,6 +10,7 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import com.fitpet.server.user.presentation.dto.PetSummaryDto;
 import com.fitpet.server.user.presentation.dto.UserDto;
 import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
@@ -30,6 +32,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PetRepository petRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
@@ -52,8 +55,18 @@ public class UserServiceImpl implements UserService {
         User user = findUserById(userId);
 
         UserDto baseDto = userMapper.toDto(user);
+        PetSummaryDto petSummary = petRepository.findByOwnerId(userId)
+            .map(pet -> PetSummaryDto.builder()
+                .petId(pet.getId())
+                .name(pet.getName())
+                .petType(pet.getPetType())
+                .color(pet.getColor())
+                .exp(pet.getExp())
+                .expression(pet.getExpression())
+                .build())
+            .orElse(null);
 
-        return enrichWithPresignedUrl(baseDto, user.getProfileImageUrl());
+        return enrichWithPresignedUrl(baseDto.withPet(petSummary), user.getProfileImageUrl());
     }
 
     private UserDto enrichWithPresignedUrl(UserDto dto, String imageKey) {
@@ -77,6 +90,7 @@ public class UserServiceImpl implements UserService {
             .targetPbf(dto.targetPbf())
             .targetStepCount(dto.targetStepCount())
             .dailyStepCount(dto.dailyStepCount())
+            .pet(dto.pet())
             .createdAt(dto.createdAt())
             .updatedAt(dto.updatedAt())
             .build();

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -3,6 +3,12 @@ package com.fitpet.server.user.application.service;
 import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.shared.s3.type.ImageType;
+import com.fitpet.server.user.application.dto.PetSummaryResult;
+import com.fitpet.server.user.application.dto.ProfileImageUpdateResult;
+import com.fitpet.server.user.application.dto.UserCreateCommand;
+import com.fitpet.server.user.application.dto.UserInputInfoCommand;
+import com.fitpet.server.user.application.dto.UserResult;
+import com.fitpet.server.user.application.dto.UserUpdateCommand;
 import com.fitpet.server.user.application.mapper.UserMapper;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
@@ -10,12 +16,6 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
-import com.fitpet.server.user.presentation.dto.PetSummaryDto;
-import com.fitpet.server.user.presentation.dto.UserDto;
-import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
-import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
-import com.fitpet.server.user.presentation.dto.request.UserUpdateRequest;
-import com.fitpet.server.user.presentation.dto.response.ProfileImageUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -42,21 +42,21 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserDto createUser(UserCreateRequest request) {
-        validateUserCreateRequest(request);
-        User user = userMapper.toEntity(request);
-        user.changePassword(passwordEncoder.encode(request.password()));
-        return userMapper.toDto(userRepository.save(user));
+    public UserResult createUser(UserCreateCommand command) {
+        validateUserCreateRequest(command);
+        User user = userMapper.toEntity(command);
+        user.changePassword(passwordEncoder.encode(command.password()));
+        return userMapper.toResult(userRepository.save(user));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public UserDto findUser(Long userId) {
+    public UserResult findUser(Long userId) {
         User user = findUserById(userId);
 
-        UserDto baseDto = userMapper.toDto(user);
-        PetSummaryDto petSummary = petRepository.findByOwnerId(userId)
-            .map(pet -> PetSummaryDto.builder()
+        UserResult baseResult = userMapper.toResult(user);
+        PetSummaryResult petSummary = petRepository.findByOwnerId(userId)
+            .map(pet -> PetSummaryResult.builder()
                 .petId(pet.getId())
                 .name(pet.getName())
                 .petType(pet.getPetType())
@@ -66,64 +66,46 @@ public class UserServiceImpl implements UserService {
                 .build())
             .orElse(null);
 
-        return enrichWithPresignedUrl(baseDto.withPet(petSummary), user.getProfileImageUrl());
+        return enrichWithPresignedUrl(baseResult.withPet(petSummary), user.getProfileImageUrl());
     }
 
-    private UserDto enrichWithPresignedUrl(UserDto dto, String imageKey) {
+    private UserResult enrichWithPresignedUrl(UserResult result, String imageKey) {
         if (!StringUtils.hasText(imageKey)) {
-            return dto;
+            return result;
         }
 
         String presignedUrl = s3Service.generatePresignedGetUrl(imageKey);
-
-        return UserDto.builder()
-            .userId(dto.userId())
-            .email(dto.email())
-            .nickname(dto.nickname())
-            .profileImageUrl(presignedUrl)
-            .age(dto.age())
-            .gender(dto.gender())
-            .weightKg(dto.weightKg())
-            .targetWeightKg(dto.targetWeightKg())
-            .heightCm(dto.heightCm())
-            .pbf(dto.pbf())
-            .targetPbf(dto.targetPbf())
-            .targetStepCount(dto.targetStepCount())
-            .dailyStepCount(dto.dailyStepCount())
-            .pet(dto.pet())
-            .createdAt(dto.createdAt())
-            .updatedAt(dto.updatedAt())
-            .build();
+        return result.withProfileImageUrl(presignedUrl);
     }
 
     @Override
     @Transactional
-    public UserDto updateUser(Long userId, UserUpdateRequest request) {
+    public UserResult updateUser(Long userId, UserUpdateCommand command) {
         User user = findUserById(userId);
-        validateUserUpdateRequest(userId, request);
+        validateUserUpdateRequest(userId, command);
 
-        if (StringUtils.hasText(request.password())) {
-            user.changePassword(passwordEncoder.encode(request.password()));
+        if (StringUtils.hasText(command.password())) {
+            user.changePassword(passwordEncoder.encode(command.password()));
         }
 
         user.update(
-            request.email(),
-            request.nickname(),
-            request.age(),
-            request.gender(),
-            request.weightKg(),
-            request.targetWeightKg(),
-            request.heightCm(),
-            request.pbf(),
-            request.targetPbf(),
-            request.targetStepCount()
+            command.email(),
+            command.nickname(),
+            command.age(),
+            command.gender(),
+            command.weightKg(),
+            command.targetWeightKg(),
+            command.heightCm(),
+            command.pbf(),
+            command.targetPbf(),
+            command.targetStepCount()
         );
-        return userMapper.toDto(user);
+        return userMapper.toResult(user);
     }
 
     @Override
     @Transactional
-    public ProfileImageUpdateResponse updateProfileImage(Long userId) {
+    public ProfileImageUpdateResult updateProfileImage(Long userId) {
         User user = findUserById(userId);
 
         if (user.getProfileImageUrl() != null && !user.getProfileImageUrl().isBlank()) {
@@ -137,7 +119,7 @@ public class UserServiceImpl implements UserService {
 
         String uploadUrl = s3Service.generatePresignedPutUrl(newImageKey);
 
-        return new ProfileImageUpdateResponse(newImageKey, uploadUrl);
+        return new ProfileImageUpdateResult(newImageKey, uploadUrl);
     }
 
     @Override
@@ -161,19 +143,30 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserDto inputInfo(Long userId, UserInputInfoRequest request) {
+    public UserResult inputInfo(Long userId, UserInputInfoCommand command) {
         User user = findUserById(userId);
 
         if (user.getRegistrationStatus() == RegistrationStatus.COMPLETE) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이미 가입이 완료된 사용자입니다.");
         }
 
-        if (userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+        if (userRepository.existsByNicknameAndIdNot(command.nickname(), userId)) {
             throw new DuplicateNicknameException();
         }
 
-        user.userInformation(request);
-        return userMapper.toDto(userRepository.save(user));
+        user.userInformation(
+            command.nickname(),
+            command.age(),
+            command.gender(),
+            command.weightKg(),
+            command.heightCm(),
+            command.targetWeightKg(),
+            command.pbf(),
+            command.targetPbf(),
+            command.targetStepCount()
+        );
+
+        return userMapper.toResult(userRepository.save(user));
     }
 
     @Override
@@ -188,22 +181,22 @@ public class UserServiceImpl implements UserService {
             .orElseThrow(UserNotFoundException::new);
     }
 
-    private void validateUserCreateRequest(UserCreateRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
+    private void validateUserCreateRequest(UserCreateCommand command) {
+        if (userRepository.existsByEmail(command.email())) {
             throw new DuplicateEmailException();
         }
-        if (userRepository.existsByNickname(request.nickname())) {
+        if (userRepository.existsByNickname(command.nickname())) {
             throw new DuplicateNicknameException();
         }
     }
 
-    private void validateUserUpdateRequest(Long userId, UserUpdateRequest request) {
-        if (StringUtils.hasText(request.email()) &&
-            userRepository.existsByEmailAndIdNot(request.email(), userId)) {
+    private void validateUserUpdateRequest(Long userId, UserUpdateCommand command) {
+        if (StringUtils.hasText(command.email()) &&
+            userRepository.existsByEmailAndIdNot(command.email(), userId)) {
             throw new DuplicateEmailException();
         }
-        if (StringUtils.hasText(request.nickname()) &&
-            userRepository.existsByNicknameAndIdNot(request.nickname(), userId)) {
+        if (StringUtils.hasText(command.nickname()) &&
+            userRepository.existsByNicknameAndIdNot(command.nickname(), userId)) {
             throw new DuplicateNicknameException();
         }
     }

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.application.service;
 
+import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.user.application.dto.GenderRankingResult;
 import com.fitpet.server.user.application.dto.RankingResult;
 import com.fitpet.server.user.application.dto.UserRanking;
@@ -11,6 +12,7 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import com.fitpet.server.user.presentation.dto.PetSummaryDto;
 import com.fitpet.server.user.presentation.dto.UserDto;
 import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
@@ -31,6 +33,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PetRepository petRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
 
@@ -52,7 +55,20 @@ public class UserServiceImpl implements UserService {
     public UserDto findUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        return userMapper.toDto(user);
+        UserDto userDto = userMapper.toDto(user);
+
+        PetSummaryDto petSummary = petRepository.findByOwnerId(userId)
+                .map(pet -> PetSummaryDto.builder()
+                        .petId(pet.getId())
+                        .name(pet.getName())
+                        .petType(pet.getPetType())
+                        .color(pet.getColor())
+                        .exp(pet.getExp())
+                        .expression(pet.getExpression())
+                        .build())
+                .orElse(null);
+
+        return userDto.withPet(petSummary);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -1,6 +1,5 @@
 package com.fitpet.server.user.domain.entity;
 
-import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -176,32 +175,42 @@ public class User {
         this.dailyStepCount = dailyStepCount;
     }
 
-    public void userInformation(UserInputInfoRequest request) {
-        this.nickname = request.nickname();
-        this.age = request.age();
-        this.gender = request.gender();
-        this.weightKg = request.weightKg();
-        this.heightCm = request.heightCm();
+    public void userInformation(
+            String nickname,
+            int age,
+            Gender gender,
+            Double weightKg,
+            Double heightCm,
+            Double targetWeightKg,
+            Double pbf,
+            Double targetPbf,
+            Integer targetStepCount
+    ) {
+        this.nickname = nickname;
+        this.age = age;
+        this.gender = gender;
+        this.weightKg = weightKg;
+        this.heightCm = heightCm;
 
-        if (request.targetWeightKg() == null) {
+        if (targetWeightKg == null) {
             this.targetWeightKg = null;
         } else {
-            this.targetWeightKg = request.targetWeightKg();
+            this.targetWeightKg = targetWeightKg;
         }
-        if (request.pbf() == null) {
+        if (pbf == null) {
             this.pbf = null;
         } else {
-            this.pbf = request.pbf();
+            this.pbf = pbf;
         }
-        if (request.targetPbf() == null) {
+        if (targetPbf == null) {
             this.targetPbf = null;
         } else {
-            this.targetPbf = request.targetPbf();
+            this.targetPbf = targetPbf;
         }
-        if (request.targetStepCount() == null) {
+        if (targetStepCount == null) {
             this.targetStepCount = null;
         } else {
-            this.targetStepCount = request.targetStepCount();
+            this.targetStepCount = targetStepCount;
         }
         this.dailyStepCount = 0;
         this.registrationStatus = RegistrationStatus.COMPLETE;

--- a/src/main/java/com/fitpet/server/user/presentation/controller/UserController.java
+++ b/src/main/java/com/fitpet/server/user/presentation/controller/UserController.java
@@ -30,31 +30,32 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<UserDto> create(@Valid @RequestBody UserCreateRequest userCreateRequest) {
-        UserDto createdUser = userService.createUser(userCreateRequest);
+        UserDto createdUser = UserDto.from(userService.createUser(userCreateRequest.toCommand()));
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
     @GetMapping
     public ResponseEntity<UserDto> find(@AuthUser Long userId) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findUser(userId));
+        return ResponseEntity.status(HttpStatus.OK).body(UserDto.from(userService.findUser(userId)));
     }
 
     @PatchMapping
     public ResponseEntity<UserDto> update(@AuthUser Long userId,
                                           @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.updateUser(userId, userUpdateRequest));
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(UserDto.from(userService.updateUser(userId, userUpdateRequest.toCommand())));
     }
 
     @PostMapping("/profile-image")
     public ResponseEntity<ProfileImageUpdateResponse> updateProfileImage(@AuthUser Long userId) {
-        ProfileImageUpdateResponse response = userService.updateProfileImage(userId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ProfileImageUpdateResponse.from(userService.updateProfileImage(userId)));
     }
 
     @PatchMapping("/signUp/complete")
     public ResponseEntity<UserDto> updateUserInfo(@AuthUser Long userId,
                                                   @Valid @RequestBody UserInputInfoRequest userInputInfoRequest) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.inputInfo(userId, userInputInfoRequest));
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(UserDto.from(userService.inputInfo(userId, userInputInfoRequest.toCommand())));
     }
 
     @DeleteMapping("/profile-image")

--- a/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
@@ -2,6 +2,7 @@ package com.fitpet.server.user.presentation.dto;
 
 import com.fitpet.server.pet.domain.entity.PetExpression;
 import com.fitpet.server.pet.domain.entity.PetType;
+import com.fitpet.server.user.application.dto.PetSummaryResult;
 import lombok.Builder;
 
 @Builder
@@ -13,4 +14,18 @@ public record PetSummaryDto(
         Long exp,
         PetExpression expression
 ) {
+    public static PetSummaryDto from(PetSummaryResult result) {
+        if (result == null) {
+            return null;
+        }
+
+        return PetSummaryDto.builder()
+            .petId(result.petId())
+            .name(result.name())
+            .petType(result.petType())
+            .color(result.color())
+            .exp(result.exp())
+            .expression(result.expression())
+            .build();
+    }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.user.presentation.dto;
+
+import com.fitpet.server.pet.domain.entity.PetExpression;
+import com.fitpet.server.pet.domain.entity.PetType;
+
+public record PetSummaryDto(
+        Long petId,
+        String name,
+        PetType petType,
+        String color,
+        Long exp,
+        PetExpression expression
+) {
+}

--- a/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
@@ -2,7 +2,9 @@ package com.fitpet.server.user.presentation.dto;
 
 import com.fitpet.server.pet.domain.entity.PetExpression;
 import com.fitpet.server.pet.domain.entity.PetType;
+import lombok.Builder;
 
+@Builder
 public record PetSummaryDto(
         Long petId,
         String name,

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
@@ -28,6 +28,7 @@ public record UserDto(
             userId,
             email,
             nickname,
+            profileImageUrl,
             age,
             gender,
             weightKg,

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
@@ -6,19 +6,39 @@ import lombok.Builder;
 
 @Builder
 public record UserDto(
-        Long userId,
-        String email,
-        String nickname,
-        Integer age,
-        Gender gender,
-        Double weightKg,
-        Double targetWeightKg,
-        Double heightCm,
-        Double pbf,
-        Double targetPbf,
-        Integer targetStepCount,
-        Integer dailyStepCount,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+    Long userId,
+    String email,
+    String nickname,
+    Integer age,
+    Gender gender,
+    Double weightKg,
+    Double targetWeightKg,
+    Double heightCm,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount,
+    Integer dailyStepCount,
+    PetSummaryDto pet,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
+    public UserDto withPet(PetSummaryDto pet) {
+        return new UserDto(
+            userId,
+            email,
+            nickname,
+            age,
+            gender,
+            weightKg,
+            targetWeightKg,
+            heightCm,
+            pbf,
+            targetPbf,
+            targetStepCount,
+            dailyStepCount,
+            pet,
+            createdAt,
+            updatedAt
+        );
+    }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.presentation.dto;
 
+import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.domain.entity.Gender;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -42,5 +43,30 @@ public record UserDto(
             createdAt,
             updatedAt
         );
+    }
+
+    public static UserDto from(UserResult result) {
+        if (result == null) {
+            return null;
+        }
+
+        return UserDto.builder()
+            .userId(result.userId())
+            .email(result.email())
+            .nickname(result.nickname())
+            .profileImageUrl(result.profileImageUrl())
+            .age(result.age())
+            .gender(result.gender())
+            .weightKg(result.weightKg())
+            .targetWeightKg(result.targetWeightKg())
+            .heightCm(result.heightCm())
+            .pbf(result.pbf())
+            .targetPbf(result.targetPbf())
+            .targetStepCount(result.targetStepCount())
+            .dailyStepCount(result.dailyStepCount())
+            .pet(PetSummaryDto.from(result.pet()))
+            .createdAt(result.createdAt())
+            .updatedAt(result.updatedAt())
+            .build();
     }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/request/UserCreateRequest.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.presentation.dto.request;
 
+import com.fitpet.server.user.application.dto.UserCreateCommand;
 import com.fitpet.server.user.domain.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -49,4 +50,19 @@ public record UserCreateRequest(
         @NotNull
         Integer targetStepCount
 ) {
+    public UserCreateCommand toCommand() {
+        return new UserCreateCommand(
+                email,
+                password,
+                nickname,
+                age,
+                gender,
+                weightKg,
+                targetWeightKg,
+                heightCm,
+                pbf,
+                targetPbf,
+                targetStepCount
+        );
+    }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/request/UserInputInfoRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/request/UserInputInfoRequest.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.presentation.dto.request;
 
+import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.domain.entity.Gender;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -36,4 +37,17 @@ public record UserInputInfoRequest(
 
         Integer targetStepCount
 ) {
+    public UserInputInfoCommand toCommand() {
+        return new UserInputInfoCommand(
+            nickname,
+            age,
+            gender,
+            weightKg,
+            heightCm,
+            targetWeightKg,
+            pbf,
+            targetPbf,
+            targetStepCount
+        );
+    }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/request/UserUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.presentation.dto.request;
 
+import com.fitpet.server.user.application.dto.UserUpdateCommand;
 import com.fitpet.server.user.domain.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
@@ -25,4 +26,19 @@ public record UserUpdateRequest(
         Double targetPbf,
         Integer targetStepCount
 ) {
+    public UserUpdateCommand toCommand() {
+        return new UserUpdateCommand(
+            email,
+            password,
+            nickname,
+            age,
+            gender,
+            weightKg,
+            targetWeightKg,
+            heightCm,
+            pbf,
+            targetPbf,
+            targetStepCount
+        );
+    }
 }

--- a/src/main/java/com/fitpet/server/user/presentation/dto/response/ProfileImageUpdateResponse.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/response/ProfileImageUpdateResponse.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.presentation.dto.response;
 
+import com.fitpet.server.user.application.dto.ProfileImageUpdateResult;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,4 +9,11 @@ import lombok.Getter;
 public class ProfileImageUpdateResponse {
     private String imageKey;
     private String uploadUrl;
+
+    public static ProfileImageUpdateResponse from(ProfileImageUpdateResult result) {
+        if (result == null) {
+            return null;
+        }
+        return new ProfileImageUpdateResponse(result.imageKey(), result.uploadUrl());
+    }
 }


### PR DESCRIPTION
## 📌 PR 요약

- `GET /users` 응답에 반려동물 정보를 함께 반환하도록 개선했습니다.
- 사용자 조회 시 `ownerId` 기준으로 펫을 조회해 `pet` 필드에 요약 정보를 포함합니다.
- 펫이 없는 경우 `pet`은 `null`로 응답합니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [x] 관련 API 변경
- [x] 기타 리팩터링

- `UserDto`에 `pet` 필드 추가
- `PetSummaryDto` 추가 (`record + @Builder`)
- `UserServiceImpl.findUser()`에서 사용자 + 펫 요약 정보 병합 응답 처리
- `UserMapper`에서 `pet` 필드 매핑 ignore 처리


## 🧪 테스트 방법

- PostMan
<img width="1296" height="898" alt="image" src="https://github.com/user-attachments/assets/9a2fda6c-fce5-4cb0-9c4a-5bc31a65578f" />


## 📎 관련 이슈


## 추가 전달 사항

- `GET /users` 응답 스키마가 변경되었습니다. (신규 필드: `pet`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 반려동물 요약 정보가 추가되었습니다. 반려동물의 이름, 종류, 색상, 경험치 및 표현이 함께 표시됩니다.
  * 사용자 조회·생성·수정 응답이 확장되어 반려동물 정보와 프로필 이미지 URL을 포함한 더 풍부한 사용자 정보를 반환합니다.
  * 프로필 이미지 업데이트 시 업로드용 URL과 이미지 키를 함께 제공하여 클라이언트에서 직접 업로드를 진행할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->