### PR TITLE
[Feat] 랭킹 추월 FCM 푸시 알림 파이프라인 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
+    // RabbitMQ (랭킹 추월 알림 비동기 처리)
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     // GCP
     implementation "com.google.cloud.sql:mysql-socket-factory-connector-j-8:1.27.1"
 }

--- a/docker-compose.mq.yml
+++ b/docker-compose.mq.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: fitpet-rabbitmq
+    ports:
+      - "5672:5672"      # AMQP 프로토콜 포트
+      - "15672:15672"    # 관리 UI (http://localhost:15672)
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-fitpet}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-fitpet}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    healthcheck:
+      test: [ "CMD", "rabbitmq-diagnostics", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  rabbitmq_data:
+    driver: local

--- a/docker-compose.mq.yml
+++ b/docker-compose.mq.yml
@@ -8,8 +8,8 @@ services:
       - "5672:5672"      # AMQP 프로토콜 포트
       - "15672:15672"    # 관리 UI (http://localhost:15672)
     environment:
-      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-fitpet}
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS:-fitpet}
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
     healthcheck:

--- a/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
@@ -5,32 +5,21 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * RabbitMQ로 발행하는 추월 알림 메시지 DTO.
- *
- * <p>JSON 직렬화를 위해 기본 생성자가 필요하다.</p>
- */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class OvertakeMessage {
 
-    /** 아웃박스 ID (중복 발송 추적용) */
     private Long outboxId;
 
-    /** 추월 당한 사용자 (알림 수신자) */
     private Long overtakenUserId;
 
-    /** 추월 한 사용자 */
     private Long overtakingUserId;
 
-    /** 추월 한 사용자의 닉네임 */
     private String overtakingUserNickname;
 
-    /** 랭킹 날짜 키 */
     private String dateKey;
 
-    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
     private int overtakerCount;
 }

--- a/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
+++ b/src/main/java/com/fitpet/server/ranking/application/dto/OvertakeMessage.java
@@ -1,0 +1,36 @@
+package com.fitpet.server.ranking.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * RabbitMQ로 발행하는 추월 알림 메시지 DTO.
+ *
+ * <p>JSON 직렬화를 위해 기본 생성자가 필요하다.</p>
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OvertakeMessage {
+
+    /** 아웃박스 ID (중복 발송 추적용) */
+    private Long outboxId;
+
+    /** 추월 당한 사용자 (알림 수신자) */
+    private Long overtakenUserId;
+
+    /** 추월 한 사용자 */
+    private Long overtakingUserId;
+
+    /** 추월 한 사용자의 닉네임 */
+    private String overtakingUserNickname;
+
+    /** 랭킹 날짜 키 */
+    private String dateKey;
+
+    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
+    private int overtakerCount;
+}

--- a/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
+++ b/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
@@ -1,0 +1,24 @@
+package com.fitpet.server.ranking.application.event;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 랭킹 점수 업데이트 이벤트.
+ *
+ * <p>Lua 스크립트로 Redis ZSet이 갱신된 직후 발행된다.
+ * {@link com.fitpet.server.ranking.application.service.RankingOvertakeDetectorService}가
+ * 비동기로 수신하여 추월 알림 파이프라인을 시작한다.</p>
+ *
+ * @param userId      점수를 올린 사용자
+ * @param previousRank 업데이트 전 0-indexed 순위 (처음 진입이면 null)
+ * @param date        랭킹 날짜
+ */
+@Getter
+@AllArgsConstructor
+public class RankingScoreUpdatedEvent {
+    private final Long userId;
+    private final Long previousRank;
+    private final LocalDate date;
+}

--- a/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
+++ b/src/main/java/com/fitpet/server/ranking/application/event/RankingScoreUpdatedEvent.java
@@ -4,17 +4,6 @@ import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/**
- * 랭킹 점수 업데이트 이벤트.
- *
- * <p>Lua 스크립트로 Redis ZSet이 갱신된 직후 발행된다.
- * {@link com.fitpet.server.ranking.application.service.RankingOvertakeDetectorService}가
- * 비동기로 수신하여 추월 알림 파이프라인을 시작한다.</p>
- *
- * @param userId      점수를 올린 사용자
- * @param previousRank 업데이트 전 0-indexed 순위 (처음 진입이면 null)
- * @param date        랭킹 날짜
- */
 @Getter
 @AllArgsConstructor
 public class RankingScoreUpdatedEvent {

--- a/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
@@ -1,0 +1,41 @@
+package com.fitpet.server.ranking.application.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 랭킹 추월 알림 Rate Limiter.
+ *
+ * <h2>100명이 한꺼번에 추월하는 문제</h2>
+ * <p>사용자 A가 걸음수를 크게 올려 100명을 한 번에 추월하면, 100개의 아웃박스 이벤트가
+ * 생성될 수 있다. 각 피추월자(overtaken user)에게 알림이 1시간에 최대 1회만 발송되도록
+ * Redis SETNX + TTL 방식으로 제한한다.</p>
+ *
+ * <p>Redis 키: {@code notification:ratelimit:overtake:{overtakenUserId}}<br>
+ * TTL: 1시간</p>
+ */
+@Component
+@RequiredArgsConstructor
+public class OvertakeNotificationRateLimiter {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "notification:ratelimit:overtake:";
+    private static final Duration TTL = Duration.ofHours(1);
+
+    /**
+     * 알림 발송 슬롯을 획득한다.
+     *
+     * @param overtakenUserId 알림을 받을 사용자
+     * @return 슬롯 획득 성공(발송 허용)이면 {@code true},
+     *         이미 해당 시간대에 알림이 발송됐으면 {@code false}
+     */
+    public boolean tryAcquire(Long overtakenUserId) {
+        String key = KEY_PREFIX + overtakenUserId;
+        // SETNX : key가 없을 때만 세팅 → 원자적으로 중복 차단
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, "1", TTL);
+        return Boolean.TRUE.equals(acquired);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
@@ -5,17 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * 랭킹 추월 알림 Rate Limiter.
- *
- * <h2>100명이 한꺼번에 추월하는 문제</h2>
- * <p>사용자 A가 걸음수를 크게 올려 100명을 한 번에 추월하면, 100개의 아웃박스 이벤트가
- * 생성될 수 있다. 각 피추월자(overtaken user)에게 알림이 1시간에 최대 1회만 발송되도록
- * Redis SETNX + TTL 방식으로 제한한다.</p>
- *
- * <p>Redis 키: {@code notification:ratelimit:overtake:{overtakenUserId}}<br>
- * TTL: 1시간</p>
- */
 @Component
 @RequiredArgsConstructor
 public class OvertakeNotificationRateLimiter {
@@ -25,28 +14,12 @@ public class OvertakeNotificationRateLimiter {
     private static final String KEY_PREFIX = "notification:ratelimit:overtake:";
     private static final Duration TTL = Duration.ofHours(1);
 
-    /**
-     * 알림 발송 슬롯을 획득한다.
-     *
-     * @param overtakenUserId 알림을 받을 사용자
-     * @return 슬롯 획득 성공(발송 허용)이면 {@code true},
-     *         이미 해당 시간대에 알림이 발송됐으면 {@code false}
-     */
     public boolean tryAcquire(Long overtakenUserId) {
         String key = KEY_PREFIX + overtakenUserId;
-        // SETNX : key가 없을 때만 세팅 → 원자적으로 중복 차단
         Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, "1", TTL);
         return Boolean.TRUE.equals(acquired);
     }
 
-    /**
-     * 획득한 슬롯을 반환한다 (보상 트랜잭션용).
-     *
-     * <p>아웃박스 저장 실패 시 rate-limit 키를 삭제해 다음 이벤트가
-     * 차단되지 않도록 복원한다.</p>
-     *
-     * @param overtakenUserId 알림을 받을 사용자
-     */
     public void release(Long overtakenUserId) {
         redisTemplate.delete(KEY_PREFIX + overtakenUserId);
     }

--- a/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/OvertakeNotificationRateLimiter.java
@@ -38,4 +38,16 @@ public class OvertakeNotificationRateLimiter {
         Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, "1", TTL);
         return Boolean.TRUE.equals(acquired);
     }
+
+    /**
+     * 획득한 슬롯을 반환한다 (보상 트랜잭션용).
+     *
+     * <p>아웃박스 저장 실패 시 rate-limit 키를 삭제해 다음 이벤트가
+     * 차단되지 않도록 복원한다.</p>
+     *
+     * @param overtakenUserId 알림을 받을 사용자
+     */
+    public void release(Long overtakenUserId) {
+        redisTemplate.delete(KEY_PREFIX + overtakenUserId);
+    }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
@@ -2,19 +2,7 @@ package com.fitpet.server.ranking.application.service;
 
 import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
 
-/**
- * 랭킹 추월 감지 서비스.
- *
- * <p>Redis ZSet 에서 순위 변동을 계산하여 추월 당한 사용자들을 찾고
- * 아웃박스 이벤트를 저장한다.</p>
- */
 public interface RankingOvertakeDetectorService {
 
-    /**
-     * {@link RankingScoreUpdatedEvent} 수신 후 비동기로 추월 여부를 감지하고
-     * 아웃박스 이벤트를 저장한다.
-     *
-     * <p>{@code @Async}로 실행되므로 호출 스레드를 블록하지 않는다.</p>
-     */
     void onRankingScoreUpdated(RankingScoreUpdatedEvent event);
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorService.java
@@ -1,0 +1,20 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
+
+/**
+ * 랭킹 추월 감지 서비스.
+ *
+ * <p>Redis ZSet 에서 순위 변동을 계산하여 추월 당한 사용자들을 찾고
+ * 아웃박스 이벤트를 저장한다.</p>
+ */
+public interface RankingOvertakeDetectorService {
+
+    /**
+     * {@link RankingScoreUpdatedEvent} 수신 후 비동기로 추월 여부를 감지하고
+     * 아웃박스 이벤트를 저장한다.
+     *
+     * <p>{@code @Async}로 실행되므로 호출 스레드를 블록하지 않는다.</p>
+     */
+    void onRankingScoreUpdated(RankingScoreUpdatedEvent event);
+}

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
@@ -12,25 +12,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 랭킹 추월 감지 구현체.
- *
- * <h2>추월 감지 알고리즘</h2>
- * <pre>
- * ZSet (ZREVRANGE 기준, 0-indexed):
- *   업데이트 전  : ... [rank 2] [rank 3] [rank 4] [rank 5 = user A] ...
- *   업데이트 후  : ... [rank 2 = user A] [rank 3] [rank 4] [rank 5] ...
- *
- *   previousRank = 4 (0-indexed, 업데이트 전)
- *   newRank      = 1 (0-indexed, 업데이트 후)
- *   추월 당한 사용자 위치 (업데이트 후 기준): newRank+1 ~ previousRank
- * </pre>
- *
- * <h2>동시성 고려</h2>
- * <p>복수의 사용자가 동시에 점수를 업데이트할 때 순위 스냅샷이 미세하게 달라질 수 있다.
- * 알림 특성상 완벽한 정합성보다 low-latency + best-effort 가 더 적합하므로
- * 락 없이 처리한다.</p>
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -42,12 +23,6 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
     private final RankingOvertakeOutboxRepository outboxRepository;
     private final OvertakeNotificationRateLimiter rateLimiter;
 
-    /**
-     * Spring 이벤트를 비동기로 수신한다.
-     *
-     * <p>{@code @Async} 덕분에 랭킹 업데이트 요청 스레드를 블록하지 않는다.
-     * 별도 스레드풀에서 실행되며, {@code @Transactional}로 아웃박스 저장을 보호한다.</p>
-     */
     @Async
     @EventListener
     @Transactional
@@ -66,7 +41,6 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
 
         Long previousRank = event.getPreviousRank();
 
-        // 랭킹에 처음 진입한 경우 추월한 사람이 없음
         if (previousRank == null) {
             log.info("[OvertakeDetector] previousRank null → 조기 종료 (처음 진입)");
             return;
@@ -77,12 +51,10 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
 
         Long newRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
 
-        // 순위가 오르지 않은 경우 (같거나 낮아졌으면 추월 없음)
         if (newRank == null || newRank >= previousRank) {
             return;
         }
 
-        // 업데이트 후 기준으로 newRank+1 ~ previousRank 위치에 있는 사용자들이 추월 당한 사람들
         Set<String> overtakenUserIds = redisTemplate.opsForZSet()
                 .reverseRange(allRankingKey, newRank + 1, previousRank);
 
@@ -97,12 +69,10 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
         for (String overtakenIdStr : overtakenUserIds) {
             Long overtakenUserId = Long.parseLong(overtakenIdStr);
 
-            // 자기 자신은 제외 (방어 코드)
             if (overtakenUserId.equals(event.getUserId())) {
                 continue;
             }
 
-            // Rate limit 체크: 1시간에 1번만 알림 발송
             if (!rateLimiter.tryAcquire(overtakenUserId)) {
                 log.debug("[OvertakeDetector] Rate limit 초과 - userId={}", overtakenUserId);
                 continue;
@@ -114,11 +84,10 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
                                 .overtakenUserId(overtakenUserId)
                                 .overtakingUserId(event.getUserId())
                                 .dateKey(event.getDate().toString())
-                                .overtakerCount(1) // 단일 이벤트당 1명 추월 (향후 집계 확장 가능)
+                                .overtakerCount(1)
                                 .build()
                 );
             } catch (Exception e) {
-                // 아웃박스 저장 실패 시 rate-limit 키를 반환해 다음 이벤트에서 재시도 가능하게 복원
                 rateLimiter.release(overtakenUserId);
                 log.error("[OvertakeDetector] 아웃박스 저장 실패, rate-limit 키 반환: userId={}", overtakenUserId, e);
                 continue;
@@ -131,4 +100,3 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
         }
     }
 }
-

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
@@ -39,32 +39,48 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
         log.info("[OvertakeDetector] 이벤트 수신: userId={}, previousRank={}, date={}",
                 event.getUserId(), event.getPreviousRank(), event.getDate());
 
-        Long previousRank = event.getPreviousRank();
-
-        if (previousRank == null) {
-            log.info("[OvertakeDetector] previousRank null → 조기 종료 (처음 진입)");
+        Long newRank = resolveNewRank(event);
+        if (newRank == null) {
             return;
         }
 
-        String allRankingKey = RANKING_KEY_PREFIX + event.getDate();
-        String userIdStr = String.valueOf(event.getUserId());
-
-        Long newRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
-
-        if (newRank == null || newRank >= previousRank) {
-            return;
-        }
-
-        Set<String> overtakenUserIds = redisTemplate.opsForZSet()
-                .reverseRange(allRankingKey, newRank + 1, previousRank);
-
+        Set<String> overtakenUserIds = getOvertakenUserIds(event, newRank);
         if (overtakenUserIds == null || overtakenUserIds.isEmpty()) {
             return;
         }
 
         log.info("[OvertakeDetector] 추월 감지: overtakingUserId={}, newRank={}, previousRank={}, overtakenCount={}",
-                event.getUserId(), newRank + 1, previousRank + 1, overtakenUserIds.size());
+                event.getUserId(), newRank + 1, event.getPreviousRank() + 1, overtakenUserIds.size());
 
+        int savedCount = saveOutboxForEligibleUsers(overtakenUserIds, event);
+        if (savedCount > 0) {
+            log.info("[OvertakeDetector] 아웃박스 저장 완료: {} 건", savedCount);
+        }
+    }
+
+    private Long resolveNewRank(RankingScoreUpdatedEvent event) {
+        Long previousRank = event.getPreviousRank();
+        if (previousRank == null) {
+            log.info("[OvertakeDetector] previousRank null → 조기 종료 (처음 진입)");
+            return null;
+        }
+
+        String allRankingKey = RANKING_KEY_PREFIX + event.getDate();
+        Long newRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, String.valueOf(event.getUserId()));
+
+        if (newRank == null || newRank >= previousRank) {
+            return null;
+        }
+        return newRank;
+    }
+
+    private Set<String> getOvertakenUserIds(RankingScoreUpdatedEvent event, Long newRank) {
+        String allRankingKey = RANKING_KEY_PREFIX + event.getDate();
+        return redisTemplate.opsForZSet()
+                .reverseRange(allRankingKey, newRank + 1, event.getPreviousRank());
+    }
+
+    private int saveOutboxForEligibleUsers(Set<String> overtakenUserIds, RankingScoreUpdatedEvent event) {
         int savedCount = 0;
         for (String overtakenIdStr : overtakenUserIds) {
             Long overtakenUserId = Long.parseLong(overtakenIdStr);
@@ -78,25 +94,28 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
                 continue;
             }
 
-            try {
-                outboxRepository.save(
-                        RankingOvertakeOutbox.builder()
-                                .overtakenUserId(overtakenUserId)
-                                .overtakingUserId(event.getUserId())
-                                .dateKey(event.getDate().toString())
-                                .overtakerCount(1)
-                                .build()
-                );
-            } catch (Exception e) {
-                rateLimiter.release(overtakenUserId);
-                log.error("[OvertakeDetector] 아웃박스 저장 실패, rate-limit 키 반환: userId={}", overtakenUserId, e);
-                continue;
+            if (saveOutbox(overtakenUserId, event)) {
+                savedCount++;
             }
-            savedCount++;
         }
+        return savedCount;
+    }
 
