### PR TITLE
feat: 랭킹 추월 FCM 푸시 알림 파이프라인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
+    // RabbitMQ (랭킹 추월 알림 비동기 처리)
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     // GCP
     implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.27.1"
 }

--- a/docker-compose.mq.yml
+++ b/docker-compose.mq.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: fitpet-rabbitmq
+    ports:
+      - "5672:5672"      # AMQP 프로토콜 포트
+      - "15672:15672"    # 관리 UI (http://localhost:15672)
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-fitpet}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-fitpet}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: [ "CMD", "rabbitmq-diagnostics", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  rabbitmq_data:
+    driver: local

--- a/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
@@ -1,0 +1,36 @@
+package com.fitpet.server.ranking.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * RabbitMQ로 발행하는 추월 알림 메시지 DTO.
+ *
+ * <p>JSON 직렬화를 위해 기본 생성자가 필요하다.</p>
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OvertakeMessage {
+
+    /** 아웃박스 ID (중복 발송 추적용) */
+    private Long outboxId;
+
+    /** 추월 당한 사용자 (알림 수신자) */
+    private Long overtakenUserId;
+
+    /** 추월 한 사용자 */
+    private Long overtakingUserId;
+
+    /** 추월 한 사용자의 닉네임 */
+    private String overtakingUserNickname;
+
+    /** 랭킹 날짜 키 */
+    private String dateKey;
+
+    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
+    private int overtakerCount;
+}

--- a/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
+++ b/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
@@ -1,0 +1,24 @@
+package com.fitpet.server.ranking.application.event;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 랭킹 점수 업데이트 이벤트.
+ *
+ * <p>Lua 스크립트로 Redis ZSet이 갱신된 직후 발행된다.
+ * {@link com.fitpet.server.ranking.application.service.RankingOvertakeDetectorService}가
+ * 비동기로 수신하여 추월 알림 파이프라인을 시작한다.</p>
+ *
+ * @param userId      점수를 올린 사용자
+ * @param previousRank 업데이트 전 0-indexed 순위 (처음 진입이면 null)
+ * @param date        랭킹 날짜
+ */
+@Getter
+@AllArgsConstructor
+public class RankingScoreUpdatedEvent {
+    private final Long userId;
+    private final Long previousRank;
+    private final LocalDate date;
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
@@ -1,0 +1,41 @@
+package com.fitpet.server.ranking.application.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 랭킹 추월 알림 Rate Limiter.
+ *
+ * <h2>100명이 한꺼번에 추월하는 문제</h2>
+ * <p>사용자 A가 걸음수를 크게 올려 100명을 한 번에 추월하면, 100개의 아웃박스 이벤트가
+ * 생성될 수 있다. 각 피추월자(overtaken user)에게 알림이 1시간에 최대 1회만 발송되도록
+ * Redis SETNX + TTL 방식으로 제한한다.</p>
+ *
+ * <p>Redis 키: {@code notification:ratelimit:overtake:{overtakenUserId}}<br>
+ * TTL: 1시간</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class OvertakeNotificationRateLimiter {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "notification:ratelimit:overtake:";
+    private static final Duration TTL = Duration.ofHours(1);
+
+    /**
+     * 알림 발송 슬롯을 획득한다.
+     *
+     * @param overtakenUserId 알림을 받을 사용자
+     * @return 슬롯 획득 성공(발송 허용)이면 {@code true},
+     *         이미 해당 시간대에 알림이 발송됐으면 {@code false}
+     */
+    public boolean tryAcquire(Long overtakenUserId) {
+        String key = KEY_PREFIX + overtakenUserId;
+        // SETNX : key가 없을 때만 세팅 → 원자적으로 중복 차단
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, "1", TTL);
+        return Boolean.TRUE.equals(acquired);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
@@ -1,0 +1,20 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
+
+/**
+ * 랭킹 추월 감지 서비스.
+ *
+ * <p>Redis ZSet 에서 순위 변동을 계산하여 추월 당한 사용자들을 찾고
+ * 아웃박스 이벤트를 저장한다.</p>
+ */
+public interface RankingOvertakeDetectorService {
+
+    /**
+     * {@link RankingScoreUpdatedEvent} 수신 후 비동기로 추월 여부를 감지하고
+     * 아웃박스 이벤트를 저장한다.
+     *
+     * <p>{@code @Async}로 실행되므로 호출 스레드를 블록하지 않는다.</p>
+     */
+    void onRankingScoreUpdated(RankingScoreUpdatedEvent event);
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
@@ -1,0 +1,127 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 랭킹 추월 감지 구현체.
+ *
+ * <h2>추월 감지 알고리즘</h2>
+ * <pre>
+ * ZSet (ZREVRANGE 기준, 0-indexed):
+ *   업데이트 전  : ... [rank 2] [rank 3] [rank 4] [rank 5 = user A] ...
+ *   업데이트 후  : ... [rank 2 = user A] [rank 3] [rank 4] [rank 5] ...
+ *
+ *   previousRank = 4 (0-indexed, 업데이트 전)
+ *   newRank      = 1 (0-indexed, 업데이트 후)
+ *   추월 당한 사용자 위치 (업데이트 후 기준): newRank+1 ~ previousRank
+ * </pre>
+ *
+ * <h2>동시성 고려</h2>
+ * <p>복수의 사용자가 동시에 점수를 업데이트할 때 순위 스냅샷이 미세하게 달라질 수 있다.
+ * 알림 특성상 완벽한 정합성보다 low-latency + best-effort 가 더 적합하므로
+ * 락 없이 처리한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetectorService {
+
+    private static final String RANKING_KEY_PREFIX = "ranking:daily:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final RankingOvertakeOutboxRepository outboxRepository;
+    private final OvertakeNotificationRateLimiter rateLimiter;
+
+    /**
+     * Spring 이벤트를 비동기로 수신한다.
+     *
+     * <p>{@code @Async} 덕분에 랭킹 업데이트 요청 스레드를 블록하지 않는다.
+     * 별도 스레드풀에서 실행되며, {@code @Transactional}로 아웃박스 저장을 보호한다.</p>
+     */
+    @Async
+    @EventListener
+    @Transactional
+    @Override
+    public void onRankingScoreUpdated(RankingScoreUpdatedEvent event) {
+        try {
+            handleOvertake(event);
+        } catch (Exception e) {
+            log.error("[OvertakeDetector] 처리 중 예외 발생: userId={}", event.getUserId(), e);
+        }
+    }
+
+    private void handleOvertake(RankingScoreUpdatedEvent event) {
+        log.info("[OvertakeDetector] 이벤트 수신: userId={}, previousRank={}, date={}",
+                event.getUserId(), event.getPreviousRank(), event.getDate());
+
+        Long previousRank = event.getPreviousRank();
+
+        // 랭킹에 처음 진입한 경우 추월한 사람이 없음
+        if (previousRank == null) {
+            log.info("[OvertakeDetector] previousRank null → 조기 종료 (처음 진입)");
+            return;
+        }
+
+        String allRankingKey = RANKING_KEY_PREFIX + event.getDate();
+        String userIdStr = String.valueOf(event.getUserId());
+
+        Long newRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
+
+        // 순위가 오르지 않은 경우 (같거나 낮아졌으면 추월 없음)
+        if (newRank == null || newRank >= previousRank) {
+            return;
+        }
+
+        // 업데이트 후 기준으로 newRank+1 ~ previousRank 위치에 있는 사용자들이 추월 당한 사람들
+        Set<String> overtakenUserIds = redisTemplate.opsForZSet()
+                .reverseRange(allRankingKey, newRank + 1, previousRank);
+
+        if (overtakenUserIds == null || overtakenUserIds.isEmpty()) {
+            return;
+        }
+
+        log.info("[OvertakeDetector] 추월 감지: overtakingUserId={}, newRank={}, previousRank={}, overtakenCount={}",
+                event.getUserId(), newRank + 1, previousRank + 1, overtakenUserIds.size());
+
+        int savedCount = 0;
+        for (String overtakenIdStr : overtakenUserIds) {
+            Long overtakenUserId = Long.parseLong(overtakenIdStr);
+
+            // 자기 자신은 제외 (방어 코드)
+            if (overtakenUserId.equals(event.getUserId())) {
+                continue;
+            }
+
+            // Rate limit 체크: 1시간에 1번만 알림 발송
+            if (!rateLimiter.tryAcquire(overtakenUserId)) {
+                log.debug("[OvertakeDetector] Rate limit 초과 - userId={}", overtakenUserId);
+                continue;
+            }
+
+            outboxRepository.save(
+                    RankingOvertakeOutbox.builder()
+                            .overtakenUserId(overtakenUserId)
+                            .overtakingUserId(event.getUserId())
+                            .dateKey(event.getDate().toString())
+                            .overtakerCount(1) // 단일 이벤트당 1명 추월 (향후 집계 확장 가능)
+                            .build()
+            );
+            savedCount++;
+        }
+
+        if (savedCount > 0) {
+            log.info("[OvertakeDetector] 아웃박스 저장 완료: {} 건", savedCount);
+        }
+    }
+}
+

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -3,6 +3,7 @@ package com.fitpet.server.ranking.application.service;
 import com.fitpet.server.dailywalk.domain.entity.DailyWalk;
 import com.fitpet.server.dailywalk.domain.repository.DailyWalkRepository;
 import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
 import com.fitpet.server.ranking.domain.type.RankingFilter;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.user.domain.entity.User;
@@ -102,6 +103,10 @@ public class RankingServiceImpl implements RankingService {
 
         String allRankingKey = getRankingKey(date, RankingFilter.ALL);
 
+        // ── 추월 감지를 위해 Lua 실행 전 현재 순위를 스냅샷 ──────────────────
+        // ZREVRANK: 0-indexed (0 = 1위). 처음 진입하면 null 반환.
+        Long previousRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
+
         List<String> keys = (gender != RankingFilter.ALL)
                 ? List.of(DAILYWALK_STEPS_KEY + dateStr, DAILYWALK_DISTANCE_KEY + dateStr,
                           DAILYWALK_CALORIES_KEY + dateStr, DAILYWALK_DIRTY_KEY + dateStr,
@@ -121,6 +126,12 @@ public class RankingServiceImpl implements RankingService {
         );
 
         log.info("[RankingService] 걸음수 Hash + 랭킹 ZSet SET 업데이트: userId={}, totalSteps={}", userId, totalSteps);
+
+        // ── 추월 감지 이벤트 발행 (비동기 처리) ─────────────────────────────
+        // RankingOvertakeDetectorService 가 @Async @EventListener 로 수신하여
+        // 별도 스레드에서 아웃박스 이벤트를 저장한다.
+        eventPublisher.publishEvent(new RankingScoreUpdatedEvent(userId, previousRank, date));
+
         return result != null ? result : totalSteps;
     }
 

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.ranking.domain.entity;
+
+public enum OutboxStatus {
+    /** MQ 발행 대기 중 */
+    PENDING,
+    /** MQ 발행 완료 (소비는 MQ가 보장) */
+    PUBLISHED,
+    /** 재시도 초과 – 수동 확인 필요 */
+    FAILED
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
@@ -1,0 +1,92 @@
+package com.fitpet.server.ranking.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 랭킹 추월 아웃박스 이벤트 테이블.
+ *
+ * <h2>아웃박스 패턴(Outbox Pattern) 적용 이유</h2>
+ * <p>랭킹 업데이트는 Redis(Lua 스크립트)에서 일어나고, 알림 발송은 RabbitMQ를 통해
+ * 별도 스레드에서 처리된다. 두 작업은 단일 트랜잭션으로 묶을 수 없으므로,
+ * "MQ 발행 전 DB에 이벤트 기록 → 폴러가 PENDING 이벤트를 MQ에 발행 → PUBLISHED 처리"
+ * 흐름으로 중간 유실을 방지한다.</p>
+ *
+ * <h2>보상 트랜잭션(Compensating Transaction) 고려</h2>
+ * <p>알림은 비즈니스 크리티컬하지 않으므로 Redis 롤백 없이 best-effort 처리한다.
+ * 아웃박스 저장 실패 시 알림이 누락되지만 랭킹 데이터 정합성은 유지된다.</p>
+ */
+@Entity
+@Table(name = "ranking_overtake_outbox")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class RankingOvertakeOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbox_id")
+    private Long id;
+
+    /** 추월 당한 사용자 (알림 수신자) */
+    @Column(name = "overtaken_user_id", nullable = false)
+    private Long overtakenUserId;
+
+    /** 추월 한 사용자 */
+    @Column(name = "overtaking_user_id", nullable = false)
+    private Long overtakingUserId;
+
+    /** 랭킹 날짜 키 (예: 2026-04-15) */
+    @Column(name = "date_key", nullable = false, length = 10)
+    private String dateKey;
+
+    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
+    @Column(name = "overtaker_count", nullable = false)
+    @Builder.Default
+    private int overtakerCount = 1;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private int retryCount = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.ranking.domain.repository;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import java.util.List;
+
+public interface RankingOvertakeOutboxRepository {
+
+    RankingOvertakeOutbox save(RankingOvertakeOutbox outbox);
+
+    /**
+     * PENDING 상태의 아웃박스 이벤트를 생성 순서대로 최대 {@code limit}건 조회한다.
+     * 폴러가 배치 단위로 호출한다.
+     */
+    List<RankingOvertakeOutbox> findPendingBatch(int limit);
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
@@ -1,0 +1,12 @@
+package com.fitpet.server.ranking.infra.jpa;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingOvertakeOutboxJpaRepository extends JpaRepository<RankingOvertakeOutbox, Long> {
+
+    List<RankingOvertakeOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status, Pageable pageable);
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.fitpet.server.ranking.infra.jpa;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingOvertakeOutboxRepositoryAdapter implements RankingOvertakeOutboxRepository {
+
+    private final RankingOvertakeOutboxJpaRepository jpaRepository;
+
+    @Override
+    public RankingOvertakeOutbox save(RankingOvertakeOutbox outbox) {
+        return jpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<RankingOvertakeOutbox> findPendingBatch(int limit) {
+        return jpaRepository.findByStatusOrderByCreatedAtAsc(
+                OutboxStatus.PENDING,
+                PageRequest.of(0, limit)
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
@@ -1,0 +1,31 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Dead Letter Queue 리스너.
+ *
+ * <p>3회 재시도 후에도 FCM 발송에 실패한 메시지는 DLQ 로 이동한다.
+ * 현재는 에러 로그만 남기지만, 향후 Slack/PagerDuty 알림, 재처리 배치 등으로 확장 가능하다.</p>
+ *
+ * <h2>데드 큐 처리 전략</h2>
+ * <ul>
+ *   <li>메시지 내용을 로그로 남겨 운영팀이 확인할 수 있게 한다.</li>
+ *   <li>FCM 토큰이 만료된 경우 → User 테이블에서 토큰 삭제하는 배치로 연계 가능.</li>
+ *   <li>RabbitMQ 서버 오류인 경우 → 수동으로 DLQ 메시지를 원래 큐로 re-publish 한다.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class DlqEventListener {
+
+    @RabbitListener(queues = RabbitMQConfig.DLQ)
+    public void handleDeadLetter(OvertakeMessage message) {
+        log.error("[DLQ] 최종 처리 실패 메시지 수신 – 수동 확인 필요: outboxId={}, overtakenUserId={}, overtakingUserId={}",
+                message.getOutboxId(), message.getOvertakenUserId(), message.getOvertakingUserId());
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
@@ -1,0 +1,118 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import com.fitpet.server.alram.domain.repository.AlramRepository;
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserDeviceRepository;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.List;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 랭킹 추월 알림 MQ 소비자.
+ *
+ * <h2>처리 흐름</h2>
+ * <ol>
+ *   <li>수신된 메시지에서 피추월자 정보를 조회한다.</li>
+ *   <li>알림 수신 동의 및 디바이스 토큰을 확인한다.</li>
+ *   <li>FCM 푸시 알림을 발송한다.</li>
+ *   <li>알림 발송 이력을 DB에 저장한다.</li>
+ * </ol>
+ *
+ * <h2>실패 처리</h2>
+ * <p>FCM 예외 발생 시 {@link RuntimeException} 으로 재포장하면 Spring AMQP 가
+ * {@link RabbitMQConfig#rankingOvertakeRetryInterceptor()} 정책에 따라 재시도한다.
+ * 3회 초과 시 Dead Letter Queue 로 이동한다.</p>
+ *
+ * <h2>멱등성</h2>
+ * <p>Rate Limiter(Redis)가 아웃박스 저장 시점에 이미 중복 발송을 차단하므로
+ * 소비자 레벨에서는 추가 멱등성 처리 없이 단순하게 유지한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingOvertakeConsumer {
+
+    private static final String NOTIFICATION_TITLE = "랭킹 변동 알림 🏃";
+
+    private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final FirebaseMessaging firebaseMessaging;
+    private final AlramRepository alramRepository;
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE, containerFactory = "rankingOvertakeListenerFactory")
+    @Transactional
+    public void consume(OvertakeMessage message) {
+        log.info("[OvertakeConsumer] 처리 시작: outboxId={}, overtakenUserId={}",
+                message.getOutboxId(), message.getOvertakenUserId());
+
+        User overtakenUser = userRepository.findById(message.getOvertakenUserId()).orElse(null);
+        if (overtakenUser == null) {
+            log.warn("[OvertakeConsumer] 사용자 없음 – 메시지 폐기: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        // 알림 수신 동의 확인
+        if (!Boolean.TRUE.equals(overtakenUser.getAllowActivityNotification())) {
+            log.info("[OvertakeConsumer] 알림 수신 거부 – 건너뜀: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        List<String> deviceTokens = userDeviceRepository.findAllTokensByUserId(message.getOvertakenUserId());
+        if (deviceTokens.isEmpty()) {
+            log.warn("[OvertakeConsumer] 디바이스 토큰 없음 – 건너뜀: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        String body = message.getOvertakerCount() + "명에게 순위를 추월당했어요! 달려볼까요? 🏃";
+
+        deviceTokens.forEach(token -> sendFcm(token, body, message));
+        saveAlramHistory(overtakenUser, body);
+
+        log.info("[OvertakeConsumer] 처리 완료: outboxId={}", message.getOutboxId());
+    }
+
+    private void sendFcm(String deviceToken, String body, OvertakeMessage message) {
+        Message fcmMessage = Message.builder()
+                .setToken(deviceToken)
+                .setNotification(Notification.builder()
+                        .setTitle(NOTIFICATION_TITLE)
+                        .setBody(body)
+                        .build())
+                .putData("type", "RANKING_OVERTAKE")
+                .putData("overtakingUserId", String.valueOf(message.getOvertakingUserId()))
+                .putData("dateKey", message.getDateKey())
+                .build();
+
+        try {
+            String fcmId = firebaseMessaging.send(fcmMessage);
+            log.info("[OvertakeConsumer] FCM 발송 성공: messageId={}, overtakenUserId={}",
+                    fcmId, message.getOvertakenUserId());
+        } catch (FirebaseMessagingException e) {
+            // 예외를 던져야 Spring AMQP 가 재시도 → 최종적으로 DLQ 로 이동한다.
+            log.error("[OvertakeConsumer] FCM 발송 실패: overtakenUserId={}", message.getOvertakenUserId(), e);
+            throw new RuntimeException("FCM 발송 실패 – 재시도 예정", e);
+        }
+    }
+
+    @Transactional
+    protected void saveAlramHistory(User overtakenUser, String body) {
+        alramRepository.save(
+                AlramMessage.builder()
+                        .user(overtakenUser)
+                        .title(NOTIFICATION_TITLE)
+                        .message(body)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
@@ -1,0 +1,55 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 아웃박스 이벤트를 RabbitMQ 로 발행하는 컴포넌트.
+ *
+ * <p>폴러({@link com.fitpet.server.ranking.infra.scheduler.OvertakeOutboxPollerScheduler})가
+ * PENDING 이벤트 배치를 가져와 이 클래스를 통해 메시지를 발행한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingOvertakePublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final UserRepository userRepository;
+
+    /**
+     * 아웃박스 이벤트 한 건을 MQ 로 발행한다.
+     *
+     * @param outbox PENDING 상태의 아웃박스 이벤트
+     */
+    public void publish(RankingOvertakeOutbox outbox) {
+        String nickname = userRepository.findById(outbox.getOvertakingUserId())
+                .map(User::getNickname)
+                .orElse("누군가");
+
+        OvertakeMessage message = OvertakeMessage.builder()
+                .outboxId(outbox.getId())
+                .overtakenUserId(outbox.getOvertakenUserId())
+                .overtakingUserId(outbox.getOvertakingUserId())
+                .overtakingUserNickname(nickname)
+                .dateKey(outbox.getDateKey())
+                .overtakerCount(outbox.getOvertakerCount())
+                .build();
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.EXCHANGE,
+                RabbitMQConfig.ROUTING_KEY,
+                message
+        );
+
+        log.debug("[OvertakePublisher] 메시지 발행: outboxId={}, overtakenUserId={}",
+                outbox.getId(), outbox.getOvertakenUserId());
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
@@ -1,0 +1,80 @@
+package com.fitpet.server.ranking.infra.scheduler;
+
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import com.fitpet.server.ranking.infra.messaging.RankingOvertakePublisher;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 아웃박스 폴러 스케줄러 (Outbox Poller).
+ *
+ * <h2>역할</h2>
+ * <p>DB에 PENDING 상태로 저장된 아웃박스 이벤트를 30초마다 배치로 읽어
+ * RabbitMQ에 발행하고 PUBLISHED 로 상태를 변경한다.</p>
+ *
+ * <h2>왜 아웃박스 패턴이 필요한가?</h2>
+ * <p>랭킹 업데이트(Redis Lua 스크립트)와 MQ 발행은 단일 트랜잭션으로 묶을 수 없다.
+ * 서버 재시작·MQ 일시 다운 시 이벤트가 유실되는 것을 방지하기 위해
+ * "DB에 먼저 기록 → 폴러가 안정적으로 발행" 흐름을 사용한다.</p>
+ *
+ * <h2>재시도 정책</h2>
+ * <ul>
+ *   <li>MQ 발행 실패 시 retryCount를 증가시키고 PENDING 유지 → 다음 폴링에서 재시도.</li>
+ *   <li>retryCount ≥ 3 이면 FAILED 처리 → 수동 확인.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OvertakeOutboxPollerScheduler {
+
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_RETRY = 3;
+
+    private final RankingOvertakeOutboxRepository outboxRepository;
+    private final RankingOvertakePublisher publisher;
+
+    /**
+     * 30초마다 PENDING 이벤트를 최대 100건 발행한다.
+     *
+     * <p>fixedDelay 사용 → 이전 실행이 완료된 후 30초 대기 (동시 실행 방지).</p>
+     */
+    @Scheduled(fixedDelay = 30_000)
+    @Transactional
+    public void pollAndPublish() {
+        List<RankingOvertakeOutbox> pending = outboxRepository.findPendingBatch(BATCH_SIZE);
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        log.info("[OvertakeOutboxPoller] {}건 발행 시작", pending.size());
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (RankingOvertakeOutbox outbox : pending) {
+            try {
+                publisher.publish(outbox);
+                outbox.markPublished();
+                outboxRepository.save(outbox);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[OvertakeOutboxPoller] 발행 실패: outboxId={}", outbox.getId(), e);
+                outbox.incrementRetryCount();
+                if (outbox.getRetryCount() >= MAX_RETRY) {
+                    outbox.markFailed();
+                    log.error("[OvertakeOutboxPoller] 최대 재시도 초과 – FAILED 처리: outboxId={}", outbox.getId());
+                }
+                outboxRepository.save(outbox);
+                failCount++;
+            }
+        }
+
+        log.info("[OvertakeOutboxPoller] 완료 – 성공: {}건, 실패: {}건", successCount, failCount);
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
@@ -1,0 +1,153 @@
+package com.fitpet.server.shared.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+
+/**
+ * RabbitMQ 인프라 설정.
+ *
+ * <h2>토폴로지</h2>
+ * <pre>
+ * Producer
+ *   → [ranking.overtake.exchange] (Direct)
+ *       --routing-key: ranking.overtake--> [ranking.overtake.queue]
+ *                                                    ↓ (소비)
+ *                                             Consumer (FCM 발송)
+ *                                                    ↓ (실패 3회)
+ *                                      [ranking.overtake.dlx] (Dead Letter Exchange)
+ *                                                    ↓
+ *                                          [ranking.overtake.dlq]  (수동 확인/알림)
+ * </pre>
+ *
+ * <h2>백오프(Backoff)</h2>
+ * <ul>
+ *   <li>초기 대기: 1s</li>
+ *   <li>배수: 2.0 (1s → 2s → 4s)</li>
+ *   <li>최대 대기: 10s</li>
+ *   <li>최대 재시도: 3회 후 DLQ로 이동</li>
+ * </ul>
+ */
+@Configuration
+public class RabbitMQConfig {
+
+    // ── 메인 큐 ──────────────────────────────────────────────
+    public static final String EXCHANGE    = "ranking.overtake.exchange";
+    public static final String QUEUE       = "ranking.overtake.queue";
+    public static final String ROUTING_KEY = "ranking.overtake";
+
+    // ── Dead Letter ───────────────────────────────────────────
+    public static final String DLX             = "ranking.overtake.dlx";
+    public static final String DLQ             = "ranking.overtake.dlq";
+    public static final String DLQ_ROUTING_KEY = "ranking.overtake.dead";
+
+    // ── Exchange ──────────────────────────────────────────────
+
+    @Bean
+    DirectExchange rankingOvertakeExchange() {
+        return new DirectExchange(EXCHANGE, true, false);
+    }
+
+    @Bean
+    DirectExchange rankingOvertakeDlx() {
+        return new DirectExchange(DLX, true, false);
+    }
+
+    // ── Queue ─────────────────────────────────────────────────
+
+    /**
+     * 메인 큐: 처리 실패 시 DLX 로 라우팅.
+     *
+     * <p>{@code x-dead-letter-exchange} 와 {@code x-dead-letter-routing-key} 를 설정하면
+     * consumer 가 NACK(requeue=false) 를 전달하거나 TTL 이 만료될 때 DLQ 로 이동한다.</p>
+     */
+    @Bean
+    Queue rankingOvertakeQueue() {
+        return QueueBuilder.durable(QUEUE)
+                .withArgument("x-dead-letter-exchange", DLX)
+                .withArgument("x-dead-letter-routing-key", DLQ_ROUTING_KEY)
+                .build();
+    }
+
+    /** Dead Letter Queue: 수동 검토 / 재처리 대상 */
+    @Bean
+    Queue rankingOvertakeDlq() {
+        return QueueBuilder.durable(DLQ).build();
+    }
+
+    // ── Binding ───────────────────────────────────────────────
+
+    @Bean
+    Binding rankingOvertakeBinding(Queue rankingOvertakeQueue,
+                                   DirectExchange rankingOvertakeExchange) {
+        return BindingBuilder.bind(rankingOvertakeQueue)
+                .to(rankingOvertakeExchange)
+                .with(ROUTING_KEY);
+    }
+
+    @Bean
+    Binding rankingOvertakeDlqBinding(Queue rankingOvertakeDlq,
+                                      DirectExchange rankingOvertakeDlx) {
+        return BindingBuilder.bind(rankingOvertakeDlq)
+                .to(rankingOvertakeDlx)
+                .with(DLQ_ROUTING_KEY);
+    }
+
+    // ── Converter & Template ──────────────────────────────────
+
+    @Bean
+    MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                  MessageConverter jsonMessageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter);
+        return template;
+    }
+
+    // ── Listener Container ────────────────────────────────────
+
+    /**
+     * 재시도 인터셉터: 지수 백오프(1s→2s→4s), 3회 초과 시 DLQ.
+     *
+     * <p>{@link RejectAndDontRequeueRecoverer} 는 최종 실패 시 NACK + requeue=false 를
+     * 전송한다. 메인 큐에 {@code x-dead-letter-exchange} 가 설정되어 있으면 DLQ로 이동한다.</p>
+     */
+    @Bean
+    RetryOperationsInterceptor rankingOvertakeRetryInterceptor() {
+        return RetryInterceptorBuilder.stateless()
+                .maxAttempts(3)
+                .backOffOptions(1_000, 2.0, 10_000) // initial, multiplier, max (ms)
+                .recoverer(new RejectAndDontRequeueRecoverer())
+                .build();
+    }
+
+    @Bean
+    SimpleRabbitListenerContainerFactory rankingOvertakeListenerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter jsonMessageConverter,
+            RetryOperationsInterceptor rankingOvertakeRetryInterceptor) {
+
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(jsonMessageConverter);
+        factory.setDefaultRequeueRejected(false); // 재시도 정책은 인터셉터가 관리
+        factory.setAdviceChain(rankingOvertakeRetryInterceptor);
+        return factory;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,13 @@ spring:
       host: ${VALKEY_HOST}
       port: ${VALKEY_PORT}
       password: "${VALKEY_PASSWORD}"
+
+  # RabbitMQ – 랭킹 추월 알림 비동기 처리
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:fitpet}
+    password: ${RABBITMQ_PASS:fitpet}
   security:
     user:
       name: ${SECURITY_USER}


### PR DESCRIPTION
## Summary

- **아웃박스 패턴 + RabbitMQ 기반** 랭킹 추월 FCM 푸시 알림 파이프라인 전체 구현
- Redis ZSet 순위 변동 감지 → DB 아웃박스 저장 → 폴러 발행 → MQ 소비 → FCM 발송 흐름
- **버그 수정**: `user.device_token`(항상 null) 대신 `user_device` 테이블에서 토큰 조회
- **메시지 개선**: `"N명에게 순위를 추월당했어요! 달려볼까요? 🏃"` 형식으로 변경
- Rate Limiter(Redis SETNX, 1시간 TTL)로 동일 사용자 알림 중복 발송 방지
- DLX/DLQ + 지수 백오프(1s→2s→4s, 최대 3회) 재시도로 FCM 실패 복원력 확보

## Changes

| 커밋 | 설명 |
|---|---|
| `9cd19e4` | RabbitMQ AMQP 의존성 및 설정 추가 |
| `356717d` | RabbitMQ 로컬 Docker 컨테이너 구성 |
| `d9f94f0` | 랭킹 추월 아웃박스 엔티티 정의 |
| `36c1c17` | 아웃박스 Repository 계층 구현 (도메인 인터페이스 + JPA 어댑터) |
| `3a297f8` | RabbitMQ Exchange/Queue/DLX/DLQ 토폴로지 및 재시도 정책 설정 |
| `9d89f6f` | 랭킹 점수 업데이트 후 추월 감지 Spring 이벤트 발행 |
| `f648961` | Redis SETNX 기반 추월 알림 Rate Limiter 구현 (1시간 1회 제한) |
| `62c74bc` | @Async 이벤트 리스너 기반 랭킹 추월 감지 및 아웃박스 저장 구현 |
| `b23c556` | 아웃박스 폴러 → RabbitMQ 메시지 발행 구현 |
| `d27f607` | 아웃박스 폴러 스케줄러 구현 (30초 주기, 최대 3회 재시도) |
| `f16bfee` | **[BUG FIX]** RabbitMQ 컨슈머 - `user_device` 테이블에서 FCM 토큰 조회, 멀티 디바이스 지원 |
| `248dd43` | Dead Letter Queue 리스너 구현 - 최종 실패 메시지 에러 로깅 |

## Architecture

```
랭킹 점수 업데이트
      │
      ▼ Spring Event (@Async)
추월 감지 (Redis ZSet reverseRank 비교)
      │  Rate Limiter 통과 시만
      ▼
ranking_overtake_outbox 저장 (PENDING)
      │
      ▼ 스케줄러 (30초 주기)
RabbitMQ 발행 → PUBLISHED 상태 업데이트
      │
      ▼ Consumer
FCM 푸시 알림 발송 (user_device 테이블 조회)
      │  실패 시
      └─▶ DLX → 재시도 (최대 3회) → DLQ
```

## Test plan

- [ ] 랭킹 점수 업데이트 API 호출 후 순위 상승 시 아웃박스 PENDING 레코드 생성 확인
- [ ] 30초 내 아웃박스 PUBLISHED 전환 및 FCM 알림 수신 확인 (안드로이드 에뮬레이터)
- [ ] Rate Limiter: 동일 피추월자에게 1시간 내 알림 1회만 발송되는지 확인
- [ ] FCM 실패 시 DLQ 이동 및 에러 로그 확인
- [ ] `user_device` 토큰이 없는 사용자: 알림 건너뜀(warn 로그) 확인
- [ ] 알림 수신 거부(`allowActivityNotification=false`) 사용자: 건너뜀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **순위 추월 알림 추가**: 다른 사용자가 순위에서 당신을 앞지를 때 등록된 기기로 실시간 푸시 알림을 받습니다. 순위 변동을 신속하게 인지할 수 있습니다.
* **알림 이력 저장**: 모든 순위 추월 알림이 저장되어 앱의 알람 섹션에서 언제든지 확인 및 관리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->