### PR TITLE
[Refactor] Redis Pub/Sub 기반 미션 진행 실시간 전파 및 PLG 관측 환경 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     // Logback expression filters
     implementation 'org.codehaus.janino:janino:3.1.12'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
     // Validation & AOP
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // Logback expression filters
     implementation 'org.codehaus.janino:janino:3.1.12'

--- a/observability/alloy/config.promtail.yml
+++ b/observability/alloy/config.promtail.yml
@@ -44,5 +44,3 @@ scrape_configs:
           logger:
           trace_id:
           span_id:
-      - output:
-          source: message

--- a/observability/alloy/config.promtail.yml
+++ b/observability/alloy/config.promtail.yml
@@ -42,5 +42,3 @@ scrape_configs:
       - labels:
           level:
           logger:
-          trace_id:
-          span_id:

--- a/observability/alloy/config.promtail.yml
+++ b/observability/alloy/config.promtail.yml
@@ -1,9 +1,9 @@
 server:
-  http_listen_port: 9080
+  http_listen_port: 12345
   grpc_listen_port: 0
 
 positions:
-  filename: /var/lib/promtail/positions.yaml
+  filename: /var/lib/alloy/data/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/observability/docker-compose.plg.yml
+++ b/observability/docker-compose.plg.yml
@@ -1,0 +1,71 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: fitpet-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-15d}
+      - --storage.tsdb.retention.size=${PROMETHEUS_RETENTION_SIZE:-8GB}
+      - --web.enable-lifecycle
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "9090:9090"
+
+  loki:
+    image: grafana/loki:2.9.8
+    container_name: fitpet-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:2.9.8
+    container_name: fitpet-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yml
+    depends_on:
+      - loki
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - ../logs:/var/log/fitpet:ro
+      - /var/log:/host/var/log:ro
+      - promtail-data:/var/lib/promtail
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: fitpet-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+      - loki
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-change-me}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_USERS_DEFAULT_THEME: dark
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_SECURITY_DISABLE_GRAVATAR: "true"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+
+volumes:
+  prometheus-data:
+  loki-data:
+  grafana-data:
+  promtail-data:

--- a/observability/docker-compose.plg.yml
+++ b/observability/docker-compose.plg.yml
@@ -29,18 +29,24 @@ services:
     ports:
       - "3100:3100"
 
-  promtail:
-    image: grafana/promtail:2.9.8
-    container_name: fitpet-promtail
+  alloy:
+    image: grafana/alloy:v1.12.1
+    container_name: fitpet-alloy
     restart: unless-stopped
-    command: -config.file=/etc/promtail/promtail-config.yml
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - --config.format=promtail
+      - /etc/alloy/config.promtail.yml
     depends_on:
       - loki
     volumes:
-      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - ./alloy/config.promtail.yml:/etc/alloy/config.promtail.yml:ro
       - ../logs:/var/log/fitpet:ro
-      - /var/log:/host/var/log:ro
-      - promtail-data:/var/lib/promtail
+      - alloy-data:/var/lib/alloy/data
+    ports:
+      - "12345:12345"
 
   grafana:
     image: grafana/grafana:11.1.0
@@ -68,4 +74,4 @@ volumes:
   prometheus-data:
   loki-data:
   grafana-data:
-  promtail-data:
+  alloy-data:

--- a/observability/docker-compose.plg.yml
+++ b/observability/docker-compose.plg.yml
@@ -56,8 +56,8 @@ services:
       - prometheus
       - loki
     environment:
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-change-me}
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?Set GRAFANA_ADMIN_USER in your shell or external env file}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in your shell or external env file}
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_USERS_DEFAULT_THEME: dark
       GF_AUTH_ANONYMOUS_ENABLED: "false"