-        if (savedCount > 0) {
-            log.info("[OvertakeDetector] 아웃박스 저장 완료: {} 건", savedCount);
+    private boolean saveOutbox(Long overtakenUserId, RankingScoreUpdatedEvent event) {
+        try {
+            outboxRepository.save(
+                    RankingOvertakeOutbox.builder()
+                            .overtakenUserId(overtakenUserId)
+                            .overtakingUserId(event.getUserId())
+                            .dateKey(event.getDate().toString())
+                            .overtakerCount(1)
+                            .build()
+            );
+            return true;
+        } catch (Exception e) {
+            rateLimiter.release(overtakenUserId);
+            log.error("[OvertakeDetector] 아웃박스 저장 실패, rate-limit 키 반환: userId={}", overtakenUserId, e);
+            return false;
         }
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
@@ -108,14 +108,21 @@ public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetect
                 continue;
             }
 
-            outboxRepository.save(
-                    RankingOvertakeOutbox.builder()
-                            .overtakenUserId(overtakenUserId)
-                            .overtakingUserId(event.getUserId())
-                            .dateKey(event.getDate().toString())
-                            .overtakerCount(1) // 단일 이벤트당 1명 추월 (향후 집계 확장 가능)
-                            .build()
-            );
+            try {
+                outboxRepository.save(
+                        RankingOvertakeOutbox.builder()
+                                .overtakenUserId(overtakenUserId)
+                                .overtakingUserId(event.getUserId())
+                                .dateKey(event.getDate().toString())
+                                .overtakerCount(1) // 단일 이벤트당 1명 추월 (향후 집계 확장 가능)
+                                .build()
+                );
+            } catch (Exception e) {
+                // 아웃박스 저장 실패 시 rate-limit 키를 반환해 다음 이벤트에서 재시도 가능하게 복원
+                rateLimiter.release(overtakenUserId);
+                log.error("[OvertakeDetector] 아웃박스 저장 실패, rate-limit 키 반환: userId={}", overtakenUserId, e);
+                continue;
+            }
             savedCount++;
         }
 

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingOvertakeDetectorServiceImpl.java
@@ -1,0 +1,127 @@
+package com.fitpet.server.ranking.application.service;
+
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 랭킹 추월 감지 구현체.
+ *
+ * <h2>추월 감지 알고리즘</h2>
+ * <pre>
+ * ZSet (ZREVRANGE 기준, 0-indexed):
+ *   업데이트 전  : ... [rank 2] [rank 3] [rank 4] [rank 5 = user A] ...
+ *   업데이트 후  : ... [rank 2 = user A] [rank 3] [rank 4] [rank 5] ...
+ *
+ *   previousRank = 4 (0-indexed, 업데이트 전)
+ *   newRank      = 1 (0-indexed, 업데이트 후)
+ *   추월 당한 사용자 위치 (업데이트 후 기준): newRank+1 ~ previousRank
+ * </pre>
+ *
+ * <h2>동시성 고려</h2>
+ * <p>복수의 사용자가 동시에 점수를 업데이트할 때 순위 스냅샷이 미세하게 달라질 수 있다.
+ * 알림 특성상 완벽한 정합성보다 low-latency + best-effort 가 더 적합하므로
+ * 락 없이 처리한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingOvertakeDetectorServiceImpl implements RankingOvertakeDetectorService {
+
+    private static final String RANKING_KEY_PREFIX = "ranking:daily:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final RankingOvertakeOutboxRepository outboxRepository;
+    private final OvertakeNotificationRateLimiter rateLimiter;
+
+    /**
+     * Spring 이벤트를 비동기로 수신한다.
+     *
+     * <p>{@code @Async} 덕분에 랭킹 업데이트 요청 스레드를 블록하지 않는다.
+     * 별도 스레드풀에서 실행되며, {@code @Transactional}로 아웃박스 저장을 보호한다.</p>
+     */
+    @Async
+    @EventListener
+    @Transactional
+    @Override
+    public void onRankingScoreUpdated(RankingScoreUpdatedEvent event) {
+        try {
+            handleOvertake(event);
+        } catch (Exception e) {
+            log.error("[OvertakeDetector] 처리 중 예외 발생: userId={}", event.getUserId(), e);
+        }
+    }
+
+    private void handleOvertake(RankingScoreUpdatedEvent event) {
+        log.info("[OvertakeDetector] 이벤트 수신: userId={}, previousRank={}, date={}",
+                event.getUserId(), event.getPreviousRank(), event.getDate());
+
+        Long previousRank = event.getPreviousRank();
+
+        // 랭킹에 처음 진입한 경우 추월한 사람이 없음
+        if (previousRank == null) {
+            log.info("[OvertakeDetector] previousRank null → 조기 종료 (처음 진입)");
+            return;
+        }
+
+        String allRankingKey = RANKING_KEY_PREFIX + event.getDate();
+        String userIdStr = String.valueOf(event.getUserId());
+
+        Long newRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
+
+        // 순위가 오르지 않은 경우 (같거나 낮아졌으면 추월 없음)
+        if (newRank == null || newRank >= previousRank) {
+            return;
+        }
+
+        // 업데이트 후 기준으로 newRank+1 ~ previousRank 위치에 있는 사용자들이 추월 당한 사람들
+        Set<String> overtakenUserIds = redisTemplate.opsForZSet()
+                .reverseRange(allRankingKey, newRank + 1, previousRank);
+
+        if (overtakenUserIds == null || overtakenUserIds.isEmpty()) {
+            return;
+        }
+
+        log.info("[OvertakeDetector] 추월 감지: overtakingUserId={}, newRank={}, previousRank={}, overtakenCount={}",
+                event.getUserId(), newRank + 1, previousRank + 1, overtakenUserIds.size());
+
+        int savedCount = 0;
+        for (String overtakenIdStr : overtakenUserIds) {
+            Long overtakenUserId = Long.parseLong(overtakenIdStr);
+
+            // 자기 자신은 제외 (방어 코드)
+            if (overtakenUserId.equals(event.getUserId())) {
+                continue;
+            }
+
+            // Rate limit 체크: 1시간에 1번만 알림 발송
+            if (!rateLimiter.tryAcquire(overtakenUserId)) {
+                log.debug("[OvertakeDetector] Rate limit 초과 - userId={}", overtakenUserId);
+                continue;
+            }
+
+            outboxRepository.save(
+                    RankingOvertakeOutbox.builder()
+                            .overtakenUserId(overtakenUserId)
+                            .overtakingUserId(event.getUserId())
+                            .dateKey(event.getDate().toString())
+                            .overtakerCount(1) // 단일 이벤트당 1명 추월 (향후 집계 확장 가능)
+                            .build()
+            );
+            savedCount++;
+        }
+
+        if (savedCount > 0) {
+            log.info("[OvertakeDetector] 아웃박스 저장 완료: {} 건", savedCount);
+        }
+    }
+}
+

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingService.java
@@ -10,11 +10,6 @@ public interface RankingService {
 
     void updateScore(Long userId, int steps);
 
-    /**
-     * 걸음수 Hash(write-behind)와 랭킹 ZSet을 단일 Lua 스크립트로 원자적 업데이트
-     * 프론트에서 총합을 전송하므로 SET 방식으로 저장
-     * @return totalSteps
-     */
     long updateStepHashAndRankingScore(Long userId, int totalSteps,
                                        BigDecimal totalDistance, int totalCalories,
                                        LocalDate date);

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -3,6 +3,7 @@ package com.fitpet.server.ranking.application.service;
 import com.fitpet.server.dailywalk.domain.entity.DailyWalk;
 import com.fitpet.server.dailywalk.domain.repository.DailyWalkRepository;
 import com.fitpet.server.ranking.application.dto.RankingDto;
+import com.fitpet.server.ranking.application.event.RankingScoreUpdatedEvent;
 import com.fitpet.server.ranking.domain.type.RankingFilter;
 import com.fitpet.server.shared.s3.S3Service;
 import com.fitpet.server.user.domain.entity.User;
@@ -102,6 +103,10 @@ public class RankingServiceImpl implements RankingService {
 
         String allRankingKey = getRankingKey(date, RankingFilter.ALL);
 
+        // ── 추월 감지를 위해 Lua 실행 전 현재 순위를 스냅샷 ──────────────────
+        // ZREVRANK: 0-indexed (0 = 1위). 처음 진입하면 null 반환.
+        Long previousRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
+
         List<String> keys = (gender != RankingFilter.ALL)
                 ? List.of(DAILYWALK_STEPS_KEY + dateStr, DAILYWALK_DISTANCE_KEY + dateStr,
                           DAILYWALK_CALORIES_KEY + dateStr, DAILYWALK_DIRTY_KEY + dateStr,
@@ -121,6 +126,12 @@ public class RankingServiceImpl implements RankingService {
         );
 
         log.info("[RankingService] 걸음수 Hash + 랭킹 ZSet SET 업데이트: userId={}, totalSteps={}", userId, totalSteps);
+
+        // ── 추월 감지 이벤트 발행 (비동기 처리) ─────────────────────────────
+        // RankingOvertakeDetectorService 가 @Async @EventListener 로 수신하여
+        // 별도 스레드에서 아웃박스 이벤트를 저장한다.
+        eventPublisher.publishEvent(new RankingScoreUpdatedEvent(userId, previousRank, date));
+
         return result != null ? result : totalSteps;
     }
 

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -112,9 +112,6 @@ public class RankingServiceImpl implements RankingService {
                           DAILYWALK_CALORIES_KEY + dateStr, DAILYWALK_DIRTY_KEY + dateStr,
                           allRankingKey);
 
-        // ── ZREVRANK + ZADD 를 같은 Lua 스크립트 안에서 원자적으로 처리 ────
-        // result[0]: 업데이트 전 순위(0-indexed). 처음 진입이면 -1(sentinel).
-        // result[1]: totalSteps
         @SuppressWarnings({"rawtypes", "unchecked"})
         List<Long> result = (List<Long>) redisTemplate.execute(updateStepAndRankingScript,
                 keys,
@@ -126,7 +123,6 @@ public class RankingServiceImpl implements RankingService {
                 TTL_SECONDS
         );
 
-        // -1 은 "처음 진입(추월 없음)" 센티넬 → null 로 변환해 이벤트에 전달
         Long rawPrevRank = (result != null && !result.isEmpty()) ? result.get(0) : null;
         Long previousRank = (rawPrevRank == null || rawPrevRank == -1L) ? null : rawPrevRank;
         long resultSteps = (result != null && result.size() > 1 && result.get(1) != null)
@@ -134,9 +130,6 @@ public class RankingServiceImpl implements RankingService {
 
         log.info("[RankingService] 걸음수 Hash + 랭킹 ZSet SET 업데이트: userId={}, totalSteps={}", userId, totalSteps);
 
-        // ── 추월 감지 이벤트 발행 (비동기 처리) ─────────────────────────────
-        // RankingOvertakeDetectorService 가 @Async @EventListener 로 수신하여
-        // 별도 스레드에서 아웃박스 이벤트를 저장한다.
         eventPublisher.publishEvent(new RankingScoreUpdatedEvent(userId, previousRank, date));
 
         return resultSteps;

--- a/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
+++ b/src/main/java/com/fitpet/server/ranking/application/service/RankingServiceImpl.java
@@ -39,7 +39,8 @@ public class RankingServiceImpl implements RankingService {
     private final S3Service s3Service;
     private final StringRedisTemplate redisTemplate;
     private final RedisScript<Long> updateRankingScript;
-    private final RedisScript<Long> updateStepAndRankingScript;
+    @SuppressWarnings("rawtypes")
+    private final RedisScript<List> updateStepAndRankingScript;
     private final ApplicationEventPublisher eventPublisher;
 
     private static final String DAILYWALK_STEPS_KEY = "dailywalk:steps:";
@@ -103,10 +104,6 @@ public class RankingServiceImpl implements RankingService {
 
         String allRankingKey = getRankingKey(date, RankingFilter.ALL);
 
-        // ── 추월 감지를 위해 Lua 실행 전 현재 순위를 스냅샷 ──────────────────
-        // ZREVRANK: 0-indexed (0 = 1위). 처음 진입하면 null 반환.
-        Long previousRank = redisTemplate.opsForZSet().reverseRank(allRankingKey, userIdStr);
-
         List<String> keys = (gender != RankingFilter.ALL)
                 ? List.of(DAILYWALK_STEPS_KEY + dateStr, DAILYWALK_DISTANCE_KEY + dateStr,
                           DAILYWALK_CALORIES_KEY + dateStr, DAILYWALK_DIRTY_KEY + dateStr,
@@ -115,7 +112,11 @@ public class RankingServiceImpl implements RankingService {
                           DAILYWALK_CALORIES_KEY + dateStr, DAILYWALK_DIRTY_KEY + dateStr,
                           allRankingKey);
 
-        Long result = redisTemplate.execute(updateStepAndRankingScript,
+        // ── ZREVRANK + ZADD 를 같은 Lua 스크립트 안에서 원자적으로 처리 ────
+        // result[0]: 업데이트 전 순위(0-indexed). 처음 진입이면 -1(sentinel).
+        // result[1]: totalSteps
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        List<Long> result = (List<Long>) redisTemplate.execute(updateStepAndRankingScript,
                 keys,
                 userIdStr,
                 String.valueOf(totalSteps),
@@ -125,6 +126,12 @@ public class RankingServiceImpl implements RankingService {
                 TTL_SECONDS
         );
 
+        // -1 은 "처음 진입(추월 없음)" 센티넬 → null 로 변환해 이벤트에 전달
+        Long rawPrevRank = (result != null && !result.isEmpty()) ? result.get(0) : null;
+        Long previousRank = (rawPrevRank == null || rawPrevRank == -1L) ? null : rawPrevRank;
+        long resultSteps = (result != null && result.size() > 1 && result.get(1) != null)
+                ? result.get(1) : totalSteps;
+
         log.info("[RankingService] 걸음수 Hash + 랭킹 ZSet SET 업데이트: userId={}, totalSteps={}", userId, totalSteps);
 
         // ── 추월 감지 이벤트 발행 (비동기 처리) ─────────────────────────────
@@ -132,7 +139,7 @@ public class RankingServiceImpl implements RankingService {
         // 별도 스레드에서 아웃박스 이벤트를 저장한다.
         eventPublisher.publishEvent(new RankingScoreUpdatedEvent(userId, previousRank, date));
 
-        return result != null ? result : totalSteps;
+        return resultSteps;
     }
 
     @Override

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
@@ -3,6 +3,8 @@ package com.fitpet.server.ranking.domain.entity;
 public enum OutboxStatus {
     /** MQ 발행 대기 중 */
     PENDING,
+    /** 폴러가 발행을 시도 중 (중간 상태) – 발행 성공 시 PUBLISHED, 실패 시 PENDING으로 복원 */
+    CLAIMED,
     /** MQ 발행 완료 (소비는 MQ가 보장) */
     PUBLISHED,
     /** 재시도 초과 – 수동 확인 필요 */

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
@@ -1,12 +1,8 @@
 package com.fitpet.server.ranking.domain.entity;
 
 public enum OutboxStatus {
-    /** MQ 발행 대기 중 */
     PENDING,
-    /** 폴러가 발행을 시도 중 (중간 상태) – 발행 성공 시 PUBLISHED, 실패 시 PENDING으로 복원 */
     CLAIMED,
-    /** MQ 발행 완료 (소비는 MQ가 보장) */
     PUBLISHED,
-    /** 재시도 초과 – 수동 확인 필요 */
     FAILED
 }

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/OutboxStatus.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.ranking.domain.entity;
+
+public enum OutboxStatus {
+    /** MQ 발행 대기 중 */
+    PENDING,
+    /** MQ 발행 완료 (소비는 MQ가 보장) */
+    PUBLISHED,
+    /** 재시도 초과 – 수동 확인 필요 */
+    FAILED
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
@@ -1,0 +1,92 @@
+package com.fitpet.server.ranking.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 랭킹 추월 아웃박스 이벤트 테이블.
+ *
+ * <h2>아웃박스 패턴(Outbox Pattern) 적용 이유</h2>
+ * <p>랭킹 업데이트는 Redis(Lua 스크립트)에서 일어나고, 알림 발송은 RabbitMQ를 통해
+ * 별도 스레드에서 처리된다. 두 작업은 단일 트랜잭션으로 묶을 수 없으므로,
+ * "MQ 발행 전 DB에 이벤트 기록 → 폴러가 PENDING 이벤트를 MQ에 발행 → PUBLISHED 처리"
+ * 흐름으로 중간 유실을 방지한다.</p>
+ *
+ * <h2>보상 트랜잭션(Compensating Transaction) 고려</h2>
+ * <p>알림은 비즈니스 크리티컬하지 않으므로 Redis 롤백 없이 best-effort 처리한다.
+ * 아웃박스 저장 실패 시 알림이 누락되지만 랭킹 데이터 정합성은 유지된다.</p>
+ */
+@Entity
+@Table(name = "ranking_overtake_outbox")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class RankingOvertakeOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "outbox_id")
+    private Long id;
+
+    /** 추월 당한 사용자 (알림 수신자) */
+    @Column(name = "overtaken_user_id", nullable = false)
+    private Long overtakenUserId;
+
+    /** 추월 한 사용자 */
+    @Column(name = "overtaking_user_id", nullable = false)
+    private Long overtakingUserId;
+
+    /** 랭킹 날짜 키 (예: 2026-04-15) */
+    @Column(name = "date_key", nullable = false, length = 10)
+    private String dateKey;
+
+    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
+    @Column(name = "overtaker_count", nullable = false)
+    @Builder.Default
+    private int overtakerCount = 1;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private OutboxStatus status = OutboxStatus.PENDING;
+
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private int retryCount = 0;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    public void markPublished() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = OutboxStatus.FAILED;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
@@ -17,19 +17,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-/**
- * 랭킹 추월 아웃박스 이벤트 테이블.
- *
- * <h2>아웃박스 패턴(Outbox Pattern) 적용 이유</h2>
- * <p>랭킹 업데이트는 Redis(Lua 스크립트)에서 일어나고, 알림 발송은 RabbitMQ를 통해
- * 별도 스레드에서 처리된다. 두 작업은 단일 트랜잭션으로 묶을 수 없으므로,
- * "MQ 발행 전 DB에 이벤트 기록 → 폴러가 PENDING 이벤트를 MQ에 발행 → PUBLISHED 처리"
- * 흐름으로 중간 유실을 방지한다.</p>
- *
- * <h2>보상 트랜잭션(Compensating Transaction) 고려</h2>
- * <p>알림은 비즈니스 크리티컬하지 않으므로 Redis 롤백 없이 best-effort 처리한다.
- * 아웃박스 저장 실패 시 알림이 누락되지만 랭킹 데이터 정합성은 유지된다.</p>
- */
 @Entity
 @Table(name = "ranking_overtake_outbox")
 @Getter
@@ -44,19 +31,15 @@ public class RankingOvertakeOutbox {
     @Column(name = "outbox_id")
     private Long id;
 
-    /** 추월 당한 사용자 (알림 수신자) */
     @Column(name = "overtaken_user_id", nullable = false)
     private Long overtakenUserId;
 
-    /** 추월 한 사용자 */
     @Column(name = "overtaking_user_id", nullable = false)
     private Long overtakingUserId;
 
-    /** 랭킹 날짜 키 (예: 2026-04-15) */
     @Column(name = "date_key", nullable = false, length = 10)
     private String dateKey;
 
-    /** 이 이벤트에서 피추월자를 추월한 사람 수 */
     @Column(name = "overtaker_count", nullable = false)
     @Builder.Default
     private int overtakerCount = 1;

--- a/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/entity/RankingOvertakeOutbox.java
@@ -77,6 +77,14 @@ public class RankingOvertakeOutbox {
     @Column(name = "published_at")
     private LocalDateTime publishedAt;
 
+    public void markClaimed() {
+        this.status = OutboxStatus.CLAIMED;
+    }
+
+    public void markPending() {
+        this.status = OutboxStatus.PENDING;
+    }
+
     public void markPublished() {
         this.status = OutboxStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
@@ -1,6 +1,5 @@
 package com.fitpet.server.ranking.domain.repository;
 
-import com.fitpet.server.ranking.domain.entity.OutboxStatus;
 import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
 import java.util.List;
 
@@ -11,6 +10,18 @@ public interface RankingOvertakeOutboxRepository {
     /**
      * PENDING 상태의 아웃박스 이벤트를 생성 순서대로 최대 {@code limit}건 조회한다.
      * 폴러가 배치 단위로 호출한다.
+     *
+     * @deprecated 폴러는 {@link #claimBatch(int)} 를 사용한다. 이 메서드는 조회 전용.
      */
+    @Deprecated
     List<RankingOvertakeOutbox> findPendingBatch(int limit);
+
+    /**
+     * PENDING 행을 CLAIMED로 원자적으로 전환하고 반환한다.
+     *
+     * <p>SELECT FOR UPDATE SKIP LOCKED 로 행을 잠근 뒤 status=CLAIMED 로 커밋하여
+     * 다른 인스턴스나 다음 폴링 주기가 같은 행을 가져가지 않도록 보장한다.
+     * MQ 발행은 이 메서드의 트랜잭션이 커밋된 이후에 수행해야 한다.</p>
+     */
+    List<RankingOvertakeOutbox> claimBatch(int limit);
 }

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
@@ -1,0 +1,16 @@
+package com.fitpet.server.ranking.domain.repository;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import java.util.List;
+
+public interface RankingOvertakeOutboxRepository {
+
+    RankingOvertakeOutbox save(RankingOvertakeOutbox outbox);
+
+    /**
+     * PENDING 상태의 아웃박스 이벤트를 생성 순서대로 최대 {@code limit}건 조회한다.
+     * 폴러가 배치 단위로 호출한다.
+     */
+    List<RankingOvertakeOutbox> findPendingBatch(int limit);
+}

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingOvertakeOutboxRepository.java
@@ -7,21 +7,8 @@ public interface RankingOvertakeOutboxRepository {
 
     RankingOvertakeOutbox save(RankingOvertakeOutbox outbox);
 
-    /**
-     * PENDING 상태의 아웃박스 이벤트를 생성 순서대로 최대 {@code limit}건 조회한다.
-     * 폴러가 배치 단위로 호출한다.
-     *
-     * @deprecated 폴러는 {@link #claimBatch(int)} 를 사용한다. 이 메서드는 조회 전용.
-     */
     @Deprecated
     List<RankingOvertakeOutbox> findPendingBatch(int limit);
 
-    /**
-     * PENDING 행을 CLAIMED로 원자적으로 전환하고 반환한다.
-     *
-     * <p>SELECT FOR UPDATE SKIP LOCKED 로 행을 잠근 뒤 status=CLAIMED 로 커밋하여
-     * 다른 인스턴스나 다음 폴링 주기가 같은 행을 가져가지 않도록 보장한다.
-     * MQ 발행은 이 메서드의 트랜잭션이 커밋된 이후에 수행해야 한다.</p>
-     */
     List<RankingOvertakeOutbox> claimBatch(int limit);
 }

--- a/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/domain/repository/RankingRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface RankingRepository extends JpaRepository<Ranking, Long> {
 
-    // Write-Back 동기화용 (100명씩 Bulk 조회)
     List<Ranking> findAllByUserIdInAndDateKey(List<Long> userIds, String dateKey);
 
     @Query("SELECT r FROM Ranking r WHERE r.dateKey = :dateKey ORDER BY r.score DESC, r.updatedAt ASC")

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
@@ -8,13 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface RankingOvertakeOutboxJpaRepository extends JpaRepository<RankingOvertakeOutbox, Long> {
 
-    /**
-     * PENDING 상태 행을 최대 {@code limit}건 비관적 락으로 조회한다.
-     *
-     * <p>FOR UPDATE SKIP LOCKED 덕분에 다른 인스턴스가 이미 처리 중인 행은
-     * 건너뛰어 멀티 인스턴스 환경에서 중복 발행을 방지한다.
-     * 호출부에 반드시 {@code @Transactional}이 존재해야 트랜잭션 종료 시까지 락이 유지된다.</p>
-     */
     @Query(value = """
             SELECT *
             FROM ranking_overtake_outbox

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
@@ -1,12 +1,27 @@
 package com.fitpet.server.ranking.infra.jpa;
 
-import com.fitpet.server.ranking.domain.entity.OutboxStatus;
 import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
 import java.util.List;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RankingOvertakeOutboxJpaRepository extends JpaRepository<RankingOvertakeOutbox, Long> {
 
-    List<RankingOvertakeOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status, Pageable pageable);
+    /**
+     * PENDING 상태 행을 최대 {@code limit}건 비관적 락으로 조회한다.
+     *
+     * <p>FOR UPDATE SKIP LOCKED 덕분에 다른 인스턴스가 이미 처리 중인 행은
+     * 건너뛰어 멀티 인스턴스 환경에서 중복 발행을 방지한다.
+     * 호출부에 반드시 {@code @Transactional}이 존재해야 트랜잭션 종료 시까지 락이 유지된다.</p>
+     */
+    @Query(value = """
+            SELECT *
+            FROM ranking_overtake_outbox
+            WHERE status = 'PENDING'
+            ORDER BY created_at ASC
+            LIMIT :limit
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<RankingOvertakeOutbox> lockPendingBatch(@Param("limit") int limit);
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxJpaRepository.java
@@ -1,0 +1,12 @@
+package com.fitpet.server.ranking.infra.jpa;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingOvertakeOutboxJpaRepository extends JpaRepository<RankingOvertakeOutbox, Long> {
+
+    List<RankingOvertakeOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status, Pageable pageable);
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
@@ -24,13 +24,6 @@ public class RankingOvertakeOutboxRepositoryAdapter implements RankingOvertakeOu
         return jpaRepository.lockPendingBatch(limit);
     }
 
-    /**
-     * PENDING 행을 CLAIMED 로 원자적으로 전환하고 반환한다.
-     *
-     * <p>FOR UPDATE SKIP LOCKED 로 행을 잠근 뒤 status=CLAIMED 로 커밋한다.
-     * 이 트랜잭션이 커밋된 이후 MQ 발행을 수행해야
-     * "발행 성공 + DB 커밋 실패 → 재발행" 경로를 차단할 수 있다.</p>
-     */
     @Override
     @Transactional
     public List<RankingOvertakeOutbox> claimBatch(int limit) {

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxReposito
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,7 +19,23 @@ public class RankingOvertakeOutboxRepositoryAdapter implements RankingOvertakeOu
     }
 
     @Override
+    @Deprecated
     public List<RankingOvertakeOutbox> findPendingBatch(int limit) {
         return jpaRepository.lockPendingBatch(limit);
+    }
+
+    /**
+     * PENDING 행을 CLAIMED 로 원자적으로 전환하고 반환한다.
+     *
+     * <p>FOR UPDATE SKIP LOCKED 로 행을 잠근 뒤 status=CLAIMED 로 커밋한다.
+     * 이 트랜잭션이 커밋된 이후 MQ 발행을 수행해야
+     * "발행 성공 + DB 커밋 실패 → 재발행" 경로를 차단할 수 있다.</p>
+     */
+    @Override
+    @Transactional
+    public List<RankingOvertakeOutbox> claimBatch(int limit) {
+        List<RankingOvertakeOutbox> batch = jpaRepository.lockPendingBatch(limit);
+        batch.forEach(RankingOvertakeOutbox::markClaimed);
+        return jpaRepository.saveAll(batch);
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.fitpet.server.ranking.infra.jpa;
+
+import com.fitpet.server.ranking.domain.entity.OutboxStatus;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingOvertakeOutboxRepositoryAdapter implements RankingOvertakeOutboxRepository {
+
+    private final RankingOvertakeOutboxJpaRepository jpaRepository;
+
+    @Override
+    public RankingOvertakeOutbox save(RankingOvertakeOutbox outbox) {
+        return jpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<RankingOvertakeOutbox> findPendingBatch(int limit) {
+        return jpaRepository.findByStatusOrderByCreatedAtAsc(
+                OutboxStatus.PENDING,
+                PageRequest.of(0, limit)
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/jpa/RankingOvertakeOutboxRepositoryAdapter.java
@@ -1,11 +1,9 @@
 package com.fitpet.server.ranking.infra.jpa;
 
-import com.fitpet.server.ranking.domain.entity.OutboxStatus;
 import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
 import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,9 +19,6 @@ public class RankingOvertakeOutboxRepositoryAdapter implements RankingOvertakeOu
 
     @Override
     public List<RankingOvertakeOutbox> findPendingBatch(int limit) {
-        return jpaRepository.findByStatusOrderByCreatedAtAsc(
-                OutboxStatus.PENDING,
-                PageRequest.of(0, limit)
-        );
+        return jpaRepository.lockPendingBatch(limit);
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
@@ -6,19 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
-/**
- * Dead Letter Queue 리스너.
- *
- * <p>3회 재시도 후에도 FCM 발송에 실패한 메시지는 DLQ 로 이동한다.
- * 현재는 에러 로그만 남기지만, 향후 Slack/PagerDuty 알림, 재처리 배치 등으로 확장 가능하다.</p>
- *
- * <h2>데드 큐 처리 전략</h2>
- * <ul>
- *   <li>메시지 내용을 로그로 남겨 운영팀이 확인할 수 있게 한다.</li>
- *   <li>FCM 토큰이 만료된 경우 → User 테이블에서 토큰 삭제하는 배치로 연계 가능.</li>
- *   <li>RabbitMQ 서버 오류인 경우 → 수동으로 DLQ 메시지를 원래 큐로 re-publish 한다.</li>
- * </ul>
- */
 @Slf4j
 @Component
 public class DlqEventListener {

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/DlqEventListener.java
@@ -1,0 +1,31 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Dead Letter Queue 리스너.
+ *
+ * <p>3회 재시도 후에도 FCM 발송에 실패한 메시지는 DLQ 로 이동한다.
+ * 현재는 에러 로그만 남기지만, 향후 Slack/PagerDuty 알림, 재처리 배치 등으로 확장 가능하다.</p>
+ *
+ * <h2>데드 큐 처리 전략</h2>
+ * <ul>
+ *   <li>메시지 내용을 로그로 남겨 운영팀이 확인할 수 있게 한다.</li>
+ *   <li>FCM 토큰이 만료된 경우 → User 테이블에서 토큰 삭제하는 배치로 연계 가능.</li>
+ *   <li>RabbitMQ 서버 오류인 경우 → 수동으로 DLQ 메시지를 원래 큐로 re-publish 한다.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class DlqEventListener {
+
+    @RabbitListener(queues = RabbitMQConfig.DLQ)
+    public void handleDeadLetter(OvertakeMessage message) {
+        log.error("[DLQ] 최종 처리 실패 메시지 수신 – 수동 확인 필요: outboxId={}, overtakenUserId={}, overtakingUserId={}",
+                message.getOutboxId(), message.getOvertakenUserId(), message.getOvertakingUserId());
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
@@ -20,26 +20,6 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * 랭킹 추월 알림 MQ 소비자.
- *
- * <h2>처리 흐름</h2>
- * <ol>
- *   <li>수신된 메시지에서 피추월자 정보를 조회한다.</li>
- *   <li>알림 수신 동의 및 디바이스 토큰을 확인한다.</li>
- *   <li>FCM 푸시 알림을 발송한다.</li>
- *   <li>알림 발송 이력을 DB에 저장한다.</li>
- * </ol>
- *
- * <h2>실패 처리</h2>
- * <p>FCM 예외 발생 시 {@link RuntimeException} 으로 재포장하면 Spring AMQP 가
- * {@link RabbitMQConfig#rankingOvertakeRetryInterceptor()} 정책에 따라 재시도한다.
- * 3회 초과 시 Dead Letter Queue 로 이동한다.</p>
- *
- * <h2>멱등성</h2>
- * <p>Rate Limiter(Redis)가 아웃박스 저장 시점에 이미 중복 발송을 차단하므로
- * 소비자 레벨에서는 추가 멱등성 처리 없이 단순하게 유지한다.</p>
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -64,19 +44,18 @@ public class RankingOvertakeConsumer {
         User overtakenUser = userRepository.findById(message.getOvertakenUserId()).orElse(null);
         if (overtakenUser == null) {
             log.warn("[OvertakeConsumer] 사용자 없음 – 메시지 폐기: userId={}", message.getOvertakenUserId());
-            return; // ack (폐기)
+            return;
         }
 
-        // 알림 수신 동의 확인
         if (!Boolean.TRUE.equals(overtakenUser.getAllowActivityNotification())) {
             log.info("[OvertakeConsumer] 알림 수신 거부 – 건너뜀: userId={}", message.getOvertakenUserId());
-            return; // ack (폐기)
+            return;
         }
 
         List<String> deviceTokens = userDeviceRepository.findAllTokensByUserId(message.getOvertakenUserId());
         if (deviceTokens.isEmpty()) {
             log.warn("[OvertakeConsumer] 디바이스 토큰 없음 – 건너뜀: userId={}", message.getOvertakenUserId());
-            return; // ack (폐기)
+            return;
         }
 
         String body = message.getOvertakerCount() + "명에게 순위를 추월당했어요! 달려볼까요? 🏃";
@@ -88,8 +67,6 @@ public class RankingOvertakeConsumer {
     }
 
     private void sendFcm(String deviceToken, String body, OvertakeMessage message) {
-        // 멱등성 키: 재시도 시 이미 성공한 토큰에 중복 발송되는 것을 방지한다.
-        // FCM 실패 시 키를 삭제해 다음 재시도에서 재발송 가능하게 복원한다.
         String idemKey = FCM_IDEM_KEY_PREFIX + message.getOutboxId() + ":" + deviceToken;
         Boolean isNew = stringRedisTemplate.opsForValue().setIfAbsent(idemKey, "1", FCM_IDEM_TTL);
         if (!Boolean.TRUE.equals(isNew)) {
@@ -113,7 +90,6 @@ public class RankingOvertakeConsumer {
             log.info("[OvertakeConsumer] FCM 발송 성공: messageId={}, overtakenUserId={}",
                     fcmId, message.getOvertakenUserId());
         } catch (FirebaseMessagingException e) {
-            // FCM 실패 시 멱등성 키 삭제 → 재시도에서 이 토큰을 다시 시도할 수 있다.
             stringRedisTemplate.delete(idemKey);
             log.error("[OvertakeConsumer] FCM 발송 실패: overtakenUserId={}", message.getOvertakenUserId(), e);
             throw new RuntimeException("FCM 발송 실패 – 재시도 예정", e);

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
@@ -7,6 +7,7 @@ import com.fitpet.server.shared.config.RabbitMQConfig;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserDeviceRepository;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.time.Duration;
 import java.util.List;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -15,6 +16,7 @@ import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,11 +46,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class RankingOvertakeConsumer {
 
     private static final String NOTIFICATION_TITLE = "랭킹 변동 알림 🏃";
+    private static final String FCM_IDEM_KEY_PREFIX = "fcm:idem:";
+    private static final Duration FCM_IDEM_TTL = Duration.ofHours(1);
 
     private final UserRepository userRepository;
     private final UserDeviceRepository userDeviceRepository;
     private final FirebaseMessaging firebaseMessaging;
     private final AlramRepository alramRepository;
+    private final StringRedisTemplate stringRedisTemplate;
 
     @RabbitListener(queues = RabbitMQConfig.QUEUE, containerFactory = "rankingOvertakeListenerFactory")
     @Transactional
@@ -83,6 +88,15 @@ public class RankingOvertakeConsumer {
     }
 
     private void sendFcm(String deviceToken, String body, OvertakeMessage message) {
+        // 멱등성 키: 재시도 시 이미 성공한 토큰에 중복 발송되는 것을 방지한다.
+        // FCM 실패 시 키를 삭제해 다음 재시도에서 재발송 가능하게 복원한다.
+        String idemKey = FCM_IDEM_KEY_PREFIX + message.getOutboxId() + ":" + deviceToken;
+        Boolean isNew = stringRedisTemplate.opsForValue().setIfAbsent(idemKey, "1", FCM_IDEM_TTL);
+        if (!Boolean.TRUE.equals(isNew)) {
+            log.info("[OvertakeConsumer] 이미 발송된 토큰 – 중복 발송 건너뜀: outboxId={}", message.getOutboxId());
+            return;
+        }
+
         Message fcmMessage = Message.builder()
                 .setToken(deviceToken)
                 .setNotification(Notification.builder()
@@ -99,7 +113,8 @@ public class RankingOvertakeConsumer {
             log.info("[OvertakeConsumer] FCM 발송 성공: messageId={}, overtakenUserId={}",
                     fcmId, message.getOvertakenUserId());
         } catch (FirebaseMessagingException e) {
-            // 예외를 던져야 Spring AMQP 가 재시도 → 최종적으로 DLQ 로 이동한다.
+            // FCM 실패 시 멱등성 키 삭제 → 재시도에서 이 토큰을 다시 시도할 수 있다.
+            stringRedisTemplate.delete(idemKey);
             log.error("[OvertakeConsumer] FCM 발송 실패: overtakenUserId={}", message.getOvertakenUserId(), e);
             throw new RuntimeException("FCM 발송 실패 – 재시도 예정", e);
         }

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakeConsumer.java
@@ -1,0 +1,118 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.alram.domain.entity.AlramMessage;
+import com.fitpet.server.alram.domain.repository.AlramRepository;
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserDeviceRepository;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.List;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 랭킹 추월 알림 MQ 소비자.
+ *
+ * <h2>처리 흐름</h2>
+ * <ol>
+ *   <li>수신된 메시지에서 피추월자 정보를 조회한다.</li>
+ *   <li>알림 수신 동의 및 디바이스 토큰을 확인한다.</li>
+ *   <li>FCM 푸시 알림을 발송한다.</li>
+ *   <li>알림 발송 이력을 DB에 저장한다.</li>
+ * </ol>
+ *
+ * <h2>실패 처리</h2>
+ * <p>FCM 예외 발생 시 {@link RuntimeException} 으로 재포장하면 Spring AMQP 가
+ * {@link RabbitMQConfig#rankingOvertakeRetryInterceptor()} 정책에 따라 재시도한다.
+ * 3회 초과 시 Dead Letter Queue 로 이동한다.</p>
+ *
+ * <h2>멱등성</h2>
+ * <p>Rate Limiter(Redis)가 아웃박스 저장 시점에 이미 중복 발송을 차단하므로
+ * 소비자 레벨에서는 추가 멱등성 처리 없이 단순하게 유지한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingOvertakeConsumer {
+
+    private static final String NOTIFICATION_TITLE = "랭킹 변동 알림 🏃";
+
+    private final UserRepository userRepository;
+    private final UserDeviceRepository userDeviceRepository;
+    private final FirebaseMessaging firebaseMessaging;
+    private final AlramRepository alramRepository;
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE, containerFactory = "rankingOvertakeListenerFactory")
+    @Transactional
+    public void consume(OvertakeMessage message) {
+        log.info("[OvertakeConsumer] 처리 시작: outboxId={}, overtakenUserId={}",
+                message.getOutboxId(), message.getOvertakenUserId());
+
+        User overtakenUser = userRepository.findById(message.getOvertakenUserId()).orElse(null);
+        if (overtakenUser == null) {
+            log.warn("[OvertakeConsumer] 사용자 없음 – 메시지 폐기: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        // 알림 수신 동의 확인
+        if (!Boolean.TRUE.equals(overtakenUser.getAllowActivityNotification())) {
+            log.info("[OvertakeConsumer] 알림 수신 거부 – 건너뜀: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        List<String> deviceTokens = userDeviceRepository.findAllTokensByUserId(message.getOvertakenUserId());
+        if (deviceTokens.isEmpty()) {
+            log.warn("[OvertakeConsumer] 디바이스 토큰 없음 – 건너뜀: userId={}", message.getOvertakenUserId());
+            return; // ack (폐기)
+        }
+
+        String body = message.getOvertakerCount() + "명에게 순위를 추월당했어요! 달려볼까요? 🏃";
+
+        deviceTokens.forEach(token -> sendFcm(token, body, message));
+        saveAlramHistory(overtakenUser, body);
+
+        log.info("[OvertakeConsumer] 처리 완료: outboxId={}", message.getOutboxId());
+    }
+
+    private void sendFcm(String deviceToken, String body, OvertakeMessage message) {
+        Message fcmMessage = Message.builder()
+                .setToken(deviceToken)
+                .setNotification(Notification.builder()
+                        .setTitle(NOTIFICATION_TITLE)
+                        .setBody(body)
+                        .build())
+                .putData("type", "RANKING_OVERTAKE")
+                .putData("overtakingUserId", String.valueOf(message.getOvertakingUserId()))
+                .putData("dateKey", message.getDateKey())
+                .build();
+
+        try {
+            String fcmId = firebaseMessaging.send(fcmMessage);
+            log.info("[OvertakeConsumer] FCM 발송 성공: messageId={}, overtakenUserId={}",
+                    fcmId, message.getOvertakenUserId());
+        } catch (FirebaseMessagingException e) {
+            // 예외를 던져야 Spring AMQP 가 재시도 → 최종적으로 DLQ 로 이동한다.
+            log.error("[OvertakeConsumer] FCM 발송 실패: overtakenUserId={}", message.getOvertakenUserId(), e);
+            throw new RuntimeException("FCM 발송 실패 – 재시도 예정", e);
+        }
+    }
+
+    @Transactional
+    protected void saveAlramHistory(User overtakenUser, String body) {
+        alramRepository.save(
+                AlramMessage.builder()
+                        .user(overtakenUser)
+                        .title(NOTIFICATION_TITLE)
+                        .message(body)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
@@ -1,0 +1,55 @@
+package com.fitpet.server.ranking.infra.messaging;
+
+import com.fitpet.server.ranking.application.dto.OvertakeMessage;
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.shared.config.RabbitMQConfig;
+import com.fitpet.server.user.domain.entity.User;
+import com.fitpet.server.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 아웃박스 이벤트를 RabbitMQ 로 발행하는 컴포넌트.
+ *
+ * <p>폴러({@link com.fitpet.server.ranking.infra.scheduler.OvertakeOutboxPollerScheduler})가
+ * PENDING 이벤트 배치를 가져와 이 클래스를 통해 메시지를 발행한다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingOvertakePublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final UserRepository userRepository;
+
+    /**
+     * 아웃박스 이벤트 한 건을 MQ 로 발행한다.
+     *
+     * @param outbox PENDING 상태의 아웃박스 이벤트
+     */
+    public void publish(RankingOvertakeOutbox outbox) {
+        String nickname = userRepository.findById(outbox.getOvertakingUserId())
+                .map(User::getNickname)
+                .orElse("누군가");
+
+        OvertakeMessage message = OvertakeMessage.builder()
+                .outboxId(outbox.getId())
+                .overtakenUserId(outbox.getOvertakenUserId())
+                .overtakingUserId(outbox.getOvertakingUserId())
+                .overtakingUserNickname(nickname)
+                .dateKey(outbox.getDateKey())
+                .overtakerCount(outbox.getOvertakerCount())
+                .build();
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.EXCHANGE,
+                RabbitMQConfig.ROUTING_KEY,
+                message
+        );
+
+        log.debug("[OvertakePublisher] 메시지 발행: outboxId={}, overtakenUserId={}",
+                outbox.getId(), outbox.getOvertakenUserId());
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
@@ -5,8 +5,12 @@ import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
 import com.fitpet.server.shared.config.RabbitMQConfig;
 import com.fitpet.server.user.domain.entity.User;
 import com.fitpet.server.user.domain.repository.UserRepository;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
@@ -14,20 +18,29 @@ import org.springframework.stereotype.Component;
  * 아웃박스 이벤트를 RabbitMQ 로 발행하는 컴포넌트.
  *
  * <p>폴러({@link com.fitpet.server.ranking.infra.scheduler.OvertakeOutboxPollerScheduler})가
- * PENDING 이벤트 배치를 가져와 이 클래스를 통해 메시지를 발행한다.</p>
+ * CLAIMED 이벤트 배치를 가져와 이 클래스를 통해 메시지를 발행한다.</p>
+ *
+ * <h2>Publisher Confirm (브로커 확인)</h2>
+ * <p>{@code publisher-confirm-type: CORRELATED} 설정 하에 {@link CorrelationData}(outboxId)를
+ * 함께 전달하고, 브로커의 ACK/NACK 를 {@link CorrelationData#getFuture()} 로 동기 대기한다.
+ * 브로커가 ACK 를 보내야 정상 반환되며, NACK·타임아웃 시 예외를 던져 폴러가
+ * retryCount 를 증가시키고 PENDING 으로 복원하도록 유도한다.</p>
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RankingOvertakePublisher {
 
+    private static final long CONFIRM_TIMEOUT_SECONDS = 5;
+
     private final RabbitTemplate rabbitTemplate;
     private final UserRepository userRepository;
 
     /**
-     * 아웃박스 이벤트 한 건을 MQ 로 발행한다.
+     * 아웃박스 이벤트 한 건을 MQ 로 발행하고 브로커 ACK 를 동기 대기한다.
      *
-     * @param outbox PENDING 상태의 아웃박스 이벤트
+     * @param outbox CLAIMED 상태의 아웃박스 이벤트
+     * @throws RuntimeException 브로커 NACK·타임아웃·인터럽트 발생 시
      */
     public void publish(RankingOvertakeOutbox outbox) {
         String nickname = userRepository.findById(outbox.getOvertakingUserId())
@@ -43,13 +56,44 @@ public class RankingOvertakePublisher {
                 .overtakerCount(outbox.getOvertakerCount())
                 .build();
 
+        // outboxId를 상관관계 ID로 사용해 브로커 ACK/NACK 를 추적한다
+        CorrelationData correlationData = new CorrelationData(String.valueOf(outbox.getId()));
+
         rabbitTemplate.convertAndSend(
                 RabbitMQConfig.EXCHANGE,
                 RabbitMQConfig.ROUTING_KEY,
-                message
+                message,
+                correlationData
         );
 
-        log.debug("[OvertakePublisher] 메시지 발행: outboxId={}, overtakenUserId={}",
+        // 브로커 ACK 를 동기적으로 대기 – 미확인 시 예외를 던져 폴러가 재시도하도록 유도
+        waitForConfirm(outbox.getId(), correlationData);
+
+        log.debug("[OvertakePublisher] 메시지 발행 완료 (ACK): outboxId={}, overtakenUserId={}",
                 outbox.getId(), outbox.getOvertakenUserId());
+    }
+
+    private void waitForConfirm(Long outboxId, CorrelationData correlationData) {
+        try {
+            CorrelationData.Confirm confirm =
+                    correlationData.getFuture().get(CONFIRM_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            if (confirm == null || !confirm.isAck()) {
+                String reason = (confirm != null) ? confirm.getReason() : "confirm null";
+                throw new RuntimeException(
+                        "[OvertakePublisher] 브로커 NACK – 재시도 예정: outboxId=" + outboxId + ", reason=" + reason);
+            }
+
+        } catch (TimeoutException e) {
+            throw new RuntimeException(
+                    "[OvertakePublisher] 브로커 ACK 타임아웃 – 재시도 예정: outboxId=" + outboxId, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(
+                    "[OvertakePublisher] 브로커 ACK 대기 중 인터럽트: outboxId=" + outboxId, e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(
+                    "[OvertakePublisher] 브로커 ACK 대기 중 예외: outboxId=" + outboxId, e.getCause());
+        }
     }
 }

--- a/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/messaging/RankingOvertakePublisher.java
@@ -14,18 +14,6 @@ import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 
-/**
- * 아웃박스 이벤트를 RabbitMQ 로 발행하는 컴포넌트.
- *
- * <p>폴러({@link com.fitpet.server.ranking.infra.scheduler.OvertakeOutboxPollerScheduler})가
- * CLAIMED 이벤트 배치를 가져와 이 클래스를 통해 메시지를 발행한다.</p>
- *
- * <h2>Publisher Confirm (브로커 확인)</h2>
- * <p>{@code publisher-confirm-type: CORRELATED} 설정 하에 {@link CorrelationData}(outboxId)를
- * 함께 전달하고, 브로커의 ACK/NACK 를 {@link CorrelationData#getFuture()} 로 동기 대기한다.
- * 브로커가 ACK 를 보내야 정상 반환되며, NACK·타임아웃 시 예외를 던져 폴러가
- * retryCount 를 증가시키고 PENDING 으로 복원하도록 유도한다.</p>
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -36,12 +24,6 @@ public class RankingOvertakePublisher {
     private final RabbitTemplate rabbitTemplate;
     private final UserRepository userRepository;
 
-    /**
-     * 아웃박스 이벤트 한 건을 MQ 로 발행하고 브로커 ACK 를 동기 대기한다.
-     *
-     * @param outbox CLAIMED 상태의 아웃박스 이벤트
-     * @throws RuntimeException 브로커 NACK·타임아웃·인터럽트 발생 시
-     */
     public void publish(RankingOvertakeOutbox outbox) {
         String nickname = userRepository.findById(outbox.getOvertakingUserId())
                 .map(User::getNickname)
@@ -56,7 +38,6 @@ public class RankingOvertakePublisher {
                 .overtakerCount(outbox.getOvertakerCount())
                 .build();
 
-        // outboxId를 상관관계 ID로 사용해 브로커 ACK/NACK 를 추적한다
         CorrelationData correlationData = new CorrelationData(String.valueOf(outbox.getId()));
 
         rabbitTemplate.convertAndSend(
@@ -66,7 +47,6 @@ public class RankingOvertakePublisher {
                 correlationData
         );
 
-        // 브로커 ACK 를 동기적으로 대기 – 미확인 시 예외를 던져 폴러가 재시도하도록 유도
         waitForConfirm(outbox.getId(), correlationData);
 
         log.debug("[OvertakePublisher] 메시지 발행 완료 (ACK): outboxId={}, overtakenUserId={}",

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 아웃박스 폴러 스케줄러 (Outbox Poller).
@@ -22,9 +21,25 @@ import org.springframework.transaction.annotation.Transactional;
  * 서버 재시작·MQ 일시 다운 시 이벤트가 유실되는 것을 방지하기 위해
  * "DB에 먼저 기록 → 폴러가 안정적으로 발행" 흐름을 사용한다.</p>
  *
+ * <h2>3단계 발행 프로토콜</h2>
+ * <ol>
+ *   <li><b>Claim (TX 1)</b> – PENDING 행을 SELECT FOR UPDATE SKIP LOCKED 로 잠근 뒤
+ *       status=CLAIMED 로 커밋. 다른 인스턴스가 같은 행을 가져가지 못한다.</li>
+ *   <li><b>Publish (TX 없음)</b> – MQ 에 메시지를 발행한다.
+ *       이 단계는 DB 트랜잭션 밖에서 수행되므로 "발행 성공 + DB 커밋 실패 → 재발행"
+ *       경로가 차단된다. 소비자는 outboxId 기반 멱등 처리로 중복을 방어한다.</li>
+ *   <li><b>결과 저장 (TX 2)</b> – 발행 성공 시 PUBLISHED, 실패 시 retryCount 증가 후
+ *       PENDING 으로 복원 (다음 폴링 주기에서 재시도). MAX_RETRY 초과 시 FAILED.</li>
+ * </ol>
+ *
+ * <h2>CLAIMED stuck 행 복구</h2>
+ * <p>JVM 충돌로 Claim 후 Publish/결과저장 전에 프로세스가 종료되면 행이 CLAIMED 에
+ * 고착될 수 있다. 주기적 클린업 잡(별도 구현 예정)에서 일정 시간 이상 CLAIMED인
+ * 행을 PENDING 으로 복원한다.</p>
+ *
  * <h2>재시도 정책</h2>
  * <ul>
- *   <li>MQ 발행 실패 시 retryCount를 증가시키고 PENDING 유지 → 다음 폴링에서 재시도.</li>
+ *   <li>MQ 발행 실패 시 retryCount를 증가시키고 PENDING 복원 → 다음 폴링에서 재시도.</li>
  *   <li>retryCount ≥ 3 이면 FAILED 처리 → 수동 확인.</li>
  * </ul>
  */
@@ -42,33 +57,45 @@ public class OvertakeOutboxPollerScheduler {
     /**
      * 30초마다 PENDING 이벤트를 최대 100건 발행한다.
      *
-     * <p>fixedDelay 사용 → 이전 실행이 완료된 후 30초 대기 (동시 실행 방지).</p>
+     * <p>fixedDelay 사용 → 이전 실행이 완료된 후 30초 대기 (동시 실행 방지).
+     * 메서드 자체에 {@code @Transactional} 을 두지 않는다. 트랜잭션 경계는
+     * claimBatch / save 내부에서 각각 관리한다.</p>
      */
     @Scheduled(fixedDelay = 30_000)
-    @Transactional
     public void pollAndPublish() {
-        List<RankingOvertakeOutbox> pending = outboxRepository.findPendingBatch(BATCH_SIZE);
-        if (pending.isEmpty()) {
+        // ── Phase 1: Claim ────────────────────────────────────────────────
+        // 별도 TX 에서 PENDING → CLAIMED 커밋. 이 TX 가 끝난 뒤 MQ 발행.
+        List<RankingOvertakeOutbox> claimed = outboxRepository.claimBatch(BATCH_SIZE);
+        if (claimed.isEmpty()) {
             return;
         }
 
-        log.info("[OvertakeOutboxPoller] {}건 발행 시작", pending.size());
+        log.info("[OvertakeOutboxPoller] {}건 발행 시작", claimed.size());
 
         int successCount = 0;
         int failCount = 0;
 
-        for (RankingOvertakeOutbox outbox : pending) {
+        for (RankingOvertakeOutbox outbox : claimed) {
+            // ── Phase 2: Publish (DB TX 밖) ───────────────────────────────
             try {
                 publisher.publish(outbox);
+
+                // ── Phase 3a: 발행 성공 → PUBLISHED (새 TX) ───────────────
                 outbox.markPublished();
                 outboxRepository.save(outbox);
                 successCount++;
+
             } catch (Exception e) {
                 log.error("[OvertakeOutboxPoller] 발행 실패: outboxId={}", outbox.getId(), e);
+
+                // ── Phase 3b: 발행 실패 → 재시도 또는 FAILED (새 TX) ──────
                 outbox.incrementRetryCount();
                 if (outbox.getRetryCount() >= MAX_RETRY) {
                     outbox.markFailed();
                     log.error("[OvertakeOutboxPoller] 최대 재시도 초과 – FAILED 처리: outboxId={}", outbox.getId());
+                } else {
+                    // PENDING 으로 복원해 다음 폴링 주기에서 재시도
+                    outbox.markPending();
                 }
                 outboxRepository.save(outbox);
                 failCount++;

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
@@ -1,0 +1,80 @@
+package com.fitpet.server.ranking.infra.scheduler;
+
+import com.fitpet.server.ranking.domain.entity.RankingOvertakeOutbox;
+import com.fitpet.server.ranking.domain.repository.RankingOvertakeOutboxRepository;
+import com.fitpet.server.ranking.infra.messaging.RankingOvertakePublisher;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 아웃박스 폴러 스케줄러 (Outbox Poller).
+ *
+ * <h2>역할</h2>
+ * <p>DB에 PENDING 상태로 저장된 아웃박스 이벤트를 30초마다 배치로 읽어
+ * RabbitMQ에 발행하고 PUBLISHED 로 상태를 변경한다.</p>
+ *
+ * <h2>왜 아웃박스 패턴이 필요한가?</h2>
+ * <p>랭킹 업데이트(Redis Lua 스크립트)와 MQ 발행은 단일 트랜잭션으로 묶을 수 없다.
+ * 서버 재시작·MQ 일시 다운 시 이벤트가 유실되는 것을 방지하기 위해
+ * "DB에 먼저 기록 → 폴러가 안정적으로 발행" 흐름을 사용한다.</p>
+ *
+ * <h2>재시도 정책</h2>
+ * <ul>
+ *   <li>MQ 발행 실패 시 retryCount를 증가시키고 PENDING 유지 → 다음 폴링에서 재시도.</li>
+ *   <li>retryCount ≥ 3 이면 FAILED 처리 → 수동 확인.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OvertakeOutboxPollerScheduler {
+
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_RETRY = 3;
+
+    private final RankingOvertakeOutboxRepository outboxRepository;
+    private final RankingOvertakePublisher publisher;
+
+    /**
+     * 30초마다 PENDING 이벤트를 최대 100건 발행한다.
+     *
+     * <p>fixedDelay 사용 → 이전 실행이 완료된 후 30초 대기 (동시 실행 방지).</p>
+     */
+    @Scheduled(fixedDelay = 30_000)
+    @Transactional
+    public void pollAndPublish() {
+        List<RankingOvertakeOutbox> pending = outboxRepository.findPendingBatch(BATCH_SIZE);
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        log.info("[OvertakeOutboxPoller] {}건 발행 시작", pending.size());
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (RankingOvertakeOutbox outbox : pending) {
+            try {
+                publisher.publish(outbox);
+                outbox.markPublished();
+                outboxRepository.save(outbox);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[OvertakeOutboxPoller] 발행 실패: outboxId={}", outbox.getId(), e);
+                outbox.incrementRetryCount();
+                if (outbox.getRetryCount() >= MAX_RETRY) {
+                    outbox.markFailed();
+                    log.error("[OvertakeOutboxPoller] 최대 재시도 초과 – FAILED 처리: outboxId={}", outbox.getId());
+                }
+                outboxRepository.save(outbox);
+                failCount++;
+            }
+        }
+
+        log.info("[OvertakeOutboxPoller] 완료 – 성공: {}건, 실패: {}건", successCount, failCount);
+    }
+}

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/OvertakeOutboxPollerScheduler.java
@@ -9,40 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * 아웃박스 폴러 스케줄러 (Outbox Poller).
- *
- * <h2>역할</h2>
- * <p>DB에 PENDING 상태로 저장된 아웃박스 이벤트를 30초마다 배치로 읽어
- * RabbitMQ에 발행하고 PUBLISHED 로 상태를 변경한다.</p>
- *
- * <h2>왜 아웃박스 패턴이 필요한가?</h2>
- * <p>랭킹 업데이트(Redis Lua 스크립트)와 MQ 발행은 단일 트랜잭션으로 묶을 수 없다.
- * 서버 재시작·MQ 일시 다운 시 이벤트가 유실되는 것을 방지하기 위해
- * "DB에 먼저 기록 → 폴러가 안정적으로 발행" 흐름을 사용한다.</p>
- *
- * <h2>3단계 발행 프로토콜</h2>
- * <ol>
- *   <li><b>Claim (TX 1)</b> – PENDING 행을 SELECT FOR UPDATE SKIP LOCKED 로 잠근 뒤
- *       status=CLAIMED 로 커밋. 다른 인스턴스가 같은 행을 가져가지 못한다.</li>
- *   <li><b>Publish (TX 없음)</b> – MQ 에 메시지를 발행한다.
- *       이 단계는 DB 트랜잭션 밖에서 수행되므로 "발행 성공 + DB 커밋 실패 → 재발행"
- *       경로가 차단된다. 소비자는 outboxId 기반 멱등 처리로 중복을 방어한다.</li>
- *   <li><b>결과 저장 (TX 2)</b> – 발행 성공 시 PUBLISHED, 실패 시 retryCount 증가 후
- *       PENDING 으로 복원 (다음 폴링 주기에서 재시도). MAX_RETRY 초과 시 FAILED.</li>
- * </ol>
- *
- * <h2>CLAIMED stuck 행 복구</h2>
- * <p>JVM 충돌로 Claim 후 Publish/결과저장 전에 프로세스가 종료되면 행이 CLAIMED 에
- * 고착될 수 있다. 주기적 클린업 잡(별도 구현 예정)에서 일정 시간 이상 CLAIMED인
- * 행을 PENDING 으로 복원한다.</p>
- *
- * <h2>재시도 정책</h2>
- * <ul>
- *   <li>MQ 발행 실패 시 retryCount를 증가시키고 PENDING 복원 → 다음 폴링에서 재시도.</li>
- *   <li>retryCount ≥ 3 이면 FAILED 처리 → 수동 확인.</li>
- * </ul>
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -54,17 +20,8 @@ public class OvertakeOutboxPollerScheduler {
     private final RankingOvertakeOutboxRepository outboxRepository;
     private final RankingOvertakePublisher publisher;
 
-    /**
-     * 30초마다 PENDING 이벤트를 최대 100건 발행한다.
-     *
-     * <p>fixedDelay 사용 → 이전 실행이 완료된 후 30초 대기 (동시 실행 방지).
-     * 메서드 자체에 {@code @Transactional} 을 두지 않는다. 트랜잭션 경계는
-     * claimBatch / save 내부에서 각각 관리한다.</p>
-     */
     @Scheduled(fixedDelay = 30_000)
     public void pollAndPublish() {
-        // ── Phase 1: Claim ────────────────────────────────────────────────
-        // 별도 TX 에서 PENDING → CLAIMED 커밋. 이 TX 가 끝난 뒤 MQ 발행.
         List<RankingOvertakeOutbox> claimed = outboxRepository.claimBatch(BATCH_SIZE);
         if (claimed.isEmpty()) {
             return;
@@ -76,11 +33,9 @@ public class OvertakeOutboxPollerScheduler {
         int failCount = 0;
 
         for (RankingOvertakeOutbox outbox : claimed) {
-            // ── Phase 2: Publish (DB TX 밖) ───────────────────────────────
             try {
                 publisher.publish(outbox);
 
-                // ── Phase 3a: 발행 성공 → PUBLISHED (새 TX) ───────────────
                 outbox.markPublished();
                 outboxRepository.save(outbox);
                 successCount++;
@@ -88,13 +43,11 @@ public class OvertakeOutboxPollerScheduler {
             } catch (Exception e) {
                 log.error("[OvertakeOutboxPoller] 발행 실패: outboxId={}", outbox.getId(), e);
 
-                // ── Phase 3b: 발행 실패 → 재시도 또는 FAILED (새 TX) ──────
                 outbox.incrementRetryCount();
                 if (outbox.getRetryCount() >= MAX_RETRY) {
                     outbox.markFailed();
                     log.error("[OvertakeOutboxPoller] 최대 재시도 초과 – FAILED 처리: outboxId={}", outbox.getId());
                 } else {
-                    // PENDING 으로 복원해 다음 폴링 주기에서 재시도
                     outbox.markPending();
                 }
                 outboxRepository.save(outbox);

--- a/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
+++ b/src/main/java/com/fitpet/server/ranking/infra/scheduler/RankingPersistenceScheduler.java
@@ -1,7 +1,5 @@
 package com.fitpet.server.ranking.infra.scheduler;
 
-// [변경 1] RankingService -> RankingSyncService로 변경
-
 import com.fitpet.server.ranking.application.service.RankingSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
@@ -1,0 +1,153 @@
+package com.fitpet.server.shared.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.interceptor.RetryOperationsInterceptor;
+
+/**
+ * RabbitMQ 인프라 설정.
+ *
+ * <h2>토폴로지</h2>
+ * <pre>
+ * Producer
+ *   → [ranking.overtake.exchange] (Direct)
+ *       --routing-key: ranking.overtake--> [ranking.overtake.queue]
+ *                                                    ↓ (소비)
+ *                                             Consumer (FCM 발송)
+ *                                                    ↓ (실패 3회)
+ *                                      [ranking.overtake.dlx] (Dead Letter Exchange)
+ *                                                    ↓
+ *                                          [ranking.overtake.dlq]  (수동 확인/알림)
+ * </pre>
+ *
+ * <h2>백오프(Backoff)</h2>
+ * <ul>
+ *   <li>초기 대기: 1s</li>
+ *   <li>배수: 2.0 (1s → 2s → 4s)</li>
+ *   <li>최대 대기: 10s</li>
+ *   <li>최대 재시도: 3회 후 DLQ로 이동</li>
+ * </ul>
+ */
+@Configuration
+public class RabbitMQConfig {
+
+    // ── 메인 큐 ──────────────────────────────────────────────
+    public static final String EXCHANGE    = "ranking.overtake.exchange";
+    public static final String QUEUE       = "ranking.overtake.queue";
+    public static final String ROUTING_KEY = "ranking.overtake";
+
+    // ── Dead Letter ───────────────────────────────────────────
+    public static final String DLX             = "ranking.overtake.dlx";
+    public static final String DLQ             = "ranking.overtake.dlq";
+    public static final String DLQ_ROUTING_KEY = "ranking.overtake.dead";
+
+    // ── Exchange ──────────────────────────────────────────────
+
+    @Bean
+    DirectExchange rankingOvertakeExchange() {
+        return new DirectExchange(EXCHANGE, true, false);
+    }
+
+    @Bean
+    DirectExchange rankingOvertakeDlx() {
+        return new DirectExchange(DLX, true, false);
+    }
+
+    // ── Queue ─────────────────────────────────────────────────
+
+    /**
+     * 메인 큐: 처리 실패 시 DLX 로 라우팅.
+     *
+     * <p>{@code x-dead-letter-exchange} 와 {@code x-dead-letter-routing-key} 를 설정하면
+     * consumer 가 NACK(requeue=false) 를 전달하거나 TTL 이 만료될 때 DLQ 로 이동한다.</p>
+     */
+    @Bean
+    Queue rankingOvertakeQueue() {
+        return QueueBuilder.durable(QUEUE)
+                .withArgument("x-dead-letter-exchange", DLX)
+                .withArgument("x-dead-letter-routing-key", DLQ_ROUTING_KEY)
+                .build();
+    }
+
+    /** Dead Letter Queue: 수동 검토 / 재처리 대상 */
+    @Bean
+    Queue rankingOvertakeDlq() {
+        return QueueBuilder.durable(DLQ).build();
+    }
+
+    // ── Binding ───────────────────────────────────────────────
+
+    @Bean
+    Binding rankingOvertakeBinding(Queue rankingOvertakeQueue,
+                                   DirectExchange rankingOvertakeExchange) {
+        return BindingBuilder.bind(rankingOvertakeQueue)
+                .to(rankingOvertakeExchange)
+                .with(ROUTING_KEY);
+    }
+
+    @Bean
+    Binding rankingOvertakeDlqBinding(Queue rankingOvertakeDlq,
+                                      DirectExchange rankingOvertakeDlx) {
+        return BindingBuilder.bind(rankingOvertakeDlq)
+                .to(rankingOvertakeDlx)
+                .with(DLQ_ROUTING_KEY);
+    }
+
+    // ── Converter & Template ──────────────────────────────────
+
+    @Bean
+    MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                  MessageConverter jsonMessageConverter) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter);
+        return template;
+    }
+
+    // ── Listener Container ────────────────────────────────────
+
+    /**
+     * 재시도 인터셉터: 지수 백오프(1s→2s→4s), 3회 초과 시 DLQ.
+     *
+     * <p>{@link RejectAndDontRequeueRecoverer} 는 최종 실패 시 NACK + requeue=false 를
+     * 전송한다. 메인 큐에 {@code x-dead-letter-exchange} 가 설정되어 있으면 DLQ로 이동한다.</p>
+     */
+    @Bean
+    RetryOperationsInterceptor rankingOvertakeRetryInterceptor() {
+        return RetryInterceptorBuilder.stateless()
+                .maxAttempts(3)
+                .backOffOptions(1_000, 2.0, 10_000) // initial, multiplier, max (ms)
+                .recoverer(new RejectAndDontRequeueRecoverer())
+                .build();
+    }
+
+    @Bean
+    SimpleRabbitListenerContainerFactory rankingOvertakeListenerFactory(
+            ConnectionFactory connectionFactory,
+            MessageConverter jsonMessageConverter,
+            RetryOperationsInterceptor rankingOvertakeRetryInterceptor) {
+
+        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setMessageConverter(jsonMessageConverter);
+        factory.setDefaultRequeueRejected(false); // 재시도 정책은 인터셉터가 관리
+        factory.setAdviceChain(rankingOvertakeRetryInterceptor);
+        return factory;
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.fitpet.server.shared.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
@@ -40,6 +41,7 @@ import org.springframework.retry.interceptor.RetryOperationsInterceptor;
  *   <li>최대 재시도: 3회 후 DLQ로 이동</li>
  * </ul>
  */
+@Slf4j
 @Configuration
 public class RabbitMQConfig {
 
@@ -117,6 +119,13 @@ public class RabbitMQConfig {
                                   MessageConverter jsonMessageConverter) {
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMessageConverter(jsonMessageConverter);
+        // mandatory=true: 라우팅 불가 메시지를 ReturnsCallback으로 반환 (publisher-returns와 함께 동작)
+        template.setMandatory(true);
+        // 라우팅 실패 콜백: exchange에 바인딩된 큐가 없을 때 호출
+        template.setReturnsCallback(returned ->
+                log.error("[RabbitMQ] 메시지 라우팅 실패 – 큐 바인딩 확인 필요: exchange={}, routingKey={}, replyText={}",
+                        returned.getExchange(), returned.getRoutingKey(), returned.getReplyText())
+        );
         return template;
     }
 

--- a/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RabbitMQConfig.java
@@ -15,47 +15,21 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
 import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 
-/**
- * RabbitMQ 인프라 설정.
- *
- * <h2>토폴로지</h2>
- * <pre>
- * Producer
- *   → [ranking.overtake.exchange] (Direct)
- *       --routing-key: ranking.overtake--> [ranking.overtake.queue]
- *                                                    ↓ (소비)
- *                                             Consumer (FCM 발송)
- *                                                    ↓ (실패 3회)
- *                                      [ranking.overtake.dlx] (Dead Letter Exchange)
- *                                                    ↓
- *                                          [ranking.overtake.dlq]  (수동 확인/알림)
- * </pre>
- *
- * <h2>백오프(Backoff)</h2>
- * <ul>
- *   <li>초기 대기: 1s</li>
- *   <li>배수: 2.0 (1s → 2s → 4s)</li>
- *   <li>최대 대기: 10s</li>
- *   <li>최대 재시도: 3회 후 DLQ로 이동</li>
- * </ul>
- */
 @Slf4j
 @Configuration
 public class RabbitMQConfig {
 
-    // ── 메인 큐 ──────────────────────────────────────────────
-    public static final String EXCHANGE    = "ranking.overtake.exchange";
-    public static final String QUEUE       = "ranking.overtake.queue";
+    public static final String EXCHANGE = "ranking.overtake.exchange";
+    public static final String QUEUE = "ranking.overtake.queue";
     public static final String ROUTING_KEY = "ranking.overtake";
 
-    // ── Dead Letter ───────────────────────────────────────────
-    public static final String DLX             = "ranking.overtake.dlx";
-    public static final String DLQ             = "ranking.overtake.dlq";
+    public static final String DLX = "ranking.overtake.dlx";
+    public static final String DLQ = "ranking.overtake.dlq";
     public static final String DLQ_ROUTING_KEY = "ranking.overtake.dead";
 
-    // ── Exchange ──────────────────────────────────────────────
 
     @Bean
     DirectExchange rankingOvertakeExchange() {
@@ -67,14 +41,6 @@ public class RabbitMQConfig {
         return new DirectExchange(DLX, true, false);
     }
 
-    // ── Queue ─────────────────────────────────────────────────
-
-    /**
-     * 메인 큐: 처리 실패 시 DLX 로 라우팅.
-     *
-     * <p>{@code x-dead-letter-exchange} 와 {@code x-dead-letter-routing-key} 를 설정하면
-     * consumer 가 NACK(requeue=false) 를 전달하거나 TTL 이 만료될 때 DLQ 로 이동한다.</p>
-     */
     @Bean
     Queue rankingOvertakeQueue() {
         return QueueBuilder.durable(QUEUE)
@@ -83,13 +49,10 @@ public class RabbitMQConfig {
                 .build();
     }
 
-    /** Dead Letter Queue: 수동 검토 / 재처리 대상 */
     @Bean
     Queue rankingOvertakeDlq() {
         return QueueBuilder.durable(DLQ).build();
     }
-
-    // ── Binding ───────────────────────────────────────────────
 
     @Bean
     Binding rankingOvertakeBinding(Queue rankingOvertakeQueue,
@@ -107,7 +70,6 @@ public class RabbitMQConfig {
                 .with(DLQ_ROUTING_KEY);
     }
 
-    // ── Converter & Template ──────────────────────────────────
 
     @Bean
     MessageConverter jsonMessageConverter() {
@@ -129,19 +91,16 @@ public class RabbitMQConfig {
         return template;
     }
 
-    // ── Listener Container ────────────────────────────────────
-
-    /**
-     * 재시도 인터셉터: 지수 백오프(1s→2s→4s), 3회 초과 시 DLQ.
-     *
-     * <p>{@link RejectAndDontRequeueRecoverer} 는 최종 실패 시 NACK + requeue=false 를
-     * 전송한다. 메인 큐에 {@code x-dead-letter-exchange} 가 설정되어 있으면 DLQ로 이동한다.</p>
-     */
     @Bean
     RetryOperationsInterceptor rankingOvertakeRetryInterceptor() {
+        ExponentialRandomBackOffPolicy backOff = new ExponentialRandomBackOffPolicy();
+        backOff.setInitialInterval(1_000);
+        backOff.setMultiplier(2.0);
+        backOff.setMaxInterval(10_000);
+
         return RetryInterceptorBuilder.stateless()
                 .maxAttempts(3)
-                .backOffOptions(1_000, 2.0, 10_000) // initial, multiplier, max (ms)
+                .backOffPolicy(backOff)
                 .recoverer(new RejectAndDontRequeueRecoverer())
                 .build();
     }

--- a/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/RedisConfig.java
@@ -7,6 +7,7 @@ import com.fitpet.server.mission.infra.redis.MissionProgressRedisChannels;
 import com.fitpet.server.mission.infra.redis.MissionProgressRedisSubscriber;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
@@ -63,10 +64,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisScript<Long> updateStepAndRankingScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+    @SuppressWarnings("rawtypes")
+    public RedisScript<List> updateStepAndRankingScript() {
+        DefaultRedisScript<List> script = new DefaultRedisScript<>();
         script.setLocation(new ClassPathResource("redis/lua/update_step_and_ranking.lua"));
-        script.setResultType(Long.class);
+        script.setResultType(List.class);
         return script;
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,8 @@ spring:
     port: ${RABBITMQ_PORT:5672}
     username: ${RABBITMQ_USER:fitpet}
     password: ${RABBITMQ_PASS:fitpet}
+    publisher-confirm-type: CORRELATED   # outboxId 기반 브로커 ACK/NACK 추적
+    publisher-returns: true               # 라우팅 실패(unroutable) 메시지 반환 활성화
   security:
     user:
       name: ${SECURITY_USER}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,13 @@ spring:
       host: ${VALKEY_HOST}
       port: ${VALKEY_PORT}
       password: "${VALKEY_PASSWORD}"
+
+  # RabbitMQ – 랭킹 추월 알림 비동기 처리
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:fitpet}
+    password: ${RABBITMQ_PASS:fitpet}
   security:
     user:
       name: ${SECURITY_USER}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,10 +29,10 @@ spring:
 
   # RabbitMQ – 랭킹 추월 알림 비동기 처리
   rabbitmq:
-    host: ${RABBITMQ_HOST:localhost}
-    port: ${RABBITMQ_PORT:5672}
-    username: ${RABBITMQ_USER:fitpet}
-    password: ${RABBITMQ_PASS:fitpet}
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username: ${RABBITMQ_USER}
+    password: ${RABBITMQ_PASS}
     publisher-confirm-type: CORRELATED   # outboxId 기반 브로커 ACK/NACK 추적
     publisher-returns: true               # 라우팅 실패(unroutable) 메시지 반환 활성화
   security:

--- a/src/main/resources/redis/lua/update_step_and_ranking.lua
+++ b/src/main/resources/redis/lua/update_step_and_ranking.lua
@@ -14,6 +14,10 @@
 -- ARGV[5]: weightedScore (랭킹용 가중치 점수)
 -- ARGV[6]: TTL (초)
 
+-- 추월 감지를 위해 ZADD 이전 순위를 원자적으로 스냅샷
+-- ZREVRANK: 0-indexed (0 = 1위). 처음 진입이면 nil → -1 로 치환
+local prev_rank = redis.call('ZREVRANK', KEYS[5], ARGV[1])
+
 redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
 redis.call('HSET', KEYS[2], ARGV[1], ARGV[3])
 redis.call('HSET', KEYS[3], ARGV[1], ARGV[4])
@@ -31,4 +35,5 @@ if KEYS[6] then
     redis.call('EXPIRE', KEYS[6], ARGV[6])
 end
 
-return tonumber(ARGV[2])
+-- {이전 순위(없으면 -1), totalSteps} 반환
+return {prev_rank or -1, tonumber(ARGV[2])}


### PR DESCRIPTION
## 📌 PR 요약

- 랭킹에서 추월당한 사용자에게 FCM 푸시 알림을 발송하는 파이프라인을 구현합니다.
- 아웃박스 패턴 + RabbitMQ를 활용해 알림 유실 없이 안정적으로 발송하며, Redis Rate Limiter로 중복 알림을 방지합니다.
- `user.device_token`(항상 null)을 참조하던 버그를 `user_device` 테이블 조회로 수정합니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
  - Redis ZSet 기반 추월 감지 (`@Async` Spring 이벤트)
  - Redis SETNX Rate Limiter (피추월자 1인당 1시간 1회 알림 제한)
  - 아웃박스 엔티티 + Repository 계층 (도메인 인터페이스 + JPA 어댑터)
  - RabbitMQ Exchange/Queue/DLX/DLQ 토폴로지 및 지수 백오프 재시도 정책 (1s→2s→4s, 최대 3회)
  - 아웃박스 폴러 스케줄러 (30초 주기, PENDING → PUBLISHED 상태 전환)
  - RabbitMQ 컨슈머 → FCM 발송 + 알림 이력 DB 저장
  - DLQ 리스너 → 최종 실패 에러 로깅
- [x] 관련 API 변경
  - 없음 (내부 파이프라인만 추가)
- [x] 기타 리팩터링
  - **버그 수정**: FCM 토큰을 `user_device` 테이블에서 조회하도록 변경 (멀티 디바이스 지원)
  - 알림 메시지 변경: `"N명에게 순위를 추월당했어요! 달려볼까요? 🏃"`

## 🧪 테스트 방법

수동테스트
<img width="496" height="146" alt="image" src="https://github.com/user-attachments/assets/abe8fed1-386a-467b-9f66-f5a631faf884" />


## 📎 관련 이슈

- 없음

## 추가 전달 사항

파이프라인 흐름
```
랭킹 점수 업데이트
      │
      ▼ Spring Event (@Async)
추월 감지 (Redis ZSet reverseRank 비교)
      │  Rate Limiter 통과 시만
      ▼
ranking_overtake_outbox 저장 (PENDING)
      │
      ▼ 스케줄러 (30초 주기)
RabbitMQ 발행 → PUBLISHED 상태 업데이트
      │
      ▼ Consumer
FCM 푸시 알림 발송 (user_device 테이블 조회)
      │  실패 시
      └─▶ DLX → 재시도 (최대 3회) → DLQ
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 랭킹 추월 알림 시스템 도입: 순위 추월 시 대상자에게 모바일 푸시 전송
  * 안정적 발행 파이프라인 추가: 메시지 브로커 연동, 확인/재시도 및 DLQ 처리
  * 발행용 아웃박스 저장 및 백그라운드 배치 발행 스케줄러 추가

* **개선**
  * 중복 방지: 사용자별 시간 단위 제한 및 기기별 멱등 처리 적용
  * 전송 신뢰성 향상: 브로커 ACK/리턴 기반 처리 및 실패 재시도/상태 관리
  * 알림 발송 내역 DB 기록으로 추적성 향상

* **환경**
  * 로컬 개발용 RabbitMQ 도커 컴포즈 구성 추가
* **기타**
  * 빌드에 RabbitMQ 클라이언트 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->