### PR TITLE
[Fix] 랭킹 조회 시 닉네임 대신 OAuth 초기값 반환 수정

### DIFF
--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -193,6 +193,7 @@ public class RankingServiceImpl implements RankingService {
         }
 
         if (!missIds.isEmpty()) {
+            log.warn("[RankingService] user:profiles 캐시 미스 — DB 동기 조회 발생: userIds={}", missIds);
             List<User> missingUsers = userRepository.findAllById(missIds);
             for (User u : missingUsers) {
                 String dbImgKey = u.getProfileImageUrl();

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -71,6 +71,14 @@ public class RedisConfig {
     }
 
     @Bean
+    public RedisScript<Long> hsetWithExpireScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setLocation(new ClassPathResource("redis/lua/hset_with_expire.lua"));
+        script.setResultType(Long.class);
+        return script;
+    }
+
+    @Bean
     public RedisTemplate<String, Object> redisTemplate() {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -16,10 +16,12 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
-import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,10 +40,12 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
     private final StringRedisTemplate redisTemplate;
+    @Qualifier("hsetWithExpireScript")
+    private final RedisScript<Long> hsetWithExpireScript;
 
     private static final String USER_IMAGE_KEY = "user:images";
     private static final String USER_PROFILE_KEY = "user:profiles";
-    private static final long USER_PROFILE_TTL_SECONDS = 259200L; // 3일
+    private static final String USER_PROFILE_TTL_SECONDS = "259200"; // 3일
 
     @Override
     @Transactional
@@ -105,8 +109,7 @@ public class UserServiceImpl implements UserService {
         );
 
         if (StringUtils.hasText(command.nickname())) {
-            redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), command.nickname());
-            redisTemplate.expire(USER_PROFILE_KEY, Duration.ofSeconds(USER_PROFILE_TTL_SECONDS));
+            putUserProfileCache(userId, command.nickname());
         }
 
         return userMapper.toResult(user);
@@ -176,8 +179,7 @@ public class UserServiceImpl implements UserService {
         );
 
         User saved = userRepository.save(user);
-        redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), saved.getNickname());
-        redisTemplate.expire(USER_PROFILE_KEY, Duration.ofSeconds(USER_PROFILE_TTL_SECONDS));
+        putUserProfileCache(userId, saved.getNickname());
         return userMapper.toResult(saved);
     }
 
@@ -211,5 +213,15 @@ public class UserServiceImpl implements UserService {
             userRepository.existsByNicknameAndIdNot(command.nickname(), userId)) {
             throw new DuplicateNicknameException();
         }
+    }
+
+    private void putUserProfileCache(Long userId, String nickname) {
+        redisTemplate.execute(
+                hsetWithExpireScript,
+                List.of(USER_PROFILE_KEY),
+                String.valueOf(userId),
+                nickname,
+                USER_PROFILE_TTL_SECONDS
+        );
     }
 }

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.DuplicateNicknameException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -40,6 +41,7 @@ public class UserServiceImpl implements UserService {
 
     private static final String USER_IMAGE_KEY = "user:images";
     private static final String USER_PROFILE_KEY = "user:profiles";
+    private static final long USER_PROFILE_TTL_SECONDS = 259200L; // 3일
 
     @Override
     @Transactional
@@ -104,6 +106,7 @@ public class UserServiceImpl implements UserService {
 
         if (StringUtils.hasText(command.nickname())) {
             redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), command.nickname());
+            redisTemplate.expire(USER_PROFILE_KEY, Duration.ofSeconds(USER_PROFILE_TTL_SECONDS));
         }
 
         return userMapper.toResult(user);
@@ -174,6 +177,7 @@ public class UserServiceImpl implements UserService {
 
         User saved = userRepository.save(user);
         redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), saved.getNickname());
+        redisTemplate.expire(USER_PROFILE_KEY, Duration.ofSeconds(USER_PROFILE_TTL_SECONDS));
         return userMapper.toResult(saved);
     }
 

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -39,6 +39,7 @@ public class UserServiceImpl implements UserService {
     private final StringRedisTemplate redisTemplate;
 
     private static final String USER_IMAGE_KEY = "user:images";
+    private static final String USER_PROFILE_KEY = "user:profiles";
 
     @Override
     @Transactional
@@ -100,6 +101,11 @@ public class UserServiceImpl implements UserService {
             command.targetPbf(),
             command.targetStepCount()
         );
+
+        if (StringUtils.hasText(command.nickname())) {
+            redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), command.nickname());
+        }
+
         return userMapper.toResult(user);
     }
 