--- a/observability/grafana/dashboards/fitpet-ops-overview.json
+++ b/observability/grafana/dashboards/fitpet-ops-overview.json
@@ -1,0 +1,438 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"fitpet-app\"}[1m]))",
+          "legendFormat": "req/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests/s",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.03
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"fitpet-app\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"fitpet-app\"}[5m])), 1)",
+          "legendFormat": "5xx_ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 5xx Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"fitpet-app\",uri!~\"/actuator.*\"}[5m]))) * 1000",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP p95 Latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "process_cpu_usage{job=\"fitpet-app\"} * 100",
+          "legendFormat": "cpu",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process CPU Usage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=\"fitpet-app\"}[1m]))",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Status Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jvm_memory_used_bytes{job=\"fitpet-app\",area=\"heap\"}",
+          "legendFormat": "heap used",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "jvm_memory_max_bytes{job=\"fitpet-app\",area=\"heap\"}",
+          "legendFormat": "heap max",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "JVM Heap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (level) (rate({job=\"fitpet-app\"}[1m]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Throughput by Level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(10, sum by (logger) (rate({job=\"fitpet-app\",level=~\"ERROR|WARN\"}[5m])))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Warning/Error Loggers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "{job=\"fitpet-app\", level=~\"ERROR|WARN\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Warning/Error Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "fitpet",
+    "ops",
+    "plg"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "FitPet Ops Overview",
+  "uid": "fitpet-ops-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: FitPet Dashboards
+    orgId: 1
+    folder: FitPet
+    type: file
+    disableDeletion: false
+    editable: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -59,4 +59,3 @@ ruler:
     local:
       directory: /loki/rules
   rule_path: /loki/rules-temp
-  alertmanager_url: http://localhost:9093

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -1,0 +1,62 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  compactor_address: http://loki:3100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+analytics:
+  reporting_enabled: false
+
+ingester:
+  wal:
+    enabled: true
+    dir: /loki/wal
+  chunk_idle_period: 5m
+  max_chunk_age: 1h
+  chunk_target_size: 1572864
+
+limits_config:
+  retention_period: 720h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+  max_entries_limit_per_query: 5000
+  max_streams_per_user: 100000
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  delete_request_store: filesystem
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  alertmanager_url: http://localhost:9093

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,22 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+  external_labels:
+    service: fitpet
+    env: local
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: fitpet-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["host.docker.internal:8081"]
+        labels:
+          role: app

--- a/observability/prometheus/rules/fitpet-alerts.yml
+++ b/observability/prometheus/rules/fitpet-alerts.yml
@@ -1,0 +1,59 @@
+groups:
+  - name: fitpet-platform
+    interval: 30s
+    rules:
+      - alert: FitPetTargetDown
+        expr: up{job="fitpet-app"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: fitpet
+        annotations:
+          summary: "FitPet scrape target down"
+          description: "Prometheus cannot scrape {{ $labels.job }} ({{ $labels.instance }}) for more than 2 minutes."
+
+      - alert: FitPetHigh5xxErrorRate
+        expr: |
+          (
+            sum(rate(http_server_requests_seconds_count{job="fitpet-app",status=~"5.."}[5m]))
+            /
+            clamp_min(sum(rate(http_server_requests_seconds_count{job="fitpet-app"}[5m])), 1)
+          ) > 0.03
+        for: 5m
+        labels:
+          severity: warning
+          service: fitpet
+        annotations:
+          summary: "High 5xx error rate"
+          description: "5xx error ratio is above 3% for 5 minutes."
+
+      - alert: FitPetHighHttpP95Latency
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (
+              rate(http_server_requests_seconds_bucket{job="fitpet-app",uri!~"/actuator.*"}[5m])
+            )
+          ) > 1.5
+        for: 10m
+        labels:
+          severity: warning
+          service: fitpet
+        annotations:
+          summary: "HTTP p95 latency is high"
+          description: "HTTP p95 latency is over 1.5s for 10 minutes."
+
+      - alert: FitPetMissionDeliverySuccessRateLow
+        expr: |
+          (
+            sum(rate(mission_progress_delivery_total{job="fitpet-app",status="success"}[5m]))
+            /
+            clamp_min(sum(rate(mission_progress_delivery_total{job="fitpet-app",status="attempt"}[5m])), 1)
+          ) < 0.95
+        for: 5m
+        labels:
+          severity: warning
+          service: fitpet
+        annotations:
+          summary: "Mission delivery success rate dropped"
+          description: "Mission delivery success rate is below 95% for 5 minutes."

--- a/observability/prometheus/rules/fitpet-alerts.yml
+++ b/observability/prometheus/rules/fitpet-alerts.yml
@@ -45,10 +45,12 @@ groups:
 
       - alert: FitPetMissionDeliverySuccessRateLow
         expr: |
+          sum(rate(mission_progress_delivery_total{job="fitpet-app",status="attempt"}[5m])) > 0
+          and
           (
             sum(rate(mission_progress_delivery_total{job="fitpet-app",status="success"}[5m]))
             /
-            clamp_min(sum(rate(mission_progress_delivery_total{job="fitpet-app",status="attempt"}[5m])), 1)
+            sum(rate(mission_progress_delivery_total{job="fitpet-app",status="attempt"}[5m]))
           ) < 0.95
         for: 5m
         labels:

--- a/observability/promtail/promtail-config.yml
+++ b/observability/promtail/promtail-config.yml
@@ -1,0 +1,48 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    batchwait: 1s
+    batchsize: 1048576
+    backoff_config:
+      min_period: 500ms
+      max_period: 5s
+      max_retries: 10
+
+scrape_configs:
+  - job_name: fitpet-app-json-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: fitpet-app
+          parser: json
+          __path__: /var/log/fitpet/*-json*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            ts: '"@timestamp"'
+            level: level
+            logger: logger_name
+            thread: thread_name
+            message: message
+            stacktrace: stack_trace
+            trace_id: traceId
+            span_id: spanId
+      - timestamp:
+          source: ts
+          format: RFC3339Nano
+          fallback_formats:
+            - RFC3339
+      - labels:
+          level:
+          logger:
+          trace_id:
+          span_id:
+      - output:
+          source: message

--- a/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
@@ -124,7 +124,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     }
 
     @Override
-    public DailyWalkResult createDailyWalk(@NotNull Long userId, DailyWalkCreateCommand cmd) {
+    public DailyWalkResult createDailyWalk(@NotNull Long userId, @NotNull DailyWalkCreateCommand cmd) {
         log.debug("[DailyWalkService] 생성 요청: userId={}, step={}, distanceKm={}, burnCalories={}, date={}",
                 userId, cmd.step(), cmd.distanceKm(), cmd.burnCalories(), cmd.date());
 
@@ -173,7 +173,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     }
 
     @Override
-    public void updateDailyWalkStep(@NotNull Long userId, DailyWalkStepUpdateCommand cmd) {
+    public void updateDailyWalkStep(@NotNull Long userId, @NotNull DailyWalkStepUpdateCommand cmd) {
         log.debug("[DailyWalkService] 걸음수 수정 요청 userId={}, cmd={}", userId, cmd);
 
         String dateStr = cmd.date().toString();

--- a/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailywalk/application/service/DailyWalkServiceImpl.java
@@ -17,8 +17,6 @@ import com.fitpet.server.shared.exception.ErrorCode;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -56,7 +54,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<DailyWalkResult> getAllByUserId(@NotNull Long userId) {
+    public List<DailyWalkResult> getAllByUserId(Long userId) {
         log.debug("[DailyWalkService] 전체 조회 요청: userId={}", userId);
         List<DailyWalk> result = dailyWalkRepository.findAllByUser_Id(userId);
         log.info("[DailyWalkService] 전체 조회 완료: userId={}, count={}", userId, result.size());
@@ -65,8 +63,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
 
     @Override
     @Transactional(readOnly = true)
-    public DailyWalkResult getDailyWalkByUserIdAndDate(@NotNull Long userId,
-                                                       @NotNull @PastOrPresent LocalDate date) {
+    public DailyWalkResult getDailyWalkByUserIdAndDate(Long userId, LocalDate date) {
         log.debug("[DailyWalkService] 사용자의 해당 날짜 조회 요청 : userId={}, date={} ", userId, date);
 
         if (date.equals(LocalDate.now())) {
@@ -88,7 +85,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<DailyStepSummaryResult> getWeeklySteps(@NotNull Long userId) {
+    public List<DailyStepSummaryResult> getWeeklySteps(Long userId) {
         LocalDate today = LocalDate.now();
         LocalDate startDate = today.minusDays(6);
         LocalDateTime start = startDate.atStartOfDay();
@@ -124,7 +121,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     }
 
     @Override
-    public DailyWalkResult createDailyWalk(@NotNull Long userId, @NotNull DailyWalkCreateCommand cmd) {
+    public DailyWalkResult createDailyWalk(Long userId, DailyWalkCreateCommand cmd) {
         log.debug("[DailyWalkService] 생성 요청: userId={}, step={}, distanceKm={}, burnCalories={}, date={}",
                 userId, cmd.step(), cmd.distanceKm(), cmd.burnCalories(), cmd.date());
 
@@ -173,7 +170,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     }
 
     @Override
-    public void updateDailyWalkStep(@NotNull Long userId, @NotNull DailyWalkStepUpdateCommand cmd) {
+    public void updateDailyWalkStep(Long userId, DailyWalkStepUpdateCommand cmd) {
         log.debug("[DailyWalkService] 걸음수 수정 요청 userId={}, cmd={}", userId, cmd);
 
         String dateStr = cmd.date().toString();
@@ -205,7 +202,7 @@ public class DailyWalkServiceImpl implements DailyWalkService {
     }
 
     @Override
-    public void deleteDailyWalk(@NotNull Long userId, @NotNull Long dailyWalkId) {
+    public void deleteDailyWalk(Long userId, Long dailyWalkId) {
         log.debug("[DailyWalkService] 삭제 요청: userId={}, dailyWalkId={}", userId, dailyWalkId);
 
         DailyWalk dailyWalk = dailyWalkRepository.findById(dailyWalkId)

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionProgressEvent.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionProgressEvent.java
@@ -1,0 +1,22 @@
+package com.fitpet.server.mission.application.dto;
+
+import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MissionType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record MissionProgressEvent(
+        String eventId,
+        MissionProgressEventType eventType,
+        Long userId,
+        Long missionCheckId,
+        Long missionId,
+        MissionCategory category,
+        MissionType periodType,
+        BigDecimal goalValue,
+        BigDecimal progressValue,
+        boolean completed,
+        LocalDateTime completedAt,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionProgressEventType.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionProgressEventType.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.mission.application.dto;
+
+public enum MissionProgressEventType {
+    UPSERT,
+    STEP_PROGRESS,
+    MEAL_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
@@ -380,7 +380,23 @@ public class MissionCheckServiceImpl implements MissionCheckService {
                 }
             }
         }
-        return isThreeMealTitle(title);
+        if (isThreeMealTitle(title)) {
+            return true;
+        }
+        return isGenericMealMissionTitle(title);
+    }
+
+    private static boolean isGenericMealMissionTitle(String title) {
+        return title != null
+                && !title.isBlank()
+                && !hasSpecificMealTimingKeyword(title);
+    }
+
+    private static boolean hasSpecificMealTimingKeyword(String title) {
+        return matchesBreakfastTitle(title)
+                || matchesLunchTitle(title)
+                || matchesDinnerTitle(title)
+                || isThreeMealTitle(title);
     }
 
     private static boolean matchesBreakfastTitle(String title) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
@@ -4,6 +4,8 @@ import com.fitpet.server.meal.domain.entity.MealTime;
 import com.fitpet.server.meal.domain.repository.MealRepository;
 import com.fitpet.server.mission.application.dto.MissionCheckCommand;
 import com.fitpet.server.mission.application.dto.MissionCheckResult;
+import com.fitpet.server.mission.application.dto.MissionProgressEvent;
+import com.fitpet.server.mission.application.dto.MissionProgressEventType;
 import com.fitpet.server.mission.application.dto.MissionProgressResult;
 import com.fitpet.server.mission.application.dto.MissionProgressUpdateItem;
 import com.fitpet.server.mission.application.mapper.MissionCheckMapper;
@@ -28,6 +30,7 @@ import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -46,6 +49,7 @@ public class MissionCheckServiceImpl implements MissionCheckService {
     private final UserRepository userRepository;
     private final PetExpressionService petExpressionService;
     private final MissionCompletionService missionCompletionService;
+    private final MissionProgressEventPublisher missionProgressEventPublisher;
 
     @Override
     public MissionCheckResult upsertMissionCheck(Long missionId, Long userId, MissionCheckCommand request) {
@@ -58,6 +62,9 @@ public class MissionCheckServiceImpl implements MissionCheckService {
 
         UpdateResult result = upsertMissionCheck(mission, user, period, request.progressValue());
         MissionCheck saved = missionCheckRepository.save(result.missionCheck());
+        if (result.changed()) {
+            publishMissionProgressEvent(saved, MissionProgressEventType.UPSERT);
+        }
 
         log.info("[MissionCheckService] 수행 여부 저장: missionCheckId={}, missionId={}, userId={}",
                 saved.getId(), missionId, userId);
@@ -89,6 +96,7 @@ public class MissionCheckServiceImpl implements MissionCheckService {
     @Override
     public MissionCheckResult completeMissionCheck(Long userId, Long missionCheckId) {
         MissionCheck completed = missionCompletionService.completeMission(userId, missionCheckId);
+        publishMissionProgressEvent(completed, MissionProgressEventType.COMPLETED);
         petExpressionService.updateExpression(userId, PetExpression.HAPPY);
         log.info("[MissionCheckService] 수행 완료 처리: missionCheckId={}, userId={}", missionCheckId, userId);
         return missionCheckMapper.toDto(completed);
@@ -226,8 +234,11 @@ public class MissionCheckServiceImpl implements MissionCheckService {
 
         if (existing.isPresent()) {
             MissionCheck current = existing.get();
+            BigDecimal beforeProgress = current.getProgressValue();
+            boolean beforeCompleted = current.isCompleted();
             applyProgressIfActive(current, progressValue);
-            return new UpdateResult(current, List.of());
+            boolean changed = hasMissionStateChanged(beforeProgress, beforeCompleted, current);
+            return new UpdateResult(current, List.of(), changed);
         }
 
         BigDecimal progress = defaultProgress(progressValue);
@@ -242,7 +253,7 @@ public class MissionCheckServiceImpl implements MissionCheckService {
                 .completedAt(null)
                 .build();
 
-        return new UpdateResult(created, List.of());
+        return new UpdateResult(created, List.of(), true);
     }
 
     private void applyProgressIfActive(MissionCheck current, BigDecimal delta) {
@@ -264,10 +275,11 @@ public class MissionCheckServiceImpl implements MissionCheckService {
             BigDecimal newProgress = current.add(delta);
             check.updateProgress(newProgress, false, null);
             missionCheckRepository.save(check);
+            publishMissionProgressEvent(check, MissionProgressEventType.STEP_PROGRESS);
             updated.add(toUpdateItem(check));
         }
 
-        return new UpdateResult(null, updated);
+        return new UpdateResult(null, updated, !updated.isEmpty());
     }
 
     private UpdateResult applyMealProgress(
@@ -289,10 +301,49 @@ public class MissionCheckServiceImpl implements MissionCheckService {
             BigDecimal newProgress = current.add(BigDecimal.ONE);
             check.updateProgress(newProgress, false, null);
             missionCheckRepository.save(check);
+            publishMissionProgressEvent(check, MissionProgressEventType.MEAL_PROGRESS);
             updated.add(toUpdateItem(check));
         }
 
-        return new UpdateResult(null, updated);
+        return new UpdateResult(null, updated, !updated.isEmpty());
+    }
+
+    private void publishMissionProgressEvent(MissionCheck check, MissionProgressEventType eventType) {
+        Mission mission = check.getMission();
+        MissionProgressEvent event = new MissionProgressEvent(
+                UUID.randomUUID().toString(),
+                eventType,
+                check.getUser().getId(),
+                check.getId(),
+                mission.getId(),
+                mission.getCategory(),
+                check.getPeriodType(),
+                mission.getGoal(),
+                check.getProgressValue(),
+                check.isCompleted(),
+                check.getCompletedAt(),
+                LocalDateTime.now()
+        );
+        missionProgressEventPublisher.publishAfterCommit(event);
+    }
+
+    private static boolean hasMissionStateChanged(
+            BigDecimal beforeProgress,
+            boolean beforeCompleted,
+            MissionCheck current
+    ) {
+        boolean progressChanged = !isEqualProgress(beforeProgress, current.getProgressValue());
+        return progressChanged || beforeCompleted != current.isCompleted();
+    }
+
+    private static boolean isEqualProgress(BigDecimal left, BigDecimal right) {
+        if (left == null && right == null) {
+            return true;
+        }
+        if (left == null || right == null) {
+            return false;
+        }
+        return left.compareTo(right) == 0;
     }
 
     private List<MissionCheck> findActiveChecks(Long userId, MissionCategory category, LocalDate date) {
@@ -405,7 +456,8 @@ public class MissionCheckServiceImpl implements MissionCheckService {
 
     private record UpdateResult(
             MissionCheck missionCheck,
-            List<MissionProgressUpdateItem> updatedItems
+            List<MissionProgressUpdateItem> updatedItems,
+            boolean changed
     ) {
     }
 

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionProgressEventPublisher.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionProgressEventPublisher.java
@@ -1,0 +1,8 @@
+package com.fitpet.server.mission.application.service;
+
+import com.fitpet.server.mission.application.dto.MissionProgressEvent;
+
+public interface MissionProgressEventPublisher {
+
+    void publishAfterCommit(MissionProgressEvent event);
+}

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionProgressStreamService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionProgressStreamService.java
@@ -1,0 +1,156 @@
+package com.fitpet.server.mission.application.service;
+
+import com.fitpet.server.mission.application.dto.MissionProgressEvent;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@Service
+public class MissionProgressStreamService {
+
+    private static final long EMITTER_TIMEOUT_MS = 60L * 60L * 1000L;
+    private static final long HEARTBEAT_INTERVAL_MS = 30_000L;
+    private static final String DELIVERY_METRIC = "mission.progress.delivery.total";
+    private static final String DELIVERY_LATENCY_METRIC = "mission.progress.delivery.latency";
+    private static final String SUBSCRIPTION_METRIC = "mission.progress.sse.subscription.total";
+    private static final String ACTIVE_EMITTER_METRIC = "mission.progress.sse.emitters.active";
+
+    private final MeterRegistry meterRegistry;
+
+    private final Map<Long, Map<String, SseEmitter>> emittersByUser = new ConcurrentHashMap<>();
+    private final AtomicInteger activeEmitterCount = new AtomicInteger();
+
+    public MissionProgressStreamService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+        Gauge.builder(ACTIVE_EMITTER_METRIC, activeEmitterCount, AtomicInteger::get)
+            .description("Number of active SSE emitters for mission progress stream")
+            .register(meterRegistry);
+    }
+
+    public SseEmitter subscribe(Long userId) {
+        String emitterId = UUID.randomUUID().toString();
+        SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
+
+        emittersByUser
+                .computeIfAbsent(userId, ignored -> new ConcurrentHashMap<>())
+                .put(emitterId, emitter);
+        activeEmitterCount.incrementAndGet();
+        meterRegistry.counter(SUBSCRIPTION_METRIC).increment();
+
+        emitter.onCompletion(() -> removeEmitter(userId, emitterId));
+        emitter.onTimeout(() -> removeEmitter(userId, emitterId));
+        emitter.onError(ex -> removeEmitter(userId, emitterId));
+
+        sendConnectedEvent(userId, emitter);
+        return emitter;
+    }
+
+    public void emitMissionProgress(MissionProgressEvent event) {
+        Map<String, SseEmitter> userEmitters = emittersByUser.get(event.userId());
+        if (userEmitters == null || userEmitters.isEmpty()) {
+            return;
+        }
+
+        String eventType = event.eventType().name();
+        List<String> disconnectedEmitterIds = new ArrayList<>();
+
+        userEmitters.forEach((emitterId, emitter) -> {
+            meterRegistry.counter(DELIVERY_METRIC, "event_type", eventType, "status", "attempt").increment();
+            boolean sent = sendEvent(emitter, "mission-progress", event.eventId(), event);
+            if (!sent) {
+                meterRegistry.counter(DELIVERY_METRIC, "event_type", eventType, "status", "failure").increment();
+                disconnectedEmitterIds.add(emitterId);
+                return;
+            }
+            meterRegistry.counter(DELIVERY_METRIC, "event_type", eventType, "status", "success").increment();
+            recordDeliveryLatency(event, eventType);
+        });
+
+        disconnectedEmitterIds.forEach(emitterId -> removeEmitter(event.userId(), emitterId));
+    }
+
+    @Scheduled(fixedDelay = HEARTBEAT_INTERVAL_MS)
+    public void sendHeartbeat() {
+        emittersByUser.forEach((userId, emitters) -> {
+            List<String> disconnectedEmitterIds = new ArrayList<>();
+            emitters.forEach((emitterId, emitter) -> {
+                boolean sent = sendEvent(emitter, "ping", null, "keepalive");
+                if (!sent) {
+                    disconnectedEmitterIds.add(emitterId);
+                }
+            });
+            disconnectedEmitterIds.forEach(emitterId -> removeEmitter(userId, emitterId));
+        });
+    }
+
+    private void sendConnectedEvent(Long userId, SseEmitter emitter) {
+        Map<String, Object> payload = Map.of(
+                "status", "subscribed",
+                "userId", userId,
+                "subscribedAt", LocalDateTime.now()
+        );
+        boolean sent = sendEvent(emitter, "connected", null, payload);
+        if (!sent) {
+            emitter.complete();
+        }
+    }
+
+    private boolean sendEvent(SseEmitter emitter, String eventName, String eventId, Object payload) {
+        try {
+            SseEmitter.SseEventBuilder builder = SseEmitter.event()
+                    .name(eventName)
+                    .data(payload);
+
+            if (eventId != null) {
+                builder.id(eventId);
+            }
+
+            emitter.send(builder);
+            return true;
+        } catch (IOException | IllegalStateException e) {
+            return false;
+        }
+    }
+
+    private void recordDeliveryLatency(MissionProgressEvent event, String eventType) {
+        if (event.occurredAt() == null) {
+            return;
+        }
+        Duration latency = Duration.between(event.occurredAt(), LocalDateTime.now());
+        if (latency.isNegative()) {
+            return;
+        }
+        Timer.builder(DELIVERY_LATENCY_METRIC)
+            .tag("event_type", eventType)
+            .register(meterRegistry)
+            .record(latency);
+    }
+
+    private void removeEmitter(Long userId, String emitterId) {
+        Map<String, SseEmitter> emitters = emittersByUser.get(userId);
+        if (emitters == null) {
+            return;
+        }
+        SseEmitter removed = emitters.remove(emitterId);
+        if (removed != null) {
+            activeEmitterCount.decrementAndGet();
+        }
+        if (emitters.isEmpty()) {
+            emittersByUser.remove(userId);
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisChannels.java
+++ b/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisChannels.java
@@ -1,0 +1,9 @@
+package com.fitpet.server.mission.infra.redis;
+
+public final class MissionProgressRedisChannels {
+
+    public static final String MISSION_PROGRESS = "mission:progress";
+
+    private MissionProgressRedisChannels() {
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisPublisher.java
+++ b/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisPublisher.java
@@ -1,0 +1,56 @@
+package com.fitpet.server.mission.infra.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fitpet.server.mission.application.dto.MissionProgressEvent;
+import com.fitpet.server.mission.application.service.MissionProgressEventPublisher;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MissionProgressRedisPublisher implements MissionProgressEventPublisher {
+
+    private static final String PUBLISH_METRIC = "mission.progress.publish.total";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void publishAfterCommit(MissionProgressEvent event) {
+        if (isTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publishNow(event);
+                }
+            });
+            return;
+        }
+        publishNow(event);
+    }
+
+    private boolean isTransactionActive() {
+        return TransactionSynchronizationManager.isSynchronizationActive()
+                && TransactionSynchronizationManager.isActualTransactionActive();
+    }
+
+    private void publishNow(MissionProgressEvent event) {
+        String eventType = event.eventType().name();
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            stringRedisTemplate.convertAndSend(MissionProgressRedisChannels.MISSION_PROGRESS, payload);
+            meterRegistry.counter(PUBLISH_METRIC, "event_type", eventType, "status", "success").increment();
+        } catch (JsonProcessingException e) {
+            meterRegistry.counter(PUBLISH_METRIC, "event_type", eventType, "status", "failure").increment();
+            log.warn("[MissionProgressRedisPublisher] 이벤트 직렬화 실패: eventId={}", event.eventId(), e);
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisPublisher.java
+++ b/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisPublisher.java
@@ -51,6 +51,10 @@ public class MissionProgressRedisPublisher implements MissionProgressEventPublis
         } catch (JsonProcessingException e) {
             meterRegistry.counter(PUBLISH_METRIC, "event_type", eventType, "status", "failure").increment();
             log.warn("[MissionProgressRedisPublisher] 이벤트 직렬화 실패: eventId={}", event.eventId(), e);
+        } catch (Exception e) {
+            meterRegistry.counter(PUBLISH_METRIC, "event_type", eventType, "status", "failure").increment();
+            log.warn("[MissionProgressRedisPublisher] Redis publish 실패: eventId={}, eventType={}",
+                    event.eventId(), eventType, e);
         }
     }
 }

--- a/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisSubscriber.java
+++ b/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisSubscriber.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.mission.infra.redis;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fitpet.server.mission.application.dto.MissionProgressEvent;
 import com.fitpet.server.mission.application.service.MissionProgressStreamService;
@@ -26,13 +27,22 @@ public class MissionProgressRedisSubscriber implements MessageListener {
     public void onMessage(Message message, byte[] pattern) {
         String payload = new String(message.getBody(), StandardCharsets.UTF_8);
         meterRegistry.counter(CONSUME_METRIC, "status", "received").increment();
+
+        MissionProgressEvent event;
         try {
-            MissionProgressEvent event = objectMapper.readValue(payload, MissionProgressEvent.class);
+            event = objectMapper.readValue(payload, MissionProgressEvent.class);
+        } catch (JsonProcessingException e) {
+            meterRegistry.counter(CONSUME_METRIC, "status", "decode_failure").increment();
+            log.warn("[MissionProgressRedisSubscriber] 이벤트 역직렬화 실패: payloadSize={}", payload.length(), e);
+            return;
+        }
+
+        try {
             missionProgressStreamService.emitMissionProgress(event);
             meterRegistry.counter(CONSUME_METRIC, "status", "processed").increment();
         } catch (Exception e) {
-            meterRegistry.counter(CONSUME_METRIC, "status", "decode_failure").increment();
-            log.warn("[MissionProgressRedisSubscriber] 이벤트 역직렬화 실패: payload={}", payload, e);
+            meterRegistry.counter(CONSUME_METRIC, "status", "emit_failure").increment();
+            log.warn("[MissionProgressRedisSubscriber] 이벤트 전달 실패: eventId={}", event.eventId(), e);
         }
     }
 }

--- a/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisSubscriber.java
+++ b/src/main/java/com/fitpet/server/mission/infra/redis/MissionProgressRedisSubscriber.java
@@ -1,0 +1,38 @@
+package com.fitpet.server.mission.infra.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fitpet.server.mission.application.dto.MissionProgressEvent;
+import com.fitpet.server.mission.application.service.MissionProgressStreamService;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MissionProgressRedisSubscriber implements MessageListener {
+
+    private static final String CONSUME_METRIC = "mission.progress.consume.total";
+
+    private final ObjectMapper objectMapper;
+    private final MissionProgressStreamService missionProgressStreamService;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String payload = new String(message.getBody(), StandardCharsets.UTF_8);
+        meterRegistry.counter(CONSUME_METRIC, "status", "received").increment();
+        try {
+            MissionProgressEvent event = objectMapper.readValue(payload, MissionProgressEvent.class);
+            missionProgressStreamService.emitMissionProgress(event);
+            meterRegistry.counter(CONSUME_METRIC, "status", "processed").increment();
+        } catch (Exception e) {
+            meterRegistry.counter(CONSUME_METRIC, "status", "decode_failure").increment();
+            log.warn("[MissionProgressRedisSubscriber] 이벤트 역직렬화 실패: payload={}", payload, e);
+        }
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/presentation/controller/MissionProgressStreamController.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/controller/MissionProgressStreamController.java
@@ -1,0 +1,23 @@
+package com.fitpet.server.mission.presentation.controller;
+
+import com.fitpet.server.mission.application.service.MissionProgressStreamService;
+import com.fitpet.server.shared.annotation.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missions/progress")
+public class MissionProgressStreamController {
+
+    private final MissionProgressStreamService missionProgressStreamService;
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthUser Long userId) {
+        return missionProgressStreamService.subscribe(userId);
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -3,6 +3,8 @@ package com.fitpet.server.shared.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fitpet.server.mission.infra.redis.MissionProgressRedisChannels;
+import com.fitpet.server.mission.infra.redis.MissionProgressRedisSubscriber;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +23,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -82,6 +86,20 @@ public class RedisConfig {
         StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
         return stringRedisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MissionProgressRedisSubscriber missionProgressRedisSubscriber
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(
+                missionProgressRedisSubscriber,
+                new ChannelTopic(MissionProgressRedisChannels.MISSION_PROGRESS)
+        );
+        return container;
     }
 
     @Bean

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,3 +1,7 @@
 spring:
   datasource:
     url: ${DB_URL}
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,3 +92,21 @@ fcm:
 springdoc:
   swagger-ui:
     disable-swagger-default-url: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        mission.progress.delivery.latency: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,8 +67,10 @@ oauth:
     user-info-uri: ${spring.security.oauth2.client.provider.kakao.user-info-uri}
 
 logging:
+  file:
+    path: ${LOG_PATH:logs}
   level:
-    org.springframework.security: DEBUG
+    org.springframework.security: INFO
 
 cloud:
   aws:
@@ -106,6 +108,9 @@ management:
       export:
         enabled: true
   metrics:
+    tags:
+      application: fitpet
+      env: ${spring.profiles.active:local}
     distribution:
       percentiles-histogram:
         http.server.requests: true

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,6 +3,7 @@
     <!-- allow overriding log directory via LOG_PATH env/property -->
     <property name="LOG_PATH" value="${LOG_PATH:-logs}"/>
     <property name="APP_NAME" value="fitpet"/>
+    <property name="APP_ENV" value="${SPRING_PROFILES_ACTIVE:-local}"/>
 
     <conversionRule conversionWord="clr"
         converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
@@ -28,6 +29,20 @@
         </rollingPolicy>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${APP_NAME}-json.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${APP_NAME}-json-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timeZone>Asia/Seoul</timeZone>
+            <customFields>{"app":"${APP_NAME}","env":"${APP_ENV}"}</customFields>
+            <includeMdc>true</includeMdc>
         </encoder>
     </appender>
 
@@ -76,6 +91,7 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="DAILY_FILE"/>
+        <appender-ref ref="JSON_FILE"/>
         <appender-ref ref="SERVICE_FILE"/>
         <appender-ref ref="CONTROLLER_FILE"/>
     </root>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <!-- allow overriding log directory via LOG_PATH env/property -->
     <property name="LOG_PATH" value="${LOG_PATH:-logs}"/>
     <property name="APP_NAME" value="fitpet"/>
-    <property name="APP_ENV" value="${SPRING_PROFILES_ACTIVE:-local}"/>
+    <springProperty scope="context" name="APP_ENV" source="spring.profiles.active" defaultValue="local"/>
 
     <conversionRule conversionWord="clr"
         converterClass="org.springframework.boot.logging.logback.ColorConverter"/>


### PR DESCRIPTION
## 📌 PR 요약

- 미션 진행 상태 전파를 Redis Pub/Sub + SSE 기반의 event-driven 구조로 전환했습니다.
- 미션 체크 저장/완료 시점에 진행 이벤트를 발행하도록 정리해, 클라이언트가 실시간으로 진행 상태를 수신할 수 있도록 개선했습니다.
- 운영 관측을 위해 Prometheus, Loki, Grafana, Promtail 기반 PLG 환경과 대시보드를 추가했습니다.
- 추가로 DailyWalk 서비스의 메서드 검증 어노테이션 충돌로 발생하던 500 오류를 수정했습니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [x] 관련 API 변경
- [x] 기타 리팩터링

- Redis Pub/Sub 발행/구독 컴포넌트 추가
- 미션 진행 이벤트 DTO 및 이벤트 타입 정의
- 미션 체크 저장/완료 시 after-commit 기준으로 진행 이벤트 발행하도록 정리
- 사용자별 SSE emitter 관리 및 heartbeat/전달 지표 수집 로직 추가
- `GET /missions/progress/stream` SSE 구독 API 추가
- Redis listener/container 설정 및 관련 메트릭 설정 정리
- JSON 로그 출력, 메트릭 태그 설정 추가
- Prometheus/Loki/Grafana/Promtail 기반 운영 관측 환경 및 Grafana ops 대시보드 추가
- `DailyWalkService` 구현체의 validation 제약 불일치 수정으로 메서드 검증 충돌 해결


- baseline vs pubsub 
<img width="955" height="453" alt="스크린샷 2026-03-06 오후 8 21 32" src="https://github.com/user-attachments/assets/c964788c-c5d2-4228-93ac-718fa4ced299" />


구분 | Baseline (DB Polling) | PubSub (SSE) | 변화율
-- | -- | -- | --
GET /missions/active 누적 요청 수 | 12,483.78 | ~0 | 약 -100%
앱 CPU 평균 사용률 | 6.04% | 0.41% | -93.15%
활성 SSE 연결 수 | - | 115.38 | -

<br class="Apple-interchange-newline">


## 🧪 테스트 방법

- 애플리케이션 실행
  - `./gradlew bootRun`
- SSE 구독 연결
  - `GET /missions/progress/stream`
  - 로컬에서는 `dev-user-id` 헤더 사용
- 걸음수/식단 관련 API 호출
  - 걸음수 생성/수정 또는 식단 생성 후, 미션 진행도가 자동 반영되는지 확인
  - 반영 결과가 SSE 이벤트로 실시간 전달되는지 확인
- 미션 완료 API 호출
  - 완료 처리 후 완료 이벤트가 SSE로 전달되는지 확인
- PLG 환경 실행
  - `docker compose -f observability/docker-compose.plg.yml up -d`
  - Grafana에서 메트릭/로그 수집 여부 확인
- 빌드 확인
  - `./gradlew compileJava`


##  테스트
- 미션 완료
<img width="1343" height="895" alt="image" src="https://github.com/user-attachments/assets/3c07866d-3e4e-4ff8-9902-7395f2edae7d" />

- 걸음수 생성 요청 후 실시간 수신
<img width="1323" height="918" alt="image" src="https://github.com/user-attachments/assets/1719732b-93dc-4ca4-873d-a88378982442" />

- 식단 생성 요청 후 실시간 수신
<img width="1330" height="866" alt="image" src="https://github.com/user-attachments/assets/2399004a-f72d-4a53-97a6-fb3c7a5a18d5" />

- PLG
<img width="1913" height="931" alt="image" src="https://github.com/user-attachments/assets/b263b893-7724-4895-bfff-d205919dc323" />

## 추가 전달 사항

- 사진의 baseline/pubsub A/B 비교용 대시보드는 제거하고, 운영용 관측 대시보드만 유지했습니다.
- 이번 PR의 핵심 목적은 write 성능 자체 개선보다, polling 의존도를 낮추고 실시간 전파 구조를 이벤트 기반으로 전환하는 데 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 미션 진행 실시간 스트리밍(SSE) 구독 엔드포인트 추가
  * 미션 진행 이벤트 발행 및 실시간 전달(구독자 브로드캐스트) 지원
  * FitPet Ops Overview Grafana 대시보드 추가(메트릭·로그 시각화)

* **Chores**
  * Prometheus, Loki, Grafana 기반 로컬 관찰성 스택(docker-compose) 추가 및 알림 규칙 추가
  * 파일형 JSON 로깅 설정 및 관련 메트릭/모니터링 구성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->