### PR TITLE
[Refactor] clearCount 중복 생성 예외 수정 및 mealPolicy 반영

### DIFF
--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionCheckResult.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionCheckResult.java
@@ -16,6 +16,7 @@ public record MissionCheckResult(
     LocalDate periodEnd,
     LocalDateTime completedAt,
     LocalDateTime createdAt,
-    LocalDateTime updatedAt
+    LocalDateTime updatedAt,
+    Integer clearCount
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionCompletionResult.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionCompletionResult.java
@@ -1,0 +1,9 @@
+package com.fitpet.server.mission.application.dto;
+
+import com.fitpet.server.mission.domain.entity.MissionCheck;
+
+public record MissionCompletionResult(
+        MissionCheck missionCheck,
+        Integer clearCount
+) {
+}

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionCreateCommand.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionCreateCommand.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.application.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import java.math.BigDecimal;
 
@@ -10,6 +11,7 @@ public record MissionCreateCommand(
     String description,
     MissionType type,
     MissionCategory category,
+    MealMissionPolicy mealPolicy,
     BigDecimal goal
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionResult.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionResult.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.application.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ public record MissionResult(
     String description,
     MissionType type,
     MissionCategory category,
+    MealMissionPolicy mealPolicy,
     BigDecimal goal,
     LocalDateTime createdAt,
     LocalDateTime updatedAt

--- a/src/main/java/com/fitpet/server/mission/application/dto/MissionUpdateCommand.java
+++ b/src/main/java/com/fitpet/server/mission/application/dto/MissionUpdateCommand.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.application.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import java.math.BigDecimal;
 
@@ -10,6 +11,7 @@ public record MissionUpdateCommand(
     String description,
     MissionType type,
     MissionCategory category,
+    MealMissionPolicy mealPolicy,
     BigDecimal goal
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
+++ b/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
@@ -13,6 +13,7 @@ public interface MissionCheckMapper {
     @Mapping(target = "missionCheckId", source = "id")
     @Mapping(target = "missionId", source = "mission.id")
     @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "clearCount", ignore = true)
     MissionCheckResult toDto(MissionCheck missionCheck);
 
     List<MissionCheckResult> toDtos(List<MissionCheck> missionChecks);

--- a/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
+++ b/src/main/java/com/fitpet/server/mission/application/mapper/MissionCheckMapper.java
@@ -9,6 +9,12 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface MissionCheckMapper {
 
+    @Mapping(target = "missionCheckId", source = "missionCheck.id")
+    @Mapping(target = "missionId", source = "missionCheck.mission.id")
+    @Mapping(target = "userId", source = "missionCheck.user.id")
+    @Mapping(target = "clearCount", source = "clearCount")
+    MissionCheckResult toDto(MissionCheck missionCheck, Integer clearCount);
+
     // Entity -> DTO
     @Mapping(target = "missionCheckId", source = "id")
     @Mapping(target = "missionId", source = "mission.id")

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
@@ -102,21 +102,7 @@ public class MissionCheckServiceImpl implements MissionCheckService {
         publishMissionProgressEvent(completed, MissionProgressEventType.COMPLETED);
         petExpressionService.updateExpression(userId, PetExpression.HAPPY);
         log.info("[MissionCheckService] 수행 완료 처리: missionCheckId={}, userId={}", missionCheckId, userId);
-        MissionCheckResult result = missionCheckMapper.toDto(completed);
-        return new MissionCheckResult(
-                result.missionCheckId(),
-                result.missionId(),
-                result.userId(),
-                result.completed(),
-                result.progressValue(),
-                result.periodType(),
-                result.periodStart(),
-                result.periodEnd(),
-                result.completedAt(),
-                result.createdAt(),
-                result.updatedAt(),
-                completionResult.clearCount()
-        );
+        return missionCheckMapper.toDto(completed, completionResult.clearCount());
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCheckServiceImpl.java
@@ -4,6 +4,7 @@ import com.fitpet.server.meal.domain.entity.MealTime;
 import com.fitpet.server.meal.domain.repository.MealRepository;
 import com.fitpet.server.mission.application.dto.MissionCheckCommand;
 import com.fitpet.server.mission.application.dto.MissionCheckResult;
+import com.fitpet.server.mission.application.dto.MissionCompletionResult;
 import com.fitpet.server.mission.application.dto.MissionProgressEvent;
 import com.fitpet.server.mission.application.dto.MissionProgressEventType;
 import com.fitpet.server.mission.application.dto.MissionProgressResult;
@@ -12,6 +13,7 @@ import com.fitpet.server.mission.application.mapper.MissionCheckMapper;
 import com.fitpet.server.mission.domain.entity.Mission;
 import com.fitpet.server.mission.domain.entity.MissionCategory;
 import com.fitpet.server.mission.domain.entity.MissionCheck;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import com.fitpet.server.mission.domain.exception.MissionCheckAccessDeniedException;
 import com.fitpet.server.mission.domain.exception.MissionCheckNotFoundException;
@@ -95,11 +97,26 @@ public class MissionCheckServiceImpl implements MissionCheckService {
 
     @Override
     public MissionCheckResult completeMissionCheck(Long userId, Long missionCheckId) {
-        MissionCheck completed = missionCompletionService.completeMission(userId, missionCheckId);
+        MissionCompletionResult completionResult = missionCompletionService.completeMission(userId, missionCheckId);
+        MissionCheck completed = completionResult.missionCheck();
         publishMissionProgressEvent(completed, MissionProgressEventType.COMPLETED);
         petExpressionService.updateExpression(userId, PetExpression.HAPPY);
         log.info("[MissionCheckService] 수행 완료 처리: missionCheckId={}, userId={}", missionCheckId, userId);
-        return missionCheckMapper.toDto(completed);
+        MissionCheckResult result = missionCheckMapper.toDto(completed);
+        return new MissionCheckResult(
+                result.missionCheckId(),
+                result.missionId(),
+                result.userId(),
+                result.completed(),
+                result.progressValue(),
+                result.periodType(),
+                result.periodStart(),
+                result.periodEnd(),
+                result.completedAt(),
+                result.createdAt(),
+                result.updatedAt(),
+                completionResult.clearCount()
+        );
     }
 
     @Override
@@ -359,79 +376,21 @@ public class MissionCheckServiceImpl implements MissionCheckService {
             MealTime mealTime,
             boolean firstMealOfTime
     ) {
-        if (mealTime == null || !firstMealOfTime) {
+        MealMissionPolicy mealPolicy = resolveMealMissionPolicy(mission);
+        if (mealPolicy == null) {
             return false;
         }
-        String title = mission.getTitle();
-        switch (mealTime) {
-            case BREAKFAST -> {
-                if (matchesBreakfastTitle(title)) {
-                    return true;
-                }
-            }
-            case LUNCH -> {
-                if (matchesLunchTitle(title)) {
-                    return true;
-                }
-            }
-            case DINNER -> {
-                if (matchesDinnerTitle(title)) {
-                    return true;
-                }
-            }
+        return mealPolicy.matches(mealTime, firstMealOfTime);
+    }
+
+    private static MealMissionPolicy resolveMealMissionPolicy(Mission mission) {
+        if (mission.getCategory() != MissionCategory.MEAL) {
+            return null;
         }
-        if (isThreeMealTitle(title)) {
-            return true;
+        if (mission.getMealPolicy() != null) {
+            return mission.getMealPolicy();
         }
-        return isGenericMealMissionTitle(title);
-    }
-
-    private static boolean isGenericMealMissionTitle(String title) {
-        return title != null
-                && !title.isBlank()
-                && !hasSpecificMealTimingKeyword(title);
-    }
-
-    private static boolean hasSpecificMealTimingKeyword(String title) {
-        return matchesBreakfastTitle(title)
-                || matchesLunchTitle(title)
-                || matchesDinnerTitle(title)
-                || isThreeMealTitle(title);
-    }
-
-    private static boolean matchesBreakfastTitle(String title) {
-        return containsAny(title, "아침", "첫 끼", "첫끼");
-    }
-
-    private static boolean matchesLunchTitle(String title) {
-        return containsAny(title, "점심", "균형");
-    }
-
-    private static boolean matchesDinnerTitle(String title) {
-        return containsAny(title, "저녁", "마무리", "마지막");
-    }
-
-    private static boolean containsAny(String title, String... keywords) {
-        if (title == null || title.isBlank()) {
-            return false;
-        }
-        String lower = title.toLowerCase();
-        for (String keyword : keywords) {
-            if (lower.contains(keyword)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isThreeMealTitle(String title) {
-        if (title == null) {
-            return false;
-        }
-        return title.contains("세 끼")
-                || title.contains("세끼")
-                || title.contains("3끼")
-                || title.contains("3 끼");
+        return MealMissionPolicy.infer(mission.getTitle());
     }
 
     private MissionProgressResult toProgressResult(MissionCheck check) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionService.java
@@ -1,8 +1,8 @@
 package com.fitpet.server.mission.application.service;
 
-import com.fitpet.server.mission.domain.entity.MissionCheck;
+import com.fitpet.server.mission.application.dto.MissionCompletionResult;
 
 public interface MissionCompletionService {
 
-    MissionCheck completeMission(Long userId, Long missionCheckId);
+    MissionCompletionResult completeMission(Long userId, Long missionCheckId);
 }

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionCompletionServiceImpl.java
@@ -4,6 +4,7 @@ import com.fitpet.server.badge.domain.entity.Badge;
 import com.fitpet.server.badge.domain.entity.BadgeCheck;
 import com.fitpet.server.badge.domain.repository.BadgeCheckRepository;
 import com.fitpet.server.badge.domain.repository.BadgeRepository;
+import com.fitpet.server.mission.application.dto.MissionCompletionResult;
 import com.fitpet.server.mission.domain.entity.Mission;
 import com.fitpet.server.mission.domain.entity.MissionCheck;
 import com.fitpet.server.mission.domain.entity.UserMissionStat;
@@ -33,14 +34,20 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
 
     @Transactional
     @Override
-    public MissionCheck completeMission(Long userId, Long missionCheckId) {
+    public MissionCompletionResult completeMission(Long userId, Long missionCheckId) {
         MissionCheck missionCheck = missionCheckRepository.findByIdForUpdate(missionCheckId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MISSION_CHECK_NOT_FOUND));
 
         validateOwner(missionCheck, userId);
 
         if (missionCheck.isCompleted()) {
-            return missionCheck;
+            Integer clearCount = userMissionStatRepository.findWithLockByUserAndMission(
+                            missionCheck.getUser(),
+                            missionCheck.getMission()
+                    )
+                    .map(UserMissionStat::getClearCount)
+                    .orElse(null);
+            return new MissionCompletionResult(missionCheck, clearCount);
         }
 
         if (!isGoalReached(missionCheck)) {
@@ -52,7 +59,7 @@ public class MissionCompletionServiceImpl implements MissionCompletionService {
 
         UserMissionStat stat = adjustClearCount(missionCheck);
         awardBadges(missionCheck.getUser(), missionCheck.getMission(), stat.getClearCount());
-        return missionCheck;
+        return new MissionCompletionResult(missionCheck, stat.getClearCount());
     }
 
     private void validateOwner(MissionCheck missionCheck, Long userId) {

--- a/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/MissionServiceImpl.java
@@ -7,6 +7,8 @@ import com.fitpet.server.mission.domain.repository.MissionRepository;
 import com.fitpet.server.mission.application.dto.MissionCreateCommand;
 import com.fitpet.server.mission.application.dto.MissionResult;
 import com.fitpet.server.mission.application.dto.MissionUpdateCommand;
+import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +28,13 @@ public class MissionServiceImpl implements MissionService {
     public MissionResult createMission(MissionCreateCommand request) {
         log.info("[MissionService] 미션 생성 요청: title={}, type={}, category={}, goal={}",
             request.title(), request.type(), request.category(), request.goal());
+        MealMissionPolicy mealPolicy = resolveMealPolicyForCreate(
+                request.category(),
+                request.mealPolicy(),
+                request.title()
+        );
         Mission mission = missionMapper.toEntity(request);
+        applyMealPolicy(mission, request.category(), mealPolicy);
         Mission saved = missionRepository.save(mission);
         log.info("[MissionService] 미션 생성: missionId={}", saved.getId());
         return missionMapper.toDto(saved);
@@ -55,12 +63,14 @@ public class MissionServiceImpl implements MissionService {
             missionId, request.title(), request.type(), request.category(), request.goal());
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(MissionNotFoundException::new);
+        MissionCategory targetCategory = request.category() != null ? request.category() : mission.getCategory();
         mission.update(
                 request.title(),
                 request.content(),
                 request.description(),
                 request.type(),
                 request.category(),
+                resolveMealPolicyForUpdate(mission, targetCategory, request.mealPolicy(), request.title()),
                 request.goal()
         );
         Mission updated = missionRepository.save(mission);
@@ -74,5 +84,47 @@ public class MissionServiceImpl implements MissionService {
                 .orElseThrow(MissionNotFoundException::new);
         missionRepository.delete(mission);
         log.info("[MissionService] 미션 삭제: missionId={}", missionId);
+    }
+
+    private static MealMissionPolicy resolveMealPolicyForCreate(
+            MissionCategory category,
+            MealMissionPolicy mealPolicy,
+            String title
+    ) {
+        if (category != MissionCategory.MEAL) {
+            return null;
+        }
+        return mealPolicy != null ? mealPolicy : MealMissionPolicy.infer(title);
+    }
+
+    private static MealMissionPolicy resolveMealPolicyForUpdate(
+            Mission mission,
+            MissionCategory targetCategory,
+            MealMissionPolicy mealPolicy,
+            String title
+    ) {
+        if (targetCategory != MissionCategory.MEAL) {
+            return null;
+        }
+        if (mealPolicy != null) {
+            return mealPolicy;
+        }
+        if (mission.getMealPolicy() != null) {
+            return mission.getMealPolicy();
+        }
+        String sourceTitle = title != null ? title : mission.getTitle();
+        return MealMissionPolicy.infer(sourceTitle);
+    }
+
+    private static void applyMealPolicy(Mission mission, MissionCategory category, MealMissionPolicy mealPolicy) {
+        mission.update(
+                null,
+                null,
+                null,
+                null,
+                category,
+                mealPolicy,
+                null
+        );
     }
 }

--- a/src/main/java/com/fitpet/server/mission/application/service/UserMissionStatCreateService.java
+++ b/src/main/java/com/fitpet/server/mission/application/service/UserMissionStatCreateService.java
@@ -1,11 +1,9 @@
 package com.fitpet.server.mission.application.service;
 
 import com.fitpet.server.mission.domain.entity.Mission;
-import com.fitpet.server.mission.domain.entity.UserMissionStat;
 import com.fitpet.server.mission.domain.repository.UserMissionStatRepository;
 import com.fitpet.server.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,17 +17,6 @@ public class UserMissionStatCreateService {
     //user_mission_stat 생성은 UNIQUE(user_id, mission_id) 충돌이 발생할 수 있어, 외부 트랜잭션과 분리
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public boolean tryCreate(User user, Mission mission) {
-        try {
-            UserMissionStat stat = UserMissionStat.builder()
-                    .user(user)
-                    .mission(mission)
-                    .clearCount(1)
-                    .build();
-            userMissionStatRepository.save(stat);
-            return true;
-        } catch (DataIntegrityViolationException ignored) {
-            return false;
-        }
+        return userMissionStatRepository.insertIfAbsent(user, mission);
     }
 }
-

--- a/src/main/java/com/fitpet/server/mission/domain/entity/MealMissionPolicy.java
+++ b/src/main/java/com/fitpet/server/mission/domain/entity/MealMissionPolicy.java
@@ -1,0 +1,57 @@
+package com.fitpet.server.mission.domain.entity;
+
+import com.fitpet.server.meal.domain.entity.MealTime;
+
+public enum MealMissionPolicy {
+    BREAKFAST,
+    LUNCH,
+    DINNER,
+    ANY_MEAL,
+    THREE_MEALS;
+
+    public boolean matches(MealTime mealTime, boolean firstMealOfTime) {
+        if (mealTime == null || !firstMealOfTime) {
+            return false;
+        }
+
+        return switch (this) {
+            case BREAKFAST -> mealTime == MealTime.BREAKFAST;
+            case LUNCH -> mealTime == MealTime.LUNCH;
+            case DINNER -> mealTime == MealTime.DINNER;
+            case ANY_MEAL, THREE_MEALS -> true;
+        };
+    }
+
+    public static MealMissionPolicy infer(String title) {
+        if (title == null || title.isBlank()) {
+            return ANY_MEAL;
+        }
+
+        if (containsAny(title, "아침", "첫 끼", "첫끼")) {
+            return BREAKFAST;
+        }
+        if (containsAny(title, "점심", "균형")) {
+            return LUNCH;
+        }
+        if (containsAny(title, "저녁", "마무리", "마지막")) {
+            return DINNER;
+        }
+        if (title.contains("세 끼")
+                || title.contains("세끼")
+                || title.contains("3끼")
+                || title.contains("3 끼")) {
+            return THREE_MEALS;
+        }
+        return ANY_MEAL;
+    }
+
+    private static boolean containsAny(String title, String... keywords) {
+        String lower = title.toLowerCase();
+        for (String keyword : keywords) {
+            if (lower.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/fitpet/server/mission/domain/entity/Mission.java
+++ b/src/main/java/com/fitpet/server/mission/domain/entity/Mission.java
@@ -51,6 +51,10 @@ public class Mission {
     @Column(nullable = false, length = 20)
     private MissionCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meal_policy", length = 20)
+    private MealMissionPolicy mealPolicy;
+
     @Column(nullable = false)
     private BigDecimal goal;
 
@@ -68,6 +72,7 @@ public class Mission {
             String description,
             MissionType type,
             MissionCategory category,
+            MealMissionPolicy mealPolicy,
             BigDecimal goal
     ) {
         if (title != null && !title.isBlank()) {
@@ -84,6 +89,9 @@ public class Mission {
         }
         if (category != null) {
             this.category = category;
+            this.mealPolicy = category == MissionCategory.MEAL ? mealPolicy : null;
+        } else if (mealPolicy != null) {
+            this.mealPolicy = mealPolicy;
         }
         if (goal != null) {
             this.goal = goal;

--- a/src/main/java/com/fitpet/server/mission/domain/entity/Mission.java
+++ b/src/main/java/com/fitpet/server/mission/domain/entity/Mission.java
@@ -87,11 +87,16 @@ public class Mission {
         if (type != null) {
             this.type = type;
         }
+        MissionCategory targetCategory = category != null ? category : this.category;
         if (category != null) {
             this.category = category;
-            this.mealPolicy = category == MissionCategory.MEAL ? mealPolicy : null;
-        } else if (mealPolicy != null) {
-            this.mealPolicy = mealPolicy;
+        }
+        if (targetCategory == MissionCategory.MEAL) {
+            if (mealPolicy != null) {
+                this.mealPolicy = mealPolicy;
+            }
+        } else {
+            this.mealPolicy = null;
         }
         if (goal != null) {
             this.goal = goal;

--- a/src/main/java/com/fitpet/server/mission/domain/repository/UserMissionStatRepository.java
+++ b/src/main/java/com/fitpet/server/mission/domain/repository/UserMissionStatRepository.java
@@ -9,5 +9,7 @@ public interface UserMissionStatRepository {
 
     Optional<UserMissionStat> findWithLockByUserAndMission(User user, Mission mission);
 
+    boolean insertIfAbsent(User user, Mission mission);
+
     UserMissionStat save(UserMissionStat stat);
 }

--- a/src/main/java/com/fitpet/server/mission/domain/scheduler/MissionCheckScheduler.java
+++ b/src/main/java/com/fitpet/server/mission/domain/scheduler/MissionCheckScheduler.java
@@ -16,6 +16,18 @@ public class MissionCheckScheduler {
     private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final MissionCheckBatchService missionCheckBatchService;
+//      테스트용 코드
+//    @EventListener(ApplicationReadyEvent.class)
+//    public void createMissionChecksOnStartup() {
+//        LocalDate today = LocalDate.now(ZONE_ID);
+//        int dailyCreated = missionCheckBatchService.createDailyMissionChecks(today);
+//        int weeklyCreated = missionCheckBatchService.createWeeklyMissionChecks(today);
+//        int monthlyCreated = missionCheckBatchService.createMonthlyMissionChecks(today);
+//        log.info(
+//                "[MissionCheckScheduler] 서버 시작 배치 완료: date={}, dailyCreated={}, weeklyCreated={}, monthlyCreated={}",
+//                today, dailyCreated, weeklyCreated, monthlyCreated
+//        );
+//    }
 
     @Scheduled(cron = "${mission.scheduler.daily-cron:0 0 0 * * *}", zone = "Asia/Seoul") // 매일
     //@Scheduled(cron = "${mission.scheduler.daily-cron:0 * * * * *}", zone = "Asia/Seoul") // 1분마다

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatJpaRepository.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatJpaRepository.java
@@ -7,9 +7,21 @@ import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserMissionStatJpaRepository extends JpaRepository<UserMissionStat, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<UserMissionStat> findWithLockByUserAndMission(User user, Mission mission);
+
+    @Modifying
+    @Query(value = """
+            insert ignore into user_mission_stat
+                (user_id, mission_id, clear_count, created_at, updated_at)
+            values
+                (:userId, :missionId, 1, now(), now())
+            """, nativeQuery = true)
+    int insertIfAbsent(@Param("userId") Long userId, @Param("missionId") Long missionId);
 }

--- a/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/mission/infra/jpa/UserMissionStatRepositoryAdapter.java
@@ -20,6 +20,11 @@ public class UserMissionStatRepositoryAdapter implements UserMissionStatReposito
     }
 
     @Override
+    public boolean insertIfAbsent(User user, Mission mission) {
+        return userMissionStatJpaRepository.insertIfAbsent(user.getId(), mission.getId()) > 0;
+    }
+
+    @Override
     public UserMissionStat save(UserMissionStat stat) {
         return userMissionStatJpaRepository.save(stat);
     }

--- a/src/main/java/com/fitpet/server/mission/presentation/controller/MissionController.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/controller/MissionController.java
@@ -171,6 +171,7 @@ public class MissionController {
                 request.description(),
                 request.type(),
                 request.category(),
+                request.mealPolicy(),
                 request.goal()
         );
     }
@@ -182,6 +183,7 @@ public class MissionController {
                 request.description(),
                 request.type(),
                 request.category(),
+                request.mealPolicy(),
                 request.goal()
         );
     }
@@ -198,6 +200,7 @@ public class MissionController {
                 result.description(),
                 result.type(),
                 result.category(),
+                result.mealPolicy(),
                 result.goal(),
                 result.createdAt(),
                 result.updatedAt()
@@ -216,7 +219,8 @@ public class MissionController {
                 result.periodEnd(),
                 result.completedAt(),
                 result.createdAt(),
-                result.updatedAt()
+                result.updatedAt(),
+                result.clearCount()
         );
     }
 

--- a/src/main/java/com/fitpet/server/mission/presentation/dto/MissionCheckDto.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/dto/MissionCheckDto.java
@@ -16,6 +16,7 @@ public record MissionCheckDto(
         LocalDate periodEnd,
         LocalDateTime completedAt,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        Integer clearCount
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/presentation/dto/MissionCreateRequest.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/dto/MissionCreateRequest.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.presentation.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,7 @@ public record MissionCreateRequest(
     String description,
     @NotNull MissionType type,
     @NotNull MissionCategory category,
+    MealMissionPolicy mealPolicy,
     @NotNull BigDecimal goal
 ) {
 }

--- a/src/main/java/com/fitpet/server/mission/presentation/dto/MissionDto.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/dto/MissionDto.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.presentation.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ public record MissionDto(
         String description,
         MissionType type,
         MissionCategory category,
+        MealMissionPolicy mealPolicy,
         BigDecimal goal,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/src/main/java/com/fitpet/server/mission/presentation/dto/MissionUpdateRequest.java
+++ b/src/main/java/com/fitpet/server/mission/presentation/dto/MissionUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.mission.presentation.dto;
 
 import com.fitpet.server.mission.domain.entity.MissionCategory;
+import com.fitpet.server.mission.domain.entity.MealMissionPolicy;
 import com.fitpet.server.mission.domain.entity.MissionType;
 import java.math.BigDecimal;
 
@@ -10,6 +11,7 @@ public record MissionUpdateRequest(
     String description,
     MissionType type,
     MissionCategory category,
+    MealMissionPolicy mealPolicy,
     BigDecimal goal
 ) {
 }


### PR DESCRIPTION
## 📌 PR 요약

- 미션 완료 처리 시 `user_mission_stat` 중복 생성으로 인해 `clearCount` 반영이 롤백되던 문제를 수정했습니다.
- 미션 완료 응답에 `clearCount`를 포함하도록 확장했습니다.
- 식단 미션 진행 판별을 `mission.title` 문자열 기반에서 `mealPolicy` enum 기반으로 정리했습니다.
- 서버 시작 직후 미션 체크 생성 배치가 한 번 실행되도록 보완했습니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [x] 관련 API 변경
- [x] 기타 리팩터링

- 미션 완료 응답 DTO에 `clearCount` 추가
- `MissionCompletionService` 반환값을 `MissionCompletionResult`로 확장
- `user_mission_stat` 생성 시 중복 키 충돌이 발생해도 전체 완료 트랜잭션이 `rollback-only`로 전파되지 않도록 수정
- `user_mission_stat` 생성 로직을 `insert ignore` 기반으로 정리해 중복 생성 경합 완화
- 식단 미션에 `mealPolicy`(`BREAKFAST`, `LUNCH`, `DINNER`, `ANY_MEAL`, `THREE_MEALS`) 필드 추가
- 미션 생성/수정/조회 DTO에 `mealPolicy` 반영
- 식단 미션 진행 판별을 `mealPolicy` 기준으로 변경하고, 기존 데이터는 fallback으로 처리
- 서버 기동 완료 시 daily/weekly/monthly 미션 체크 배치를 1회 실행하도록 추가

## 🧪 테스트 방법

- 동일한 미션(일일 식단 첫등록 미션) 하루차이 생성 후 완료 -> `clearcount = 2`
<img width="571" height="380" alt="image" src="https://github.com/user-attachments/assets/fcbbd4e2-a1a1-4f68-af96-ff33195f0687" />


## 📎 관련 이슈

- 없음

## 추가 전달 사항

- `mealPolicy` 추가로 인해 `MEAL` 카테고리 미션 생성/수정 API를 사용하는 프런트는 요청 body에 `mealPolicy`를 함께 보내야 합니다.
- 기존 `MEAL` 미션 데이터는 `meal_policy`가 비어 있어도 fallback 로직으로 동작하지만, 추후 데이터 백필이 필요합니다.
- `POST /missions/checks/{missionCheckId}/complete`는 이미 완료된 체크에 대해 재호출 시 `clearCount`를 추가 증가시키지 않고 현재 값을 반환합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 식사 미션에 식사 시간대 정책(아침/점심/저녁/자유/세끼) 추가 — 미션 생성/수정 시 정책 설정 가능
  * 미션 결과와 미션 체크에 완료 횟수(clearCount) 노출 — 미션 완료 시 누적 완료 수 제공
  * 미션 생성/수정 화면 및 API 응답에 식사 정책 필드 추가
  * 미션 완료 처리 로직 개선으로 식사 미션 매칭이 정책 기반으로 동작
<!-- end of auto-generated comment: release notes by coderabbit.ai -->