### PR TITLE
[Chore] 시간대 설정 중복 제거 및 KST 설정 단일화

### DIFF
--- a/src/main/java/com/fitpet/server/FitPetApplication.java
+++ b/src/main/java/com/fitpet/server/FitPetApplication.java
@@ -1,5 +1,6 @@
 package com.fitpet.server;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -9,6 +10,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class FitPetApplication {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        System.setProperty("user.timezone", "Asia/Seoul");
         SpringApplication.run(FitPetApplication.class, args);
     }
 

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -29,6 +29,7 @@ public interface UserMapper {
     User toEntity(UserCreateRequest request);
 
     @Mapping(source = "id", target = "userId")
+    @Mapping(target = "pet", ignore = true)
     UserDto toDto(User user);
 
 }

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.application.service;
 
+import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.shared.s3.type.ImageType;
 import com.fitpet.server.user.application.mapper.UserMapper;
@@ -9,6 +10,7 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import com.fitpet.server.user.presentation.dto.PetSummaryDto;
 import com.fitpet.server.user.presentation.dto.UserDto;
 import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
@@ -30,6 +32,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PetRepository petRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
@@ -52,8 +55,18 @@ public class UserServiceImpl implements UserService {
         User user = findUserById(userId);
 
         UserDto baseDto = userMapper.toDto(user);
+        PetSummaryDto petSummary = petRepository.findByOwnerId(userId)
+            .map(pet -> PetSummaryDto.builder()
+                .petId(pet.getId())
+                .name(pet.getName())
+                .petType(pet.getPetType())
+                .color(pet.getColor())
+                .exp(pet.getExp())
+                .expression(pet.getExpression())
+                .build())
+            .orElse(null);
 
-        return enrichWithPresignedUrl(baseDto, user.getProfileImageUrl());
+        return enrichWithPresignedUrl(baseDto.withPet(petSummary), user.getProfileImageUrl());
     }
 
     private UserDto enrichWithPresignedUrl(UserDto dto, String imageKey) {
@@ -77,6 +90,7 @@ public class UserServiceImpl implements UserService {
             .targetPbf(dto.targetPbf())
             .targetStepCount(dto.targetStepCount())
             .dailyStepCount(dto.dailyStepCount())
+            .pet(dto.pet())
             .createdAt(dto.createdAt())
             .updatedAt(dto.updatedAt())
             .build();

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.user.application.service;
 
+import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.user.application.dto.GenderRankingResult;
 import com.fitpet.server.user.application.dto.RankingResult;
 import com.fitpet.server.user.application.dto.UserRanking;
@@ -11,6 +12,7 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import com.fitpet.server.user.presentation.dto.PetSummaryDto;
 import com.fitpet.server.user.presentation.dto.UserDto;
 import com.fitpet.server.user.presentation.dto.request.UserCreateRequest;
 import com.fitpet.server.user.presentation.dto.request.UserInputInfoRequest;
@@ -31,6 +33,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PetRepository petRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
 
@@ -52,7 +55,20 @@ public class UserServiceImpl implements UserService {
     public UserDto findUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
-        return userMapper.toDto(user);
+        UserDto userDto = userMapper.toDto(user);
+
+        PetSummaryDto petSummary = petRepository.findByOwnerId(userId)
+                .map(pet -> PetSummaryDto.builder()
+                        .petId(pet.getId())
+                        .name(pet.getName())
+                        .petType(pet.getPetType())
+                        .color(pet.getColor())
+                        .exp(pet.getExp())
+                        .expression(pet.getExpression())
+                        .build())
+                .orElse(null);
+
+        return userDto.withPet(petSummary);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.user.presentation.dto;
+
+import com.fitpet.server.pet.domain.entity.PetExpression;
+import com.fitpet.server.pet.domain.entity.PetType;
+
+public record PetSummaryDto(
+        Long petId,
+        String name,
+        PetType petType,
+        String color,
+        Long exp,
+        PetExpression expression
+) {
+}

--- a/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/PetSummaryDto.java
@@ -2,7 +2,9 @@ package com.fitpet.server.user.presentation.dto;
 
 import com.fitpet.server.pet.domain.entity.PetExpression;
 import com.fitpet.server.pet.domain.entity.PetType;
+import lombok.Builder;
 
+@Builder
 public record PetSummaryDto(
         Long petId,
         String name,

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
@@ -28,6 +28,7 @@ public record UserDto(
             userId,
             email,
             nickname,
+            profileImageUrl,
             age,
             gender,
             weightKg,

--- a/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
+++ b/src/main/java/com/fitpet/server/user/presentation/dto/UserDto.java
@@ -6,19 +6,39 @@ import lombok.Builder;
 
 @Builder
 public record UserDto(
-        Long userId,
-        String email,
-        String nickname,
-        Integer age,
-        Gender gender,
-        Double weightKg,
-        Double targetWeightKg,
-        Double heightCm,
-        Double pbf,
-        Double targetPbf,
-        Integer targetStepCount,
-        Integer dailyStepCount,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+    Long userId,
+    String email,
+    String nickname,
+    Integer age,
+    Gender gender,
+    Double weightKg,
+    Double targetWeightKg,
+    Double heightCm,
+    Double pbf,
+    Double targetPbf,
+    Integer targetStepCount,
+    Integer dailyStepCount,
+    PetSummaryDto pet,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
+    public UserDto withPet(PetSummaryDto pet) {
+        return new UserDto(
+            userId,
+            email,
+            nickname,
+            age,
+            gender,
+            weightKg,
+            targetWeightKg,
+            heightCm,
+            pbf,
+            targetPbf,
+            targetStepCount,
+            dailyStepCount,
+            pet,
+            createdAt,
+            updatedAt
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ spring:
   datasource:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      connection-init-sql: SET time_zone = '+09:00'
   jpa:
     hibernate:
       ddl-auto: update
@@ -14,6 +16,10 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        jdbc:
+          time_zone: Asia/Seoul
+  jackson:
+    time-zone: Asia/Seoul
 
   data:
     redis:


### PR DESCRIPTION
## 📌 PR 요약

- 시간대 설정 로직을 단순화했습니다.
- 중복되던 `TimeZoneConfig`를 제거하고, 기존 `application.yaml` + `FitPetApplication` 설정으로 KST 기준을 유지하도록 정리했습니다.

## ✅ 작업 상세 내용

- [ ] 주요 기능 구현
- [ ] 관련 API 변경
- [x] 기타 리팩터링

## 🧪 테스트 방법

- PostMan Patch 적용 후
<img width="834" height="764" alt="image" src="https://github.com/user-attachments/assets/d1ea42be-09a4-4ec9-801a-b926ff06c73d" />


## 📎 관련 이슈

## 추가 전달 사항
- DB에서 직접 수정하면 UTC 시간대입니다.
- 백엔드를 경유해야 KST로 저장됩니다.
- 기능 동작 변경 없이 시간대 설정 중복만 제거한 정리 작업입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 반려동물 정보가 추가되었습니다. 반려동물의 ID, 이름, 종류, 색상, 경험치, 표현 정보를 사용자 데이터와 함께 조회할 수 있으며, 사용자 프로필을 조회할 때마다 함께 표시됩니다.

* **유지보수**
  * 시스템의 시간대를 Asia/Seoul(UTC+9)로 통일했습니다. 데이터베이스 연결, JPA/Hibernate, 데이터 직렬화 라이브러리의 시간대 설정을 최적화하여 전체 시스템에서 일관된 시간 처리를 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->