@@ -166,7 +172,9 @@ public class UserServiceImpl implements UserService {
             command.targetStepCount()
         );
 
-        return userMapper.toResult(userRepository.save(user));
+        User saved = userRepository.save(user);
+        redisTemplate.opsForHash().put(USER_PROFILE_KEY, String.valueOf(userId), saved.getNickname());
+        return userMapper.toResult(saved);
     }
 
     @Override

--- a/src/main/resources/redis/lua/hset_with_expire.lua
+++ b/src/main/resources/redis/lua/hset_with_expire.lua
@@ -1,0 +1,8 @@
+-- user:profiles Hash에 닉네임을 저장하고 TTL을 원자적으로 설정
+-- KEYS[1]: hash key (예: user:profiles)
+-- ARGV[1]: field (userId)
+-- ARGV[2]: value (nickname)
+-- ARGV[3]: TTL (초 단위)
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+return 1

--- a/src/test/java/com/fitpet/server/ranking/application/service/RankingServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/ranking/application/service/RankingServiceImplTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fitpet.server.dailywalk.domain.repository.DailyWalkRepository;
@@ -125,6 +127,42 @@ class RankingServiceImplTest {
         // then
         assertThat(result.getNickname()).isEqualTo(updatedNickname);
         assertThat(result.getNickname()).doesNotContain("@"); // 이메일 prefix가 아님을 확인
+    }
+
+    @Test
+    @DisplayName("getMyRank — 캐시 미스 시 userRepository.findAllById()를 호출해 DB에서 조회한다 (모니터링 대상)")
+    void getMyRank_캐시_미스_시_DB_조회가_발생한다() {
+        // given
+        User user = User.builder().id(USER_ID).nickname("닉네임").profileImageUrl(null).build();
+
+        when(zSetOperations.reverseRank(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(0L);
+        when(zSetOperations.score(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(5000.0);
+        when(hashOperations.multiGet(eq(USER_PROFILE_KEY), anyList())).thenReturn(singleNull());
+        when(hashOperations.multiGet(eq(USER_IMAGE_KEY), anyList())).thenReturn(singleNull());
+        when(userRepository.findAllById(List.of(USER_ID))).thenReturn(List.of(user));
+
+        // when
+        sut.getMyRank(USER_ID, RankingFilter.ALL);
+
+        // then — 캐시 미스이므로 DB 조회가 발생해야 한다
+        verify(userRepository).findAllById(List.of(USER_ID));
+    }
+
+    @Test
+    @DisplayName("getMyRank — 캐시 히트 시 userRepository.findAllById()를 호출하지 않는다")
+    void getMyRank_캐시_히트_시_DB_조회가_발생하지_않는다() {
+        // given
+        when(zSetOperations.reverseRank(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(0L);
+        when(zSetOperations.score(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(5000.0);
+        when(hashOperations.multiGet(eq(USER_PROFILE_KEY), anyList())).thenReturn(List.of("캐시닉네임"));
+        when(hashOperations.multiGet(eq(USER_IMAGE_KEY), anyList())).thenReturn(List.of("profile/1.jpg"));
+        when(s3Service.generatePresignedGetUrl(any())).thenReturn("https://s3.example.com/1.jpg");
+
+        // when
+        sut.getMyRank(USER_ID, RankingFilter.ALL);
+
+        // then — 캐시 히트이므로 DB 조회가 발생하지 않아야 한다
+        verify(userRepository, never()).findAllById(anyList());
     }
 
     /** List.of()는 null 원소를 허용하지 않으므로 별도 헬퍼 사용 */

--- a/src/test/java/com/fitpet/server/ranking/application/service/RankingServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/ranking/application/service/RankingServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.fitpet.server.ranking.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fitpet.server.dailywalk.domain.repository.DailyWalkRepository;
+import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.domain.type.RankingFilter;
+import com.fitpet.server.shared.s3.S3Service;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@ExtendWith(MockitoExtension.class)
+class RankingServiceImplTest {
+
+    @Mock DailyWalkRepository dailyWalkRepository;
+    @Mock UserRepository userRepository;
+    @Mock S3Service s3Service;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock RedisScript<Long> updateRankingScript;
+    @Mock RedisScript<Long> updateStepAndRankingScript;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock ZSetOperations<String, String> zSetOperations;
+    @Mock HashOperations<String, Object, Object> hashOperations;
+
+    @InjectMocks RankingServiceImpl sut;
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_PROFILE_KEY = "user:profiles";
+    private static final String USER_IMAGE_KEY = "user:images";
+    private static final String RANKING_KEY = "ranking:daily:" + LocalDate.now();
+
+    @BeforeEach
+    void setUp() {
+        Mockito.lenient().when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        Mockito.lenient().when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+    }
+
+    @Test
+    @DisplayName("getMyRank — Redis 캐시에 닉네임이 있으면 캐시의 닉네임을 반환한다")
+    void getMyRank_Redis_캐시_닉네임_반환() {
+        // given
+        String cachedNickname = "캐시닉네임";
+        String imageKey = "profile/1.jpg";
+        String presignedUrl = "https://s3.example.com/profile/1.jpg";
+
+        when(zSetOperations.reverseRank(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(0L);
+        when(zSetOperations.score(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(5000.0);
+        when(hashOperations.multiGet(eq(USER_PROFILE_KEY), anyList())).thenReturn(List.of(cachedNickname));
+        when(hashOperations.multiGet(eq(USER_IMAGE_KEY), anyList())).thenReturn(List.of(imageKey));
+        when(s3Service.generatePresignedGetUrl(imageKey)).thenReturn(presignedUrl);
+
+        // when
+        RankingDto result = sut.getMyRank(USER_ID, RankingFilter.ALL);
+
+        // then
+        assertThat(result.getNickname()).isEqualTo(cachedNickname);
+        assertThat(result.getRank()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getMyRank — Redis 캐시 미스 시 DB에서 닉네임을 조회해 반환한다")
+    void getMyRank_캐시_미스_DB_닉네임_반환() {
+        // given
+        String dbNickname = "DB닉네임";
+        User user = User.builder()
+                .id(USER_ID)
+                .nickname(dbNickname)
+                .profileImageUrl("profile/1.jpg")
+                .build();
+
+        when(zSetOperations.reverseRank(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(0L);
+        when(zSetOperations.score(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(5000.0);
+        // 캐시 미스: nickname null, imageKey null
+        when(hashOperations.multiGet(eq(USER_PROFILE_KEY), anyList())).thenReturn(singleNull());
+        when(hashOperations.multiGet(eq(USER_IMAGE_KEY), anyList())).thenReturn(singleNull());
+        when(userRepository.findAllById(List.of(USER_ID))).thenReturn(List.of(user));
+        when(s3Service.generatePresignedGetUrl(any())).thenReturn("https://s3.example.com/profile/1.jpg");
+
+        // when
+        RankingDto result = sut.getMyRank(USER_ID, RankingFilter.ALL);
+
+        // then
+        assertThat(result.getNickname()).isEqualTo(dbNickname);
+    }
+
+    @Test
+    @DisplayName("getMyRank — OAuth 초기 닉네임(이메일 prefix)이 캐시에 남아있어도 DB 갱신 후에는 DB 닉네임을 반환한다")
+    void getMyRank_캐시_미스_후_DB_닉네임으로_교체된다() {
+        // given — 캐시 미스 상황 (inputInfo 이후 캐시가 갱신됐다고 가정)
+        String updatedNickname = "사용자설정닉네임";
+        User userAfterInputInfo = User.builder()
+                .id(USER_ID)
+                .nickname(updatedNickname)
+                .profileImageUrl(null)
+                .build();
+
+        when(zSetOperations.reverseRank(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(2L);
+        when(zSetOperations.score(eq(RANKING_KEY), eq(String.valueOf(USER_ID)))).thenReturn(3000.0);
+        when(hashOperations.multiGet(eq(USER_PROFILE_KEY), anyList())).thenReturn(singleNull());
+        when(hashOperations.multiGet(eq(USER_IMAGE_KEY), anyList())).thenReturn(singleNull());
+        when(userRepository.findAllById(List.of(USER_ID))).thenReturn(List.of(userAfterInputInfo));
+
+        // when
+        RankingDto result = sut.getMyRank(USER_ID, RankingFilter.ALL);
+
+        // then
+        assertThat(result.getNickname()).isEqualTo(updatedNickname);
+        assertThat(result.getNickname()).doesNotContain("@"); // 이메일 prefix가 아님을 확인
+    }
+
+    /** List.of()는 null 원소를 허용하지 않으므로 별도 헬퍼 사용 */
+    private List<Object> singleNull() {
+        List<Object> list = new java.util.ArrayList<>();
+        list.add(null);
+        return list;
+    }
+}

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.user.application.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -16,17 +17,16 @@ import com.fitpet.server.user.domain.entity.Gender;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,25 +38,21 @@ class UserServiceImplTest {
     @Mock PasswordEncoder passwordEncoder;
     @Mock S3Service s3Service;
     @Mock StringRedisTemplate redisTemplate;
-    @Mock HashOperations<String, Object, Object> hashOperations;
+    @Mock RedisScript<Long> hsetWithExpireScript;
 
     @InjectMocks UserServiceImpl sut;
 
     private static final Long USER_ID = 1L;
     private static final String USER_PROFILE_KEY = "user:profiles";
-
-    @BeforeEach
-    void setUp() {
-        Mockito.lenient().when(redisTemplate.opsForHash()).thenReturn(hashOperations);
-    }
+    private static final String TTL = "259200";
 
     // ──────────────────────────────────────────────
     // inputInfo()
     // ──────────────────────────────────────────────
 
     @Test
-    @DisplayName("inputInfo 호출 시 Redis user:profiles 캐시가 새 닉네임으로 갱신된다")
-    void inputInfo_Redis_캐시가_새_닉네임으로_갱신된다() {
+    @DisplayName("inputInfo 호출 시 Lua 스크립트로 user:profiles 캐시가 닉네임+TTL 포함해 원자적으로 갱신된다")
+    void inputInfo_Lua스크립트로_캐시_닉네임과_TTL_원자적_갱신() {
         // given
         String newNickname = "새닉네임";
         User incompleteUser = User.builder()
@@ -83,8 +79,14 @@ class UserServiceImplTest {
         // when
         sut.inputInfo(USER_ID, command);
 
-        // then
-        verify(hashOperations).put(USER_PROFILE_KEY, String.valueOf(USER_ID), newNickname);
+        // then — Lua 스크립트가 KEY, userId, nickname, TTL 로 호출됐는지 검증
+        verify(redisTemplate).execute(
+                eq(hsetWithExpireScript),
+                eq(List.of(USER_PROFILE_KEY)),
+                eq(String.valueOf(USER_ID)),
+                eq(newNickname),
+                eq(TTL)
+        );
     }
 
     // ──────────────────────────────────────────────
@@ -92,8 +94,8 @@ class UserServiceImplTest {
     // ──────────────────────────────────────────────
 
     @Test
-    @DisplayName("updateUser 호출 시 닉네임이 있으면 Redis user:profiles 캐시가 갱신된다")
-    void updateUser_닉네임_있으면_Redis_캐시가_갱신된다() {
+    @DisplayName("updateUser 호출 시 닉네임이 있으면 Lua 스크립트로 user:profiles 캐시가 갱신된다")
+    void updateUser_닉네임_있으면_Lua스크립트로_캐시_갱신() {
         // given
         String newNickname = "수정닉네임";
         User existingUser = User.builder()
@@ -114,12 +116,18 @@ class UserServiceImplTest {
         sut.updateUser(USER_ID, command);
 
         // then
-        verify(hashOperations).put(USER_PROFILE_KEY, String.valueOf(USER_ID), newNickname);
+        verify(redisTemplate).execute(
+                eq(hsetWithExpireScript),
+                eq(List.of(USER_PROFILE_KEY)),
+                eq(String.valueOf(USER_ID)),
+                eq(newNickname),
+                eq(TTL)
+        );
     }
 
     @Test
-    @DisplayName("updateUser 호출 시 닉네임이 null이면 Redis user:profiles 캐시를 갱신하지 않는다")
-    void updateUser_닉네임_null이면_Redis_캐시_갱신_안_한다() {
+    @DisplayName("updateUser 호출 시 닉네임이 null이면 Lua 스크립트를 호출하지 않는다")
+    void updateUser_닉네임_null이면_Lua스크립트_호출_안_한다() {
         // given
         User existingUser = User.builder()
                 .id(USER_ID)
@@ -138,12 +146,12 @@ class UserServiceImplTest {
         sut.updateUser(USER_ID, command);
 
         // then
-        verify(hashOperations, never()).put(eq(USER_PROFILE_KEY), any(), any());
+        verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
     }
 
     @Test
-    @DisplayName("updateUser 호출 시 닉네임이 빈 문자열이면 Redis user:profiles 캐시를 갱신하지 않는다")
-    void updateUser_닉네임_빈문자열이면_Redis_캐시_갱신_안_한다() {
+    @DisplayName("updateUser 호출 시 닉네임이 빈 문자열이면 Lua 스크립트를 호출하지 않는다")
+    void updateUser_닉네임_빈문자열이면_Lua스크립트_호출_안_한다() {
         // given
         User existingUser = User.builder()
                 .id(USER_ID)
@@ -162,6 +170,6 @@ class UserServiceImplTest {
         sut.updateUser(USER_ID, command);
 
         // then
-        verify(hashOperations, never()).put(eq(USER_PROFILE_KEY), any(), any());
+        verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
     }
 }

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -1,0 +1,167 @@
+package com.fitpet.server.user.application.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fitpet.server.pet.domain.repository.PetRepository;
+import com.fitpet.server.shared.s3.S3Service;
+import com.fitpet.server.user.application.dto.UserInputInfoCommand;
+import com.fitpet.server.user.application.dto.UserResult;
+import com.fitpet.server.user.application.dto.UserUpdateCommand;
+import com.fitpet.server.user.application.mapper.UserMapper;
+import com.fitpet.server.user.domain.entity.Gender;
+import com.fitpet.server.user.domain.entity.RegistrationStatus;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PetRepository petRepository;
+    @Mock UserMapper userMapper;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock S3Service s3Service;
+    @Mock StringRedisTemplate redisTemplate;
+    @Mock HashOperations<String, Object, Object> hashOperations;
+
+    @InjectMocks UserServiceImpl sut;
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_PROFILE_KEY = "user:profiles";
+
+    @BeforeEach
+    void setUp() {
+        Mockito.lenient().when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+    }
+
+    // ──────────────────────────────────────────────
+    // inputInfo()
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("inputInfo 호출 시 Redis user:profiles 캐시가 새 닉네임으로 갱신된다")
+    void inputInfo_Redis_캐시가_새_닉네임으로_갱신된다() {
+        // given
+        String newNickname = "새닉네임";
+        User incompleteUser = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .registrationStatus(RegistrationStatus.INCOMPLETE)
+                .build();
+        User savedUser = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .nickname(newNickname)
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(incompleteUser));
+        when(userRepository.existsByNicknameAndIdNot(newNickname, USER_ID)).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userMapper.toResult(savedUser)).thenReturn(UserResult.builder().userId(USER_ID).nickname(newNickname).build());
+
+        UserInputInfoCommand command = new UserInputInfoCommand(
+                newNickname, 25, Gender.male, 70.0, 175.0, 65.0, 20.0, 18.0, 8000
+        );
+
+        // when
+        sut.inputInfo(USER_ID, command);
+
+        // then
+        verify(hashOperations).put(USER_PROFILE_KEY, String.valueOf(USER_ID), newNickname);
+    }
+
+    // ──────────────────────────────────────────────
+    // updateUser()
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("updateUser 호출 시 닉네임이 있으면 Redis user:profiles 캐시가 갱신된다")
+    void updateUser_닉네임_있으면_Redis_캐시가_갱신된다() {
+        // given
+        String newNickname = "수정닉네임";
+        User existingUser = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .nickname("기존닉네임")
+                .build();
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(existingUser));
+        when(userRepository.existsByNicknameAndIdNot(newNickname, USER_ID)).thenReturn(false);
+        when(userMapper.toResult(any(User.class))).thenReturn(UserResult.builder().userId(USER_ID).build());
+
+        UserUpdateCommand command = new UserUpdateCommand(
+                null, null, newNickname, null, null, null, null, null, null, null, null
+        );
+
+        // when
+        sut.updateUser(USER_ID, command);
+
+        // then
+        verify(hashOperations).put(USER_PROFILE_KEY, String.valueOf(USER_ID), newNickname);
+    }
+
+    @Test
+    @DisplayName("updateUser 호출 시 닉네임이 null이면 Redis user:profiles 캐시를 갱신하지 않는다")
+    void updateUser_닉네임_null이면_Redis_캐시_갱신_안_한다() {
+        // given
+        User existingUser = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .nickname("기존닉네임")
+                .build();
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(existingUser));
+        when(userMapper.toResult(any(User.class))).thenReturn(UserResult.builder().userId(USER_ID).build());
+
+        UserUpdateCommand command = new UserUpdateCommand(
+                null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        // when
+        sut.updateUser(USER_ID, command);
+
+        // then
+        verify(hashOperations, never()).put(eq(USER_PROFILE_KEY), any(), any());
+    }
+
+    @Test
+    @DisplayName("updateUser 호출 시 닉네임이 빈 문자열이면 Redis user:profiles 캐시를 갱신하지 않는다")
+    void updateUser_닉네임_빈문자열이면_Redis_캐시_갱신_안_한다() {
+        // given
+        User existingUser = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .nickname("기존닉네임")
+                .build();
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(existingUser));
+        when(userMapper.toResult(any(User.class))).thenReturn(UserResult.builder().userId(USER_ID).build());
+
+        UserUpdateCommand command = new UserUpdateCommand(
+                null, null, "", null, null, null, null, null, null, null, null
+        );
+
+        // when
+        sut.updateUser(USER_ID, command);
+
+        // then
+        verify(hashOperations, never()).put(eq(USER_PROFILE_KEY), any(), any());
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약

  `GET /ranking/summary` 응답의 `nickname` 필드가 유저가 설정한 닉네임이 아닌 OAuth 초기값으로 반환되는 것을 수정합니다.
  닉네임 변경 시 Redis `user:profiles` 캐시를 즉시 갱신하도록 처리하며,
  HSET+EXPIRE 원자성 보장 및 캐시 미스 모니터링도 함께 개선합니다.

  ## ✅ 작업 상세 내용

  - [x] **닉네임 변경 시 Redis 캐시 미갱신**
    - `inputInfo()` (회원가입 완료), `updateUser()` (닉네임 수정) 호출 시
      `user:profiles` 캐시를 즉시 갱신하도록 수정
    - 기존에는 DB에만 저장되고 캐시는 갱신되지 않아 랭킹 조회 시 OAuth 초기 닉네임 반환

  - [x] **Redis TTL 미설정 수정**
    - `user:profiles` 해시 키에 TTL 없이 `put()` 하던 문제 수정
    - 닉네임 갱신 시 3일(259200초) TTL 적용

  - [x] **HSET+EXPIRE 원자성 보장 — Lua 스크립트 도입**
    - `put()` + `expire()` 분리 호출 시 사이 실패 가능성 해소
    - `hset_with_expire.lua` Lua 스크립트로 HSET과 EXPIRE를 원자적으로 처리
    - 기존 `update_ranking_and_dirty.lua` 패턴과 동일한 방식으로 일관성 유지

  - [x] **캐시 미스 모니터링 로그 추가**
    - `getUserProfileMap()` 에서 캐시 미스 발생 시 `log.warn` 출력
    - 운영 중 캐시 미스 빈도 모니터링 가능

  ## 🧪 테스트 방법

- 테스트 코드 및 Postman 테스트
<img width="477" height="178" alt="image" src="https://github.com/user-attachments/assets/77adb8fc-4c8b-47b1-a0a0-d32a3d4ff1f2" />
<img width="849" height="196" alt="image" src="https://github.com/user-attachments/assets/0a6eafe9-f461-429f-bfb2-1c8adb2bb576" />

---
<img width="554" height="504" alt="image" src="https://github.com/user-attachments/assets/b93f6015-947e-4f42-bcae-bc8c2fd17912" />
<img width="679" height="540" alt="image" src="https://github.com/user-attachments/assets/ef5a5806-ca6f-421e-b69d-1515a5e8522a" />
<img width="725" height="526" alt="image" src="https://github.com/user-attachments/assets/4beb5674-86e1-41e3-8e15-192ccf9e25ac" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 사용자 프로필 정보에 대한 Redis 캐싱 적용으로 데이터베이스 조회 최소화

* **안정성 강화**
  * 캐시 미스 발생 시 로깅으로 시스템 모니터링 강화
  * 원자적 캐시 업데이트 메커니즘 도입으로 데이터 일관성 보장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->