### PR TITLE
[Feat] 회원 탈퇴 Soft Delete 구현 및 재가입 재활성화

### DIFF
--- a/src/main/java/com/fitpet/server/auth/application/service/AuthService.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthService.java
@@ -13,4 +13,6 @@ public interface AuthService {
     TokenResponse loginWithGoogle(String idToken);
 
     TokenResponse loginWithKakao(String kakaoAccessToken);
+
+    void revokeTokens(Long userId);
 }

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -140,6 +140,11 @@ public class AuthServiceImpl implements AuthService {
         return TokenResponse.success(resolveRegistrationStatus(user), access, refresh);
     }
 
+    @Override
+    public void revokeTokens(Long userId) {
+        redisTokenRepository.delete(userId);
+    }
+
     private RegistrationStatus resolveRegistrationStatus(User user) {
         RegistrationStatus status = user.getRegistrationStatus();
         return status != null ? status : RegistrationStatus.INCOMPLETE;

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -104,30 +104,30 @@ public class AuthServiceImpl implements AuthService {
         // 1) provider+uid로 조회 (탈퇴 계정 포함)
         Optional<User> byProvider = userRepository.findByOAuthIncludeDeleted(provider, providerUid);
         if (byProvider.isPresent()) {
-            User u = byProvider.get();
-            if (u.getDeletedAt() != null) {
-                u.reactivate();
-                return userRepository.save(u);
+            User user = byProvider.get();
+            if (user.getDeletedAt() != null) {
+                user.reactivate();
+                return userRepository.save(user);
             }
-            return u;
+            return user;
         }
 
         // 2) 이메일로 기존 계정이 있으면 연결 (탈퇴 계정 포함)
         if (email != null && !email.isBlank()) {
             Optional<User> byEmail = userRepository.findByEmailIncludeDeleted(email);
             if (byEmail.isPresent()) {
-                User u = byEmail.get();
-                u.linkSocial(provider, providerUid);
-                if (u.getDeletedAt() != null) {
-                    u.reactivate();
+                User user = byEmail.get();
+                user.linkSocial(provider, providerUid);
+                if (user.getDeletedAt() != null) {
+                    user.reactivate();
                 }
-                return userRepository.save(u);
+                return userRepository.save(user);
             }
         }
 
         // 3) 신규 생성
         String dummyPw = passwordEncoder.encode(UUID.randomUUID().toString());
-        User u = User.builder()
+        User user = User.builder()
             .email(email != null ? email : ("anon+" + provider + "-" + providerUid + "@local"))
             .password(dummyPw)
             .nickname((email != null && email.contains("@")) ? email.substring(0, email.indexOf('@'))
@@ -136,7 +136,7 @@ public class AuthServiceImpl implements AuthService {
             .providerUid(providerUid)
             .registrationStatus(RegistrationStatus.INCOMPLETE)
             .build();
-        return userRepository.save(u);
+        return userRepository.save(user);
     }
 
     private TokenResponse issueTokens(User user) {

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -100,20 +100,27 @@ public class AuthServiceImpl implements AuthService {
         return issueTokens(user);
     }
 
-    // 구글, 카카오 로그인으로 한 사용자가 없으면 새로 만들어 저장 , 있으면 그대로 사용(업데이트x)
     private User upsertOAuthUser(String email, String provider, String providerUid) {
-        // 1) provider+uid로 1차 조회
-        Optional<User> byProvider = userRepository.findByProviderAndProviderUid(provider, providerUid);
+        // 1) provider+uid로 조회 (탈퇴 계정 포함)
+        Optional<User> byProvider = userRepository.findByProviderAndProviderUidIncludeDeleted(provider, providerUid);
         if (byProvider.isPresent()) {
-            return byProvider.get();
+            User u = byProvider.get();
+            if (u.getDeletedAt() != null) {
+                u.reactivate();
+                return userRepository.save(u);
+            }
+            return u;
         }
 
-        // 2) 이메일로 기존 계정이 있으면 연결(정책상 허용 시)
+        // 2) 이메일로 기존 계정이 있으면 연결 (탈퇴 계정 포함)
         if (email != null && !email.isBlank()) {
-            Optional<User> byEmail = userRepository.findByEmail(email);
+            Optional<User> byEmail = userRepository.findByEmailIncludeDeleted(email);
             if (byEmail.isPresent()) {
-                var u = byEmail.get();
+                User u = byEmail.get();
                 u.linkSocial(provider, providerUid);
+                if (u.getDeletedAt() != null) {
+                    u.reactivate();
+                }
                 return userRepository.save(u);
             }
         }
@@ -127,7 +134,6 @@ public class AuthServiceImpl implements AuthService {
                 : (provider.toLowerCase() + "_" + providerUid))
             .provider(provider)
             .providerUid(providerUid)
-            // 정보 입력 받은 후 COMPLETE로 변경
             .registrationStatus(RegistrationStatus.INCOMPLETE)
             .build();
         return userRepository.save(u);

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -117,7 +117,9 @@ public class AuthServiceImpl implements AuthService {
             Optional<User> byEmail = userRepository.findByEmailIncludeDeleted(email);
             if (byEmail.isPresent()) {
                 User user = byEmail.get();
-                user.linkSocial(provider, providerUid);
+                if (user.getProvider() == null || user.getProvider().isBlank()) {
+                    user.linkSocial(provider, providerUid);
+                }
                 if (user.getDeletedAt() != null) {
                     user.reactivate();
                 }

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.fitpet.server.auth.application.service;
 import com.fitpet.server.auth.domain.exception.InvalidAccessTokenException;
 import com.fitpet.server.auth.domain.exception.InvalidLoginException;
 import com.fitpet.server.auth.domain.exception.InvalidRefreshTokenException;
+import com.fitpet.server.auth.domain.exception.OAuthProviderMismatchException;
 import com.fitpet.server.auth.infra.GoogleTokenVerifier;
 import com.fitpet.server.auth.infra.KakaoClient;
 import com.fitpet.server.auth.infra.KakaoClient.KakaoProfile;
@@ -117,7 +118,13 @@ public class AuthServiceImpl implements AuthService {
             Optional<User> byEmail = userRepository.findByEmailIncludeDeleted(email);
             if (byEmail.isPresent()) {
                 User user = byEmail.get();
-                if (user.getProvider() == null || user.getProvider().isBlank()) {
+                boolean noProvider = user.getProvider() == null || user.getProvider().isBlank();
+                boolean sameProvider = provider.equals(user.getProvider());
+
+                if (!noProvider && !sameProvider) {
+                    throw new OAuthProviderMismatchException();
+                }
+                if (noProvider) {
                     user.linkSocial(provider, providerUid);
                 }
                 if (user.getDeletedAt() != null) {

--- a/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/fitpet/server/auth/application/service/AuthServiceImpl.java
@@ -102,7 +102,7 @@ public class AuthServiceImpl implements AuthService {
 
     private User upsertOAuthUser(String email, String provider, String providerUid) {
         // 1) provider+uid로 조회 (탈퇴 계정 포함)
-        Optional<User> byProvider = userRepository.findByProviderAndProviderUidIncludeDeleted(provider, providerUid);
+        Optional<User> byProvider = userRepository.findByOAuthIncludeDeleted(provider, providerUid);
         if (byProvider.isPresent()) {
             User u = byProvider.get();
             if (u.getDeletedAt() != null) {

--- a/src/main/java/com/fitpet/server/auth/domain/exception/OAuthProviderMismatchException.java
+++ b/src/main/java/com/fitpet/server/auth/domain/exception/OAuthProviderMismatchException.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.auth.domain.exception;
+
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
+
+public class OAuthProviderMismatchException extends BusinessException {
+    public OAuthProviderMismatchException() {
+        super(ErrorCode.OAUTH_PROVIDER_MISMATCH);
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
+++ b/src/main/java/com/fitpet/server/shared/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     OAUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "유효하지 않은 소셜 토큰입니다."),
     OAUTH_VERIFICATION_FAILED(HttpStatus.BAD_GATEWAY, "A005", "소셜 토큰 검증에 실패했습니다."),
     OAUTH_PROFILE_NOT_FOUND(HttpStatus.BAD_GATEWAY, "A006", "소셜 사용자 정보를 확인할 수 없습니다."),
+    OAUTH_PROVIDER_MISMATCH(HttpStatus.CONFLICT, "A007", "해당 이메일은 다른 소셜 계정으로 연결되어 있습니다."),
 
     TERMS_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "해당 약관을 찾을 수 없습니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "T002", "필수 약관에 동의해야 합니다."),

--- a/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
+++ b/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
@@ -1,10 +1,10 @@
 package com.fitpet.server.user.application.facade;
 
 import com.fitpet.server.auth.application.service.AuthService;
-import com.fitpet.server.termsmaster.application.dto.TermsAgreementCommand;
-import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.termsmaster.application.dto.TermsAgreementCommand;
+import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.application.service.UserService;
@@ -12,9 +12,11 @@ import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserFacade {
@@ -39,7 +41,15 @@ public class UserFacade {
     }
 
     public void withdraw(Long userId) {
-        userService.withdrawUser(userId);
-        authService.revokeTokens(userId);
+        log.info("[UserFacade] 회원 탈퇴 시작: userId={}", userId);
+        try {
+            userService.cleanupUserImages(userId);
+            userService.withdrawUser(userId);
+            authService.revokeTokens(userId);
+            log.info("[UserFacade] 회원 탈퇴 완료: userId={}", userId);
+        } catch (Exception e) {
+            log.error("[UserFacade] 회원 탈퇴 실패: userId={}", userId, e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
+++ b/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
@@ -43,7 +43,6 @@ public class UserFacade {
     public void withdraw(Long userId) {
         log.info("[UserFacade] 회원 탈퇴 시작: userId={}", userId);
         try {
-            userService.cleanupUserImages(userId);
             userService.withdrawUser(userId);
             authService.revokeTokens(userId);
             log.info("[UserFacade] 회원 탈퇴 완료: userId={}", userId);

--- a/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
+++ b/src/main/java/com/fitpet/server/user/application/facade/UserFacade.java
@@ -1,9 +1,10 @@
 package com.fitpet.server.user.application.facade;
 
-import com.fitpet.server.shared.exception.BusinessException;
-import com.fitpet.server.shared.exception.ErrorCode;
+import com.fitpet.server.auth.application.service.AuthService;
 import com.fitpet.server.termsmaster.application.dto.TermsAgreementCommand;
 import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
+import com.fitpet.server.shared.exception.BusinessException;
+import com.fitpet.server.shared.exception.ErrorCode;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.application.service.UserService;
@@ -21,6 +22,7 @@ public class UserFacade {
     private final UserService userService;
     private final TermsAgreementService termsAgreementService;
     private final UserRepository userRepository;
+    private final AuthService authService;
 
     @Transactional
     public UserResult completeSignUp(Long userId, UserInputInfoCommand infoCommand,
@@ -34,5 +36,10 @@ public class UserFacade {
                 termsCommands != null ? termsCommands : List.of());
 
         return result;
+    }
+
+    public void withdraw(Long userId) {
+        userService.withdrawUser(userId);
+        authService.revokeTokens(userId);
     }
 }

--- a/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/fitpet/server/user/application/mapper/UserMapper.java
@@ -25,7 +25,8 @@ public interface UserMapper {
             @Mapping(target = "dailyStepCount", ignore = true),
             @Mapping(target = "allowActivityNotification", ignore = true),
             @Mapping(target = "lastAccessedAt", ignore = true),
-            @Mapping(target = "profileImageUrl", ignore = true)
+            @Mapping(target = "profileImageUrl", ignore = true),
+            @Mapping(target = "deletedAt", ignore = true)
     })
     User toEntity(UserCreateCommand command);
  

--- a/src/main/java/com/fitpet/server/user/application/service/UserService.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserService.java
@@ -25,6 +25,8 @@ public interface UserService {
 
     List<ProfileImageHistoryResult> getProfileImageHistory(Long userId);
 
+    void cleanupUserImages(Long userId);
+
     void withdrawUser(Long userId);
 
     UserResult inputInfo(Long userId, UserInputInfoCommand command);

--- a/src/main/java/com/fitpet/server/user/application/service/UserService.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserService.java
@@ -25,7 +25,7 @@ public interface UserService {
 
     List<ProfileImageHistoryResult> getProfileImageHistory(Long userId);
 
-    void deleteUser(Long userId);
+    void withdrawUser(Long userId);
 
     UserResult inputInfo(Long userId, UserInputInfoCommand command);
 

--- a/src/main/java/com/fitpet/server/user/application/service/UserService.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserService.java
@@ -17,15 +17,11 @@ public interface UserService {
 
     ProfileImageUpdateResult updateProfileImage(Long userId);
 
-    // S3 존재 확인 + 소유권 검증 (트랜잭션 밖에서 호출)
     void checkHistoryImageAccess(Long userId, String imageKey);
 
-    // DB 업데이트만 담당 (트랜잭션)
     void applyHistoryImage(Long userId, String imageKey);
 
     List<ProfileImageHistoryResult> getProfileImageHistory(Long userId);
-
-    void cleanupUserImages(Long userId);
 
     void withdrawUser(Long userId);
 

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -205,12 +205,6 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void cleanupUserImages(Long userId) {
-        profileImageRepository.findAllByUserId(userId)
-                .forEach(img -> s3Service.deleteObject(img.getImageKey()));
-    }
-
-    @Override
     @Transactional
     public void withdrawUser(Long userId) {
         User user = findUserById(userId);

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -51,6 +51,7 @@ public class UserServiceImpl implements UserService {
 
     private static final String USER_IMAGE_KEY = "user:images";
     private static final String USER_PROFILE_KEY = "user:profiles";
+    private static final String USER_GENDER_KEY = "user:genders";
     private static final String USER_PROFILE_TTL_SECONDS = "259200"; // 3일
     private static final int MAX_PROFILE_IMAGE_HISTORY = 10;
 
@@ -212,6 +213,7 @@ public class UserServiceImpl implements UserService {
 
         redisTemplate.opsForHash().delete(USER_IMAGE_KEY, String.valueOf(userId));
         redisTemplate.opsForHash().delete(USER_PROFILE_KEY, String.valueOf(userId));
+        redisTemplate.opsForHash().delete(USER_GENDER_KEY, String.valueOf(userId));
 
         user.withdraw();
         userRepository.save(user);

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -22,7 +22,6 @@ import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserProfileImageRepository;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -58,9 +57,20 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UserResult createUser(UserCreateCommand command) {
-        validateUserCreateRequest(command);
-        User user = userMapper.toEntity(command);
-        user.changePassword(passwordEncoder.encode(command.password()));
+        return userRepository.findByEmailIncludeDeleted(command.email())
+                .filter(u -> u.getDeletedAt() != null)
+                .map(u -> reactivateUser(u, command.password()))
+                .orElseGet(() -> {
+                    validateUserCreateRequest(command);
+                    User user = userMapper.toEntity(command);
+                    user.changePassword(passwordEncoder.encode(command.password()));
+                    return userMapper.toResult(userRepository.save(user));
+                });
+    }
+
+    private UserResult reactivateUser(User user, String newPassword) {
+        user.changePassword(passwordEncoder.encode(newPassword));
+        user.reactivate();
         return userMapper.toResult(userRepository.save(user));
     }
 
@@ -209,12 +219,7 @@ public class UserServiceImpl implements UserService {
         redisTemplate.opsForHash().delete(USER_IMAGE_KEY, String.valueOf(userId));
         redisTemplate.opsForHash().delete(USER_PROFILE_KEY, String.valueOf(userId));
 
-        String token = UUID.randomUUID().toString();
-        user.withdraw(
-            "deleted_" + userId + "_" + token + "@deleted.local",
-            "deleted_" + userId + "_" + token,
-            passwordEncoder.encode(token)
-        );
+        user.withdraw();
         userRepository.save(user);
     }
 

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -22,6 +22,7 @@ import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserProfileImageRepository;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -195,9 +196,23 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void deleteUser(Long userId) {
+    public void withdrawUser(Long userId) {
         User user = findUserById(userId);
-        userRepository.delete(user);
+
+        List<UserProfileImage> images = profileImageRepository.findAllByUserId(userId);
+        images.forEach(img -> s3Service.deleteObject(img.getImageKey()));
+        profileImageRepository.deleteAllByUserId(userId);
+
+        redisTemplate.opsForHash().delete(USER_IMAGE_KEY, String.valueOf(userId));
+        redisTemplate.opsForHash().delete(USER_PROFILE_KEY, String.valueOf(userId));
+
+        String token = UUID.randomUUID().toString();
+        user.withdraw(
+            "deleted_" + userId + "_" + token + "@deleted.local",
+            "deleted_" + userId + "_" + token,
+            passwordEncoder.encode(token)
+        );
+        userRepository.save(user);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -195,12 +195,15 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public void cleanupUserImages(Long userId) {
+        profileImageRepository.findAllByUserId(userId)
+                .forEach(img -> s3Service.deleteObject(img.getImageKey()));
+    }
+
+    @Override
     @Transactional
     public void withdrawUser(Long userId) {
         User user = findUserById(userId);
-
-        List<UserProfileImage> images = profileImageRepository.findAllByUserId(userId);
-        images.forEach(img -> s3Service.deleteObject(img.getImageKey()));
         profileImageRepository.deleteAllByUserId(userId);
 
         redisTemplate.opsForHash().delete(USER_IMAGE_KEY, String.valueOf(userId));

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -238,15 +238,13 @@ public class User {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public void withdraw(String anonymousEmail, String anonymousNickname, String encodedDummyPassword) {
-        this.email = anonymousEmail;
-        this.nickname = anonymousNickname;
-        this.password = encodedDummyPassword;
-        this.provider = null;
-        this.providerUid = null;
+    public void withdraw() {
         this.profileImageUrl = null;
         this.deviceToken = null;
-        this.refreshToken = null;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void reactivate() {
+        this.deletedAt = null;
     }
 }

--- a/src/main/java/com/fitpet/server/user/domain/entity/User.java
+++ b/src/main/java/com/fitpet/server/user/domain/entity/User.java
@@ -18,6 +18,7 @@ import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -25,6 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @DynamicUpdate
+@SQLRestriction("deleted_at IS NULL")
 @Table(name = "users",
         uniqueConstraints = {
                 @UniqueConstraint(name = "uk_users_email", columnNames = "email"),
@@ -119,6 +121,9 @@ public class User {
 
     @Column(name = "last_accessed_at")
     private LocalDateTime lastAccessedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public void changePassword(String encodedPassword) {
         this.password = encodedPassword;
@@ -231,5 +236,17 @@ public class User {
 
     public void updateProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void withdraw(String anonymousEmail, String anonymousNickname, String encodedDummyPassword) {
+        this.email = anonymousEmail;
+        this.nickname = anonymousNickname;
+        this.password = encodedDummyPassword;
+        this.provider = null;
+        this.providerUid = null;
+        this.profileImageUrl = null;
+        this.deviceToken = null;
+        this.refreshToken = null;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserProfileImageRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserProfileImageRepository.java
@@ -13,4 +13,6 @@ public interface UserProfileImageRepository {
     Optional<UserProfileImage> findByUserIdAndImageKey(Long userId, String imageKey);
     void delete(UserProfileImage image);
     void deleteByUserIdAndImageKey(Long userId, String imageKey);
+    List<UserProfileImage> findAllByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
@@ -31,6 +31,10 @@ public interface UserRepository {
 
     Optional<User> findByProviderAndProviderUid(String provider, String providerUid);
 
+    Optional<User> findByEmailIncludeDeleted(String email);
+
+    Optional<User> findByProviderAndProviderUidIncludeDeleted(String provider, String providerUid);
+
     List<User> findAll();
 
     Slice<User> findAll(Pageable pageable);

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
@@ -33,7 +33,7 @@ public interface UserRepository {
 
     Optional<User> findByEmailIncludeDeleted(String email);
 
-    Optional<User> findByProviderAndProviderUidIncludeDeleted(String provider, String providerUid);
+    Optional<User> findByOAuthIncludeDeleted(String provider, String providerUid);
 
     List<User> findAll();
 

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserProfileImageRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserProfileImageRepositoryAdapter.java
@@ -53,4 +53,14 @@ public class UserProfileImageRepositoryAdapter implements UserProfileImageReposi
     public void deleteByUserIdAndImageKey(Long userId, String imageKey) {
         jpaRepository.deleteByUserIdAndImageKey(userId, imageKey);
     }
+
+    @Override
+    public List<UserProfileImage> findAllByUserId(Long userId) {
+        return jpaRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        jpaRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
@@ -74,6 +74,16 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByEmailIncludeDeleted(String email) {
+        return jpa.findByEmailIncludeDeleted(email);
+    }
+
+    @Override
+    public Optional<User> findByProviderAndProviderUidIncludeDeleted(String provider, String providerUid) {
+        return jpa.findByProviderAndProviderUidIncludeDeleted(provider, providerUid);
+    }
+
+    @Override
     public List<User> findAll() {
         return jpa.findAll();
     }

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
@@ -79,8 +79,8 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByProviderAndProviderUidIncludeDeleted(String provider, String providerUid) {
-        return jpa.findByProviderAndProviderUidIncludeDeleted(provider, providerUid);
+    public Optional<User> findByOAuthIncludeDeleted(String provider, String providerUid) {
+        return jpa.findByOAuthIncludeDeleted(provider, providerUid);
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
+++ b/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
@@ -28,6 +28,12 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderAndProviderUid(String provider, String providerUid);
 
+    @Query(value = "SELECT * FROM users WHERE email = :email LIMIT 1", nativeQuery = true)
+    Optional<User> findByEmailIncludeDeleted(@Param("email") String email);
+
+    @Query(value = "SELECT * FROM users WHERE provider = :provider AND provider_uid = :providerUid LIMIT 1", nativeQuery = true)
+    Optional<User> findByProviderAndProviderUidIncludeDeleted(@Param("provider") String provider, @Param("providerUid") String providerUid);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update User user set user.dailyStepCount = 0")
     int resetDailyStepCount();

--- a/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
+++ b/src/main/java/com/fitpet/server/user/infra/jpa/UserJpaRepository.java
@@ -32,7 +32,7 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailIncludeDeleted(@Param("email") String email);
 
     @Query(value = "SELECT * FROM users WHERE provider = :provider AND provider_uid = :providerUid LIMIT 1", nativeQuery = true)
-    Optional<User> findByProviderAndProviderUidIncludeDeleted(@Param("provider") String provider, @Param("providerUid") String providerUid);
+    Optional<User> findByOAuthIncludeDeleted(@Param("provider") String provider, @Param("providerUid") String providerUid);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update User user set user.dailyStepCount = 0")

--- a/src/main/java/com/fitpet/server/user/infra/jpa/UserProfileImageJpaRepository.java
+++ b/src/main/java/com/fitpet/server/user/infra/jpa/UserProfileImageJpaRepository.java
@@ -30,4 +30,10 @@ public interface UserProfileImageJpaRepository extends JpaRepository<UserProfile
     @Modifying
     @Transactional
     void deleteByUserIdAndImageKey(Long userId, String imageKey);
+
+    List<UserProfileImage> findAllByUserId(Long userId);
+
+    @Modifying
+    @Transactional
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/fitpet/server/user/presentation/controller/UserController.java
+++ b/src/main/java/com/fitpet/server/user/presentation/controller/UserController.java
@@ -84,7 +84,7 @@ public class UserController {
 
     @DeleteMapping
     public ResponseEntity<Void> delete(@AuthUser Long userId) {
-        userService.deleteUser(userId);
+        userFacade.withdraw(userId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
@@ -39,9 +39,7 @@ class AuthServiceImplTest {
 
     @InjectMocks AuthServiceImpl sut;
 
-    // ──────────────────────────────────────────────
     // loginWithGoogle — 탈퇴 계정 재활성화
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("구글 로그인 시 provider+uid로 탈퇴 계정이 조회되면 reactivate 후 토큰 발급")
@@ -123,6 +121,30 @@ class AuthServiceImplTest {
     }
 
     @Test
+    @DisplayName("구글 로그인 시 이메일 매칭 계정에 이미 다른 provider가 있으면 linkSocial을 호출하지 않는다")
+    void loginWithGoogle_이메일_매칭_계정에_다른_provider_있으면_덮어쓰지_않음() {
+        User kakaoUser = User.builder()
+                .id(5L).email("shared@test.com")
+                .provider("KAKAO").providerUid("kakao-uid-777")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("google-sub-999", "shared@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "google-sub-999"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailIncludeDeleted("shared@test.com"))
+                .thenReturn(Optional.of(kakaoUser));
+        when(userRepository.save(kakaoUser)).thenReturn(kakaoUser);
+        stubTokenIssue(kakaoUser);
+
+        sut.loginWithGoogle("id-token");
+
+        assertThat(kakaoUser.getProvider()).isEqualTo("KAKAO");
+        assertThat(kakaoUser.getProviderUid()).isEqualTo("kakao-uid-777");
+    }
+
+    @Test
     @DisplayName("구글 로그인 시 일치하는 계정이 없으면 신규 생성")
     void loginWithGoogle_일치_계정_없으면_신규_생성() {
         // given
@@ -151,9 +173,7 @@ class AuthServiceImplTest {
         assertThat(saved.getRegistrationStatus()).isEqualTo(RegistrationStatus.INCOMPLETE);
     }
 
-    // ──────────────────────────────────────────────
     // loginWithKakao — 탈퇴 계정 재활성화
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("카카오 로그인 시 provider+uid로 탈퇴 계정이 조회되면 reactivate 후 토큰 발급")
@@ -207,9 +227,7 @@ class AuthServiceImplTest {
         assertThat(captor.getValue().getEmail()).endsWith("@anon.kakao.local");
     }
 
-    // ──────────────────────────────────────────────
     // helpers
-    // ──────────────────────────────────────────────
 
     private void stubTokenIssue(User user) {
         when(jwtTokenProvider.generateAccessToken(any(), anyString(), any())).thenReturn("access");

--- a/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
@@ -1,0 +1,219 @@
+package com.fitpet.server.auth.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fitpet.server.auth.infra.GoogleTokenVerifier;
+import com.fitpet.server.auth.infra.KakaoClient;
+import com.fitpet.server.auth.infra.KakaoClient.KakaoProfile;
+import com.fitpet.server.auth.infra.RedisTokenRepository;
+import com.fitpet.server.auth.presentation.dto.GoogleProfile;
+import com.fitpet.server.auth.presentation.dto.TokenResponse;
+import com.fitpet.server.security.jwt.JwtTokenProvider;
+import com.fitpet.server.user.domain.entity.RegistrationStatus;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock RedisTokenRepository redisTokenRepository;
+    @Mock KakaoClient kakaoClient;
+    @Mock GoogleTokenVerifier googleTokenVerifier;
+
+    @InjectMocks AuthServiceImpl sut;
+
+    // ──────────────────────────────────────────────
+    // loginWithGoogle — 탈퇴 계정 재활성화
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("구글 로그인 시 provider+uid로 탈퇴 계정이 조회되면 reactivate 후 토큰 발급")
+    void loginWithGoogle_탈퇴_계정_provider_uid로_재활성화() {
+        // given
+        User deleted = User.builder()
+                .id(1L).email("google@test.com")
+                .provider("GOOGLE").providerUid("google-sub-123")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+        deleted.withdraw();
+
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("google-sub-123", "google@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "google-sub-123"))
+                .thenReturn(Optional.of(deleted));
+        when(userRepository.save(deleted)).thenReturn(deleted);
+        stubTokenIssue(deleted);
+
+        // when
+        TokenResponse result = sut.loginWithGoogle("id-token");
+
+        // then
+        assertThat(deleted.getDeletedAt()).isNull();
+        verify(userRepository).save(deleted);
+        assertThat(result.success()).isTrue();
+    }
+
+    @Test
+    @DisplayName("구글 로그인 시 provider+uid 조회 결과가 활성 계정이면 reactivate 없이 토큰 발급")
+    void loginWithGoogle_활성_계정이면_그대로_토큰_발급() {
+        // given
+        User active = User.builder()
+                .id(2L).email("google@test.com")
+                .provider("GOOGLE").providerUid("google-sub-456")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("google-sub-456", "google@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "google-sub-456"))
+                .thenReturn(Optional.of(active));
+        stubTokenIssue(active);
+
+        // when
+        sut.loginWithGoogle("id-token");
+
+        // then
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("구글 로그인 시 이메일로 탈퇴 계정이 조회되면 소셜 연결 + reactivate 후 토큰 발급")
+    void loginWithGoogle_탈퇴_계정_이메일로_소셜연결_후_재활성화() {
+        // given
+        User deleted = User.builder()
+                .id(3L).email("local@test.com")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+        deleted.withdraw();
+
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("new-sub-789", "local@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "new-sub-789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailIncludeDeleted("local@test.com"))
+                .thenReturn(Optional.of(deleted));
+        when(userRepository.save(deleted)).thenReturn(deleted);
+        stubTokenIssue(deleted);
+
+        // when
+        sut.loginWithGoogle("id-token");
+
+        // then
+        assertThat(deleted.getDeletedAt()).isNull();
+        assertThat(deleted.getProvider()).isEqualTo("GOOGLE");
+        assertThat(deleted.getProviderUid()).isEqualTo("new-sub-789");
+        verify(userRepository).save(deleted);
+    }
+
+    @Test
+    @DisplayName("구글 로그인 시 일치하는 계정이 없으면 신규 생성")
+    void loginWithGoogle_일치_계정_없으면_신규_생성() {
+        // given
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("brand-new-sub", "new@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "brand-new-sub"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailIncludeDeleted("new@test.com"))
+                .thenReturn(Optional.empty());
+        when(passwordEncoder.encode(anyString())).thenReturn("dummy-pw");
+
+        User newUser = User.builder().id(10L).email("new@test.com")
+                .registrationStatus(RegistrationStatus.INCOMPLETE).build();
+        when(userRepository.save(any(User.class))).thenReturn(newUser);
+        stubTokenIssue(newUser);
+
+        // when
+        sut.loginWithGoogle("id-token");
+
+        // then
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User saved = captor.getValue();
+        assertThat(saved.getEmail()).isEqualTo("new@test.com");
+        assertThat(saved.getProvider()).isEqualTo("GOOGLE");
+        assertThat(saved.getRegistrationStatus()).isEqualTo(RegistrationStatus.INCOMPLETE);
+    }
+
+    // ──────────────────────────────────────────────
+    // loginWithKakao — 탈퇴 계정 재활성화
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("카카오 로그인 시 provider+uid로 탈퇴 계정이 조회되면 reactivate 후 토큰 발급")
+    void loginWithKakao_탈퇴_계정_재활성화() {
+        // given
+        User deleted = User.builder()
+                .id(4L).email("kakao@test.com")
+                .provider("KAKAO").providerUid("kakao-id-999")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+        deleted.withdraw();
+
+        when(kakaoClient.getProfile("kakao-token"))
+                .thenReturn(new KakaoProfile("kakao-id-999", "kakao@test.com"));
+        when(userRepository.findByOAuthIncludeDeleted("KAKAO", "kakao-id-999"))
+                .thenReturn(Optional.of(deleted));
+        when(userRepository.save(deleted)).thenReturn(deleted);
+        stubTokenIssue(deleted);
+
+        // when
+        sut.loginWithKakao("kakao-token");
+
+        // then
+        assertThat(deleted.getDeletedAt()).isNull();
+        verify(userRepository).save(deleted);
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 시 이메일이 null이면 익명 이메일로 신규 생성")
+    void loginWithKakao_이메일_null이면_익명_이메일_생성() {
+        // given
+        when(kakaoClient.getProfile("kakao-token"))
+                .thenReturn(new KakaoProfile("kakao-id-000", null));
+        when(userRepository.findByOAuthIncludeDeleted("KAKAO", "kakao-id-000"))
+                .thenReturn(Optional.empty());
+        when(passwordEncoder.encode(anyString())).thenReturn("dummy-pw");
+
+        User newUser = User.builder().id(11L)
+                .email("kakao_kakao-id-000@anon.kakao.local")
+                .registrationStatus(RegistrationStatus.INCOMPLETE).build();
+        when(userRepository.save(any(User.class))).thenReturn(newUser);
+        stubTokenIssue(newUser);
+
+        // when
+        sut.loginWithKakao("kakao-token");
+
+        // then
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getEmail()).startsWith("kakao_");
+        assertThat(captor.getValue().getEmail()).endsWith("@anon.kakao.local");
+    }
+
+    // ──────────────────────────────────────────────
+    // helpers
+    // ──────────────────────────────────────────────
+
+    private void stubTokenIssue(User user) {
+        when(jwtTokenProvider.generateAccessToken(any(), anyString(), any())).thenReturn("access");
+        when(jwtTokenProvider.generateRefreshToken(any(), anyString())).thenReturn("refresh");
+        when(jwtTokenProvider.getRefreshExpirationMs()).thenReturn(1_800_000L);
+    }
+}

--- a/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/auth/application/service/AuthServiceImplTest.java
@@ -1,12 +1,14 @@
 package com.fitpet.server.auth.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fitpet.server.auth.domain.exception.OAuthProviderMismatchException;
 import com.fitpet.server.auth.infra.GoogleTokenVerifier;
 import com.fitpet.server.auth.infra.KakaoClient;
 import com.fitpet.server.auth.infra.KakaoClient.KakaoProfile;
@@ -121,8 +123,8 @@ class AuthServiceImplTest {
     }
 
     @Test
-    @DisplayName("구글 로그인 시 이메일 매칭 계정에 이미 다른 provider가 있으면 linkSocial을 호출하지 않는다")
-    void loginWithGoogle_이메일_매칭_계정에_다른_provider_있으면_덮어쓰지_않음() {
+    @DisplayName("구글 로그인 시 이메일 매칭 계정에 이미 다른 provider가 있으면 OAuthProviderMismatchException")
+    void loginWithGoogle_이메일_매칭_계정에_다른_provider_있으면_예외() {
         User kakaoUser = User.builder()
                 .id(5L).email("shared@test.com")
                 .provider("KAKAO").providerUid("kakao-uid-777")
@@ -135,13 +137,30 @@ class AuthServiceImplTest {
                 .thenReturn(Optional.empty());
         when(userRepository.findByEmailIncludeDeleted("shared@test.com"))
                 .thenReturn(Optional.of(kakaoUser));
-        when(userRepository.save(kakaoUser)).thenReturn(kakaoUser);
-        stubTokenIssue(kakaoUser);
 
-        sut.loginWithGoogle("id-token");
+        assertThatThrownBy(() -> sut.loginWithGoogle("id-token"))
+                .isInstanceOf(OAuthProviderMismatchException.class);
+    }
 
-        assertThat(kakaoUser.getProvider()).isEqualTo("KAKAO");
-        assertThat(kakaoUser.getProviderUid()).isEqualTo("kakao-uid-777");
+    @Test
+    @DisplayName("구글 로그인 시 탈퇴한 계정에 다른 provider가 있으면 OAuthProviderMismatchException")
+    void loginWithGoogle_탈퇴_계정에_다른_provider_있으면_예외() {
+        User deletedKakaoUser = User.builder()
+                .id(6L).email("deleted@test.com")
+                .provider("KAKAO").providerUid("kakao-uid-888")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+        deletedKakaoUser.withdraw();
+
+        when(googleTokenVerifier.verifyIdToken("id-token"))
+                .thenReturn(new GoogleProfile("google-sub-000", "deleted@test.com", true));
+        when(userRepository.findByOAuthIncludeDeleted("GOOGLE", "google-sub-000"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailIncludeDeleted("deleted@test.com"))
+                .thenReturn(Optional.of(deletedKakaoUser));
+
+        assertThatThrownBy(() -> sut.loginWithGoogle("id-token"))
+                .isInstanceOf(OAuthProviderMismatchException.class);
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
+++ b/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fitpet.server.auth.application.service.AuthService;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.exception.ErrorCode;
 import com.fitpet.server.termsmaster.application.service.TermsAgreementService;
@@ -30,6 +31,7 @@ class UserFacadeTest {
     @Mock UserService userService;
     @Mock TermsAgreementService termsAgreementService;
     @Mock UserRepository userRepository;
+    @Mock AuthService authService;
 
     @InjectMocks UserFacade sut;
 
@@ -88,5 +90,17 @@ class UserFacadeTest {
         sut.completeSignUp(USER_ID, dummyInfoCommand(), List.of());
 
         verify(termsAgreementService).saveTermsAgreements(eq(USER_ID), any());
+    }
+
+    // ──────────────────────────────────────────────
+    // withdraw()
+    // ──────────────────────────────────────────────
+
+    @Test
+    void withdraw_호출_시_userService_withdrawUser_와_authService_revokeTokens_모두_호출() {
+        sut.withdraw(USER_ID);
+
+        verify(userService).withdrawUser(USER_ID);
+        verify(authService).revokeTokens(USER_ID);
     }
 }

--- a/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
+++ b/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
@@ -3,6 +3,8 @@ package com.fitpet.server.user.application.facade;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +21,7 @@ import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -92,10 +95,6 @@ class UserFacadeTest {
         verify(termsAgreementService).saveTermsAgreements(eq(USER_ID), any());
     }
 
-    // ──────────────────────────────────────────────
-    // withdraw()
-    // ──────────────────────────────────────────────
-
     @Test
     void withdraw_호출_시_S3정리_후_DB처리_후_토큰_취소_순서대로_호출() {
         sut.withdraw(USER_ID);
@@ -104,5 +103,17 @@ class UserFacadeTest {
         inOrder.verify(userService).cleanupUserImages(USER_ID);
         inOrder.verify(userService).withdrawUser(USER_ID);
         inOrder.verify(authService).revokeTokens(USER_ID);
+    }
+
+    @Test
+    @DisplayName("withdraw 중 S3 삭제 예외 발생 시 DB 처리가 호출되지 않는다")
+    void withdraw_S3_예외_시_DB_호출_안_됨() {
+        doThrow(new RuntimeException("S3 error")).when(userService).cleanupUserImages(USER_ID);
+
+        assertThatThrownBy(() -> sut.withdraw(USER_ID))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(userService, never()).withdrawUser(USER_ID);
+        verify(authService, never()).revokeTokens(USER_ID);
     }
 }

--- a/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
+++ b/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
@@ -97,10 +97,12 @@ class UserFacadeTest {
     // ──────────────────────────────────────────────
 
     @Test
-    void withdraw_호출_시_userService_withdrawUser_와_authService_revokeTokens_모두_호출() {
+    void withdraw_호출_시_S3정리_후_DB처리_후_토큰_취소_순서대로_호출() {
         sut.withdraw(USER_ID);
 
-        verify(userService).withdrawUser(USER_ID);
-        verify(authService).revokeTokens(USER_ID);
+        org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(userService, authService);
+        inOrder.verify(userService).cleanupUserImages(USER_ID);
+        inOrder.verify(userService).withdrawUser(USER_ID);
+        inOrder.verify(authService).revokeTokens(USER_ID);
     }
 }

--- a/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
+++ b/src/test/java/com/fitpet/server/user/application/facade/UserFacadeTest.java
@@ -3,8 +3,6 @@ package com.fitpet.server.user.application.facade;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,24 +94,11 @@ class UserFacadeTest {
     }
 
     @Test
-    void withdraw_호출_시_S3정리_후_DB처리_후_토큰_취소_순서대로_호출() {
+    void withdraw_호출_시_DB처리_후_토큰_취소_순서대로_호출() {
         sut.withdraw(USER_ID);
 
         org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(userService, authService);
-        inOrder.verify(userService).cleanupUserImages(USER_ID);
         inOrder.verify(userService).withdrawUser(USER_ID);
         inOrder.verify(authService).revokeTokens(USER_ID);
-    }
-
-    @Test
-    @DisplayName("withdraw 중 S3 삭제 예외 발생 시 DB 처리가 호출되지 않는다")
-    void withdraw_S3_예외_시_DB_호출_안_됨() {
-        doThrow(new RuntimeException("S3 error")).when(userService).cleanupUserImages(USER_ID);
-
-        assertThatThrownBy(() -> sut.withdraw(USER_ID))
-                .isInstanceOf(RuntimeException.class);
-
-        verify(userService, never()).withdrawUser(USER_ID);
-        verify(authService, never()).revokeTokens(USER_ID);
     }
 }

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fitpet.server.pet.domain.repository.PetRepository;
-import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.user.application.dto.UserCreateCommand;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
@@ -22,7 +21,6 @@ import com.fitpet.server.user.application.mapper.UserMapper;
 import com.fitpet.server.user.domain.entity.Gender;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
-import com.fitpet.server.user.domain.entity.UserProfileImage;
 import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
@@ -235,29 +233,6 @@ class UserServiceImplTest {
         sut.createUser(command);
 
         verify(userRepository).save(newUser);
-    }
-
-    @Test
-    @DisplayName("cleanupUserImages 호출 시 모든 프로필 이미지 S3 삭제")
-    void cleanupUserImages_S3_삭제() {
-        UserProfileImage img1 = UserProfileImage.createCurrent(USER_ID, "key1");
-        UserProfileImage img2 = UserProfileImage.createCurrent(USER_ID, "key2");
-        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of(img1, img2));
-
-        sut.cleanupUserImages(USER_ID);
-
-        verify(s3Service).deleteObject("key1");
-        verify(s3Service).deleteObject("key2");
-    }
-
-    @Test
-    @DisplayName("cleanupUserImages 호출 시 이미지가 없으면 S3 삭제를 호출하지 않는다")
-    void cleanupUserImages_이미지_없으면_S3_호출_안_한다() {
-        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
-
-        sut.cleanupUserImages(USER_ID);
-
-        verify(s3Service, never()).deleteObject(anyString());
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -57,9 +57,7 @@ class UserServiceImplTest {
     private static final String USER_PROFILE_KEY = "user:profiles";
     private static final String TTL = "259200";
 
-    // ──────────────────────────────────────────────
     // inputInfo()
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("inputInfo 호출 시 Lua 스크립트로 user:profiles 캐시가 닉네임+TTL 포함해 원자적으로 갱신된다")
@@ -100,9 +98,7 @@ class UserServiceImplTest {
         );
     }
 
-    // ──────────────────────────────────────────────
     // updateUser()
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("updateUser 호출 시 닉네임이 있으면 Lua 스크립트로 user:profiles 캐시가 갱신된다")
@@ -160,9 +156,7 @@ class UserServiceImplTest {
         verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
     }
 
-    // ──────────────────────────────────────────────
     // withdrawUser()
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("withdrawUser 호출 시 존재하지 않는 userId면 UserNotFoundException")
@@ -203,9 +197,7 @@ class UserServiceImplTest {
         verify(s3Service, never()).deleteObject(anyString());
     }
 
-    // ──────────────────────────────────────────────
     // createUser() — 재가입 재활성화
-    // ──────────────────────────────────────────────
 
     @Test
     @DisplayName("createUser 호출 시 탈퇴한 이메일이면 기존 계정을 재활성화한다")
@@ -256,6 +248,35 @@ class UserServiceImplTest {
 
         verify(s3Service).deleteObject("key1");
         verify(s3Service).deleteObject("key2");
+    }
+
+    @Test
+    @DisplayName("cleanupUserImages 호출 시 이미지가 없으면 S3 삭제를 호출하지 않는다")
+    void cleanupUserImages_이미지_없으면_S3_호출_안_한다() {
+        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
+
+        sut.cleanupUserImages(USER_ID);
+
+        verify(s3Service, never()).deleteObject(anyString());
+    }
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 profileImageUrl과 deviceToken이 null이 된다")
+    void withdrawUser_profileImageUrl_deviceToken_null화() {
+        User user = User.builder()
+                .id(USER_ID)
+                .email("test@test.com")
+                .profileImageUrl("s3://bucket/profile.jpg")
+                .deviceToken("fcm-token")
+                .build();
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOps);
+
+        sut.withdrawUser(USER_ID);
+
+        assertThat(user.getProfileImageUrl()).isNull();
+        assertThat(user.getDeviceToken()).isNull();
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.fitpet.server.pet.domain.repository.PetRepository;
 import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.s3.S3Service;
+import com.fitpet.server.user.application.dto.UserCreateCommand;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.application.dto.UserUpdateCommand;
@@ -172,19 +173,18 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("withdrawUser 호출 시 User 익명화 + deletedAt 설정 + save 호출")
-    void withdrawUser_User_익명화_및_deletedAt_설정() {
+    @DisplayName("withdrawUser 호출 시 deletedAt만 설정되고 email/nickname은 변경되지 않는다")
+    void withdrawUser_deletedAt만_설정() {
         User user = User.builder().id(USER_ID).email("test@test.com").nickname("테스트").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);
 
         sut.withdrawUser(USER_ID);
 
         assertThat(user.getDeletedAt()).isNotNull();
-        assertThat(user.getEmail()).startsWith("deleted_");
-        assertThat(user.getNickname()).startsWith("deleted_");
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getNickname()).isEqualTo("테스트");
         verify(userRepository).save(user);
     }
 
@@ -193,7 +193,6 @@ class UserServiceImplTest {
     void withdrawUser_이미지_DB_삭제() {
         User user = User.builder().id(USER_ID).email("test@test.com").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);
 
@@ -201,6 +200,48 @@ class UserServiceImplTest {
 
         verify(profileImageRepository).deleteAllByUserId(USER_ID);
         verify(s3Service, never()).deleteObject(anyString());
+    }
+
+    // ──────────────────────────────────────────────
+    // createUser() — 재가입 재활성화
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("createUser 호출 시 탈퇴한 이메일이면 기존 계정을 재활성화한다")
+    void createUser_탈퇴_이메일_재활성화() {
+        User deleted = User.builder()
+                .id(USER_ID).email("test@test.com").nickname("기존닉네임")
+                .build();
+        deleted.withdraw();
+
+        when(userRepository.findByEmailIncludeDeleted("test@test.com")).thenReturn(Optional.of(deleted));
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        when(userRepository.save(any())).thenReturn(deleted);
+        when(userMapper.toResult(any())).thenReturn(UserResult.builder().userId(USER_ID).build());
+
+        UserCreateCommand command = new UserCreateCommand("test@test.com", "pass", "닉네임", null, null, null, null, null, null, null, null);
+        sut.createUser(command);
+
+        assertThat(deleted.getDeletedAt()).isNull();
+        verify(userRepository).save(deleted);
+    }
+
+    @Test
+    @DisplayName("createUser 호출 시 탈퇴 이력 없는 이메일이면 신규 가입한다")
+    void createUser_탈퇴_이력_없으면_신규_가입() {
+        when(userRepository.findByEmailIncludeDeleted("new@test.com")).thenReturn(Optional.empty());
+        when(userRepository.existsByEmail("new@test.com")).thenReturn(false);
+        when(userRepository.existsByNickname("새닉네임")).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        User newUser = User.builder().id(2L).email("new@test.com").build();
+        when(userMapper.toEntity(any())).thenReturn(newUser);
+        when(userRepository.save(any())).thenReturn(newUser);
+        when(userMapper.toResult(any())).thenReturn(UserResult.builder().userId(2L).build());
+
+        UserCreateCommand command = new UserCreateCommand("new@test.com", "pass", "새닉네임", null, null, null, null, null, null, null, null);
+        sut.createUser(command);
+
+        verify(userRepository).save(newUser);
     }
 
     @Test
@@ -221,7 +262,6 @@ class UserServiceImplTest {
     void withdrawUser_Redis_캐시_삭제() {
         User user = User.builder().id(USER_ID).email("test@test.com").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);
 

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -1,13 +1,18 @@
 package com.fitpet.server.user.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fitpet.server.pet.domain.repository.PetRepository;
+import com.fitpet.server.shared.exception.BusinessException;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
@@ -16,6 +21,8 @@ import com.fitpet.server.user.application.mapper.UserMapper;
 import com.fitpet.server.user.domain.entity.Gender;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.entity.UserProfileImage;
+import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -148,6 +156,72 @@ class UserServiceImplTest {
 
         // then
         verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
+    }
+
+    // ──────────────────────────────────────────────
+    // withdrawUser()
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 존재하지 않는 userId면 UserNotFoundException")
+    void withdrawUser_존재하지_않는_userId면_예외() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sut.withdrawUser(999L))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 User 익명화 + deletedAt 설정 + save 호출")
+    void withdrawUser_User_익명화_및_deletedAt_설정() {
+        User user = User.builder().id(USER_ID).email("test@test.com").nickname("테스트").build();
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
+        HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOps);
+
+        sut.withdrawUser(USER_ID);
+
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(user.getEmail()).startsWith("deleted_");
+        assertThat(user.getNickname()).startsWith("deleted_");
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 프로필 이미지 S3 삭제 + DB 전체 삭제")
+    void withdrawUser_프로필_이미지_S3_및_DB_삭제() {
+        User user = User.builder().id(USER_ID).email("test@test.com").build();
+        UserProfileImage img1 = UserProfileImage.createCurrent(USER_ID, "key1");
+        UserProfileImage img2 = UserProfileImage.createCurrent(USER_ID, "key2");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of(img1, img2));
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
+        HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOps);
+
+        sut.withdrawUser(USER_ID);
+
+        verify(s3Service).deleteObject("key1");
+        verify(s3Service).deleteObject("key2");
+        verify(profileImageRepository).deleteAllByUserId(USER_ID);
+    }
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 Redis user:profiles, user:images 캐시 삭제")
+    void withdrawUser_Redis_캐시_삭제() {
+        User user = User.builder().id(USER_ID).email("test@test.com").build();
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
+        HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOps);
+
+        sut.withdrawUser(USER_ID);
+
+        verify(hashOps).delete("user:profiles", String.valueOf(USER_ID));
+        verify(hashOps).delete("user:images", String.valueOf(USER_ID));
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -255,7 +255,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("withdrawUser 호출 시 Redis user:profiles, user:images 캐시 삭제")
+    @DisplayName("withdrawUser 호출 시 Redis user:profiles, user:images, user:genders 캐시 삭제")
     void withdrawUser_Redis_캐시_삭제() {
         User user = User.builder().id(USER_ID).email("test@test.com").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -266,6 +266,7 @@ class UserServiceImplTest {
 
         verify(hashOps).delete("user:profiles", String.valueOf(USER_ID));
         verify(hashOps).delete("user:images", String.valueOf(USER_ID));
+        verify(hashOps).delete("user:genders", String.valueOf(USER_ID));
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -176,7 +176,6 @@ class UserServiceImplTest {
     void withdrawUser_User_익명화_및_deletedAt_설정() {
         User user = User.builder().id(USER_ID).email("test@test.com").nickname("테스트").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
         when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);
@@ -190,22 +189,31 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("withdrawUser 호출 시 프로필 이미지 S3 삭제 + DB 전체 삭제")
-    void withdrawUser_프로필_이미지_S3_및_DB_삭제() {
+    @DisplayName("withdrawUser 호출 시 이미지 DB 전체 삭제 (S3 삭제는 cleanupUserImages 담당)")
+    void withdrawUser_이미지_DB_삭제() {
         User user = User.builder().id(USER_ID).email("test@test.com").build();
-        UserProfileImage img1 = UserProfileImage.createCurrent(USER_ID, "key1");
-        UserProfileImage img2 = UserProfileImage.createCurrent(USER_ID, "key2");
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of(img1, img2));
         when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);
 
         sut.withdrawUser(USER_ID);
 
+        verify(profileImageRepository).deleteAllByUserId(USER_ID);
+        verify(s3Service, never()).deleteObject(anyString());
+    }
+
+    @Test
+    @DisplayName("cleanupUserImages 호출 시 모든 프로필 이미지 S3 삭제")
+    void cleanupUserImages_S3_삭제() {
+        UserProfileImage img1 = UserProfileImage.createCurrent(USER_ID, "key1");
+        UserProfileImage img2 = UserProfileImage.createCurrent(USER_ID, "key2");
+        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of(img1, img2));
+
+        sut.cleanupUserImages(USER_ID);
+
         verify(s3Service).deleteObject("key1");
         verify(s3Service).deleteObject("key2");
-        verify(profileImageRepository).deleteAllByUserId(USER_ID);
     }
 
     @Test
@@ -213,7 +221,6 @@ class UserServiceImplTest {
     void withdrawUser_Redis_캐시_삭제() {
         User user = User.builder().id(USER_ID).email("test@test.com").build();
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(profileImageRepository.findAllByUserId(USER_ID)).thenReturn(List.of());
         when(passwordEncoder.encode(anyString())).thenReturn("encoded_dummy");
         HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
         when(redisTemplate.opsForHash()).thenReturn(hashOps);

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -23,6 +23,7 @@ import com.fitpet.server.user.domain.entity.Gender;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.entity.UserProfileImage;
+import com.fitpet.server.user.domain.exception.DuplicateEmailException;
 import com.fitpet.server.user.domain.exception.UserNotFoundException;
 import com.fitpet.server.user.domain.repository.UserRepository;
 import java.util.List;
@@ -269,6 +270,33 @@ class UserServiceImplTest {
 
         verify(hashOps).delete("user:profiles", String.valueOf(USER_ID));
         verify(hashOps).delete("user:images", String.valueOf(USER_ID));
+    }
+
+    @Test
+    @DisplayName("createUser 호출 시 활성 계정(deletedAt==null)과 이메일 중복이면 DuplicateEmailException")
+    void createUser_활성_계정_이메일_중복이면_예외() {
+        User activeUser = User.builder().id(USER_ID).email("exist@test.com").build();
+        // deletedAt == null → filter 통과 못함 → orElseGet → validateUserCreateRequest
+        when(userRepository.findByEmailIncludeDeleted("exist@test.com")).thenReturn(Optional.of(activeUser));
+        when(userRepository.existsByEmail("exist@test.com")).thenReturn(true);
+
+        UserCreateCommand command = new UserCreateCommand("exist@test.com", "pass", "닉네임", null, null, null, null, null, null, null, null);
+
+        assertThatThrownBy(() -> sut.createUser(command))
+                .isInstanceOf(DuplicateEmailException.class);
+    }
+
+    @Test
+    @DisplayName("withdrawUser 호출 시 user.withdraw()가 호출되어 deletedAt이 설정된다")
+    void withdrawUser_호출_시_deletedAt_설정() {
+        User user = User.builder().id(USER_ID).email("test@test.com").build();
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        HashOperations<String, Object, Object> hashOps = mock(HashOperations.class);
+        when(redisTemplate.opsForHash()).thenReturn(hashOps);
+
+        sut.withdrawUser(USER_ID);
+
+        assertThat(user.getDeletedAt()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/fitpet/server/user/domain/entity/UserTest.java
+++ b/src/test/java/com/fitpet/server/user/domain/entity/UserTest.java
@@ -1,0 +1,89 @@
+package com.fitpet.server.user.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    // ──────────────────────────────────────────────
+    // withdraw()
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("withdraw 호출 시 deletedAt이 설정된다")
+    void withdraw_deletedAt_설정() {
+        User user = User.builder().id(1L).email("test@test.com").build();
+
+        user.withdraw();
+
+        assertThat(user.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("withdraw 호출 시 profileImageUrl과 deviceToken이 null이 된다")
+    void withdraw_profileImageUrl_deviceToken_null화() {
+        User user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .profileImageUrl("s3://bucket/profile.jpg")
+                .deviceToken("fcm-token-abc")
+                .build();
+
+        user.withdraw();
+
+        assertThat(user.getProfileImageUrl()).isNull();
+        assertThat(user.getDeviceToken()).isNull();
+    }
+
+    @Test
+    @DisplayName("withdraw 호출 후 email, nickname 등 다른 필드는 변경되지 않는다")
+    void withdraw_다른_필드는_유지() {
+        User user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스트닉네임")
+                .registrationStatus(RegistrationStatus.COMPLETE)
+                .build();
+
+        user.withdraw();
+
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getNickname()).isEqualTo("테스트닉네임");
+        assertThat(user.getRegistrationStatus()).isEqualTo(RegistrationStatus.COMPLETE);
+    }
+
+    // ──────────────────────────────────────────────
+    // reactivate()
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("reactivate 호출 시 deletedAt이 null로 복원된다")
+    void reactivate_deletedAt_null_복원() {
+        User user = User.builder().id(1L).email("test@test.com").build();
+        user.withdraw();
+        assertThat(user.getDeletedAt()).isNotNull();
+
+        user.reactivate();
+
+        assertThat(user.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("withdraw 후 reactivate 연속 호출 시 deletedAt이 null로 복원된다")
+    void withdraw_후_reactivate_정상_복원() {
+        User user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("닉네임")
+                .build();
+
+        user.withdraw();
+        user.reactivate();
+
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getNickname()).isEqualTo("닉네임");
+    }
+}

--- a/src/test/java/com/fitpet/server/user/infra/jpa/UserSoftDeleteRepositoryTest.java
+++ b/src/test/java/com/fitpet/server/user/infra/jpa/UserSoftDeleteRepositoryTest.java
@@ -1,0 +1,137 @@
+package com.fitpet.server.user.infra.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fitpet.server.user.domain.entity.User;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ActiveProfiles("test")
+class UserSoftDeleteRepositoryTest {
+
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    @Autowired
+    TestEntityManager em;
+
+    // ──────────────────────────────────────────────
+    // @SQLRestriction 동작 검증
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("탈퇴한 계정은 findByEmail로 조회되지 않는다 (@SQLRestriction)")
+    void findByEmail_탈퇴_계정_조회_안_됨() {
+        User user = savedUser("soft@test.com", null, null);
+        user.withdraw();
+        userJpaRepository.saveAndFlush(user);
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findByEmail("soft@test.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("탈퇴한 계정은 findById로 조회되지 않는다 (@SQLRestriction)")
+    void findById_탈퇴_계정_조회_안_됨() {
+        User user = savedUser("byid@test.com", null, null);
+        user.withdraw();
+        userJpaRepository.saveAndFlush(user);
+        Long id = user.getId();
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findById(id);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("활성 계정은 findByEmail로 정상 조회된다")
+    void findByEmail_활성_계정_정상_조회() {
+        savedUser("active@test.com", null, null);
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findByEmail("active@test.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getDeletedAt()).isNull();
+    }
+
+    // ──────────────────────────────────────────────
+    // native query — @SQLRestriction 우회 검증
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("탈퇴한 계정은 findByEmailIncludeDeleted로 조회된다 (native query)")
+    void findByEmailIncludeDeleted_탈퇴_계정_조회_됨() {
+        User user = savedUser("deleted@test.com", null, null);
+        user.withdraw();
+        userJpaRepository.saveAndFlush(user);
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findByEmailIncludeDeleted("deleted@test.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("탈퇴한 소셜 계정은 findByOAuthIncludeDeleted로 조회된다 (native query)")
+    void findByOAuthIncludeDeleted_탈퇴_소셜_계정_조회_됨() {
+        User user = savedUser("kakao@test.com", "KAKAO", "kakao-uid-123");
+        user.withdraw();
+        userJpaRepository.saveAndFlush(user);
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findByOAuthIncludeDeleted("KAKAO", "kakao-uid-123");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getDeletedAt()).isNotNull();
+        assertThat(result.get().getProvider()).isEqualTo("KAKAO");
+        assertThat(result.get().getProviderUid()).isEqualTo("kakao-uid-123");
+    }
+
+    @Test
+    @DisplayName("활성 소셜 계정도 findByOAuthIncludeDeleted로 조회된다")
+    void findByOAuthIncludeDeleted_활성_소셜_계정_조회_됨() {
+        savedUser("google@test.com", "GOOGLE", "google-uid-456");
+        em.clear();
+
+        Optional<User> result = userJpaRepository.findByOAuthIncludeDeleted("GOOGLE", "google-uid-456");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("findByEmailIncludeDeleted는 존재하지 않는 이메일이면 empty를 반환한다")
+    void findByEmailIncludeDeleted_없는_이메일이면_empty() {
+        Optional<User> result = userJpaRepository.findByEmailIncludeDeleted("none@test.com");
+
+        assertThat(result).isEmpty();
+    }
+
+    // ──────────────────────────────────────────────
+    // helper
+    // ──────────────────────────────────────────────
+
+    private User savedUser(String email, String provider, String providerUid) {
+        User user = User.builder()
+                .email(email)
+                .password("encoded-pw")
+                .provider(provider)
+                .providerUid(providerUid)
+                .build();
+        return userJpaRepository.saveAndFlush(user);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,10 +1,12 @@
 spring:
   # H2 데이터베이스 설정
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=VALUE
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      connection-init-sql: # application.yaml의 SET time_zone 덮어쓰기
 
   # JPA 설정
   jpa:


### PR DESCRIPTION
## 📌 PR 요약

회원 탈퇴 시 물리 삭제 대신 `deleted_at` 컬럼으로 소프트 딜리트를 적용합니다.
탈퇴 계정은 일반 조회에서 자동 필터링되며
동일 이메일/OAuth로 재가입 시 기존 계정을 재활성화합니다.

## ✅ 작업 상세 내용

- [x] **Soft Delete 적용**
  - `User` 엔티티에 `@SQLRestriction("deleted_at IS NULL")` 추가 — 일반 JPA 쿼리에서 탈퇴 계정 자동 필터
  - `withdraw()` 도메인 메서드 — `deletedAt` 설정, `deviceToken` null화
  - `reactivate()` 도메인 메서드 — `deletedAt` null 복원

- [x] **회원 탈퇴 플로우 구현 (DB/Redis/Token 분리)**
  - `UserService.withdrawUser()` — Redis 캐시 삭제 + soft delete (`@Transactional`)
  - `AuthService.revokeTokens()` — Redis refresh token 삭제

- [x] **재가입 시 계정 재활성화**
  - 일반 회원가입: 동일 이메일 탈퇴 계정 발견 시 비밀번호 변경 후 재활성화 
  - Google/Kakao OAuth 로그인: provider+uid 또는 이메일로 탈퇴 계정 조회 후 재활성화

## 🧪 테스트 방법


<img width="901" height="276" alt="image" src="https://github.com/user-attachments/assets/0ab83ab3-8216-403d-86b3-c38bd8deafb2" />
<img width="922" height="315" alt="image" src="https://github.com/user-attachments/assets/9a41ed2f-2f8e-4807-b4a7-e5a9386fdb05" />
<img width="966" height="517" alt="image" src="https://github.com/user-attachments/assets/fd01c1d3-3429-41ae-a904-dbd70fd1d2cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 탈퇴(철회) 시 연관된 인증 토큰이 자동으로 취소됩니다.
  * 탈퇴한 계정은 재활성화(복구)되어 재가입 시 기존 정보가 복원됩니다.
  * 탈퇴 시 프로필 이미지와 관련 캐시가 정리됩니다.

* **테스트**
  * 소셜 로그인, 계정 생성/재활성화, 탈퇴 및 토큰 취소 흐름에 대한 단위/통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->