### PR TITLE
[Feat] GPS 세션 소프트 삭제 API 추가

### DIFF
--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionJpaRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionJpaRepository.java
@@ -4,17 +4,25 @@ import com.fitpet.server.dailyworkout.domain.entity.GpsSession;
 import com.fitpet.server.user.domain.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 
 public interface GpsSessionJpaRepository extends JpaRepository<GpsSession, Long> {
-    List<GpsSession> findByUserAndStartTimeBetween(User user, LocalDateTime start, LocalDateTime end);
+    @Query("SELECT s FROM GpsSession s WHERE s.user = :user AND s.deleted = false "
+        + "AND s.startTime >= :start AND s.startTime < :end")
+    List<GpsSession> findByUserAndStartTimeBetween(@Param("user") User user,
+                                                   @Param("start") LocalDateTime start,
+                                                   @Param("end") LocalDateTime end);
 
-    @Query("SELECT s FROM GpsSession s WHERE s.user = :user AND s.startTime >= :start AND s.startTime < :end "
+    @Query("SELECT s FROM GpsSession s WHERE s.user = :user AND s.deleted = false "
+        + "AND s.startTime >= :start AND s.startTime < :end "
         + "ORDER BY s.startTime DESC")
     List<GpsSession> findMonthlySessions(@Param("user") User user,
                                          @Param("start") LocalDateTime start,
                                          @Param("end") LocalDateTime end);
+
+    Optional<GpsSession> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/Infra/jpa/GpsSessionRepositoryAdapter.java
@@ -34,4 +34,9 @@ public class GpsSessionRepositoryAdapter implements GpsSessionRepository {
     public Optional<GpsSession> findById(Long id) {
         return gpsSessionJpaRepository.findById(id);
     }
+
+    @Override
+    public Optional<GpsSession> findActiveById(Long id) {
+        return gpsSessionJpaRepository.findByIdAndDeletedFalse(id);
+    }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionService.java
@@ -21,4 +21,6 @@ public interface GpsSessionService {
     List<GpsSessionSummaryResponse> getMonthlySessions(Long userId, int year, int month);
 
     GpsSessionDetailResponse getSessionDetail(Long userId, Long sessionId);
+
+    void deleteSession(Long userId, Long sessionId);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/application/service/GpsSessionServiceImpl.java
@@ -71,7 +71,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     @Override
     public GpsLogResponse logGps(Long userId, GpsLogRequest request) {
 
-        GpsSession session = gpsSessionRepository.findById(request.getSessionId())
+        GpsSession session = gpsSessionRepository.findActiveById(request.getSessionId())
                 .orElseThrow(() -> {
                     log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
                     return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
@@ -134,7 +134,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     public SessionEndResponse endSession(Long userId, SessionEndRequest request) {
         log.info("GPS 세션 종료 요청: sessionId={}", request.getSessionId());
 
-        GpsSession session = gpsSessionRepository.findById(request.getSessionId())
+        GpsSession session = gpsSessionRepository.findActiveById(request.getSessionId())
                 .orElseThrow(() -> {
                     log.warn("세션을 찾을 수 없음: sessionId={}", request.getSessionId());
                     return new BusinessException(ErrorCode.SESSION_NOT_FOUND);
@@ -191,7 +191,7 @@ public class GpsSessionServiceImpl implements GpsSessionService {
     @Override
     @Transactional(readOnly = true)
     public GpsSessionDetailResponse getSessionDetail(Long userId, Long sessionId) {
-        GpsSession session = gpsSessionRepository.findById(sessionId)
+        GpsSession session = gpsSessionRepository.findActiveById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
 
         if (!session.isOwnedBy(userId)) {
@@ -215,5 +215,20 @@ public class GpsSessionServiceImpl implements GpsSessionService {
                 session.getBurnCalories(),
                 routeLogs
         );
+    }
+
+    @Override
+    public void deleteSession(Long userId, Long sessionId) {
+        GpsSession session = gpsSessionRepository.findActiveById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isOwnedBy(userId)) {
+            log.warn("세션 삭제 권한 없음: userId={}, ownerId={}, sessionId={}",
+                    userId, session.getUser().getId(), session.getId());
+            throw new BusinessException(ErrorCode.SESSION_ACCESS_DENIED);
+        }
+
+        session.delete();
+        log.info("GPS 세션 삭제 완료: userId={}, sessionId={}", userId, sessionId);
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/entity/GpsSession.java
@@ -65,6 +65,13 @@ public class GpsSession {
     private LocalDateTime createdAt;
 
     @Builder.Default
+    @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder.Default
     @OneToMany(mappedBy = "gpsSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GpsLog> gpsLogs = new ArrayList<>();
     
@@ -79,6 +86,11 @@ public class GpsSession {
             return false;
         }
         return this.user.getId().equals(userId);
+    }
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     // 거리 누적 로직

--- a/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsSessionRepository.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/domain/repository/GpsSessionRepository.java
@@ -15,4 +15,6 @@ public interface GpsSessionRepository {
     List<GpsSession> findMonthlySessions(User user, LocalDateTime start, LocalDateTime end);
 
     Optional<GpsSession> findById(Long id);
+
+    Optional<GpsSession> findActiveById(Long id);
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -18,6 +18,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -82,5 +83,14 @@ public class GpsController {
     ) {
         GpsSessionDetailResponse response = gpsSessionService.getSessionDetail(userId, sessionId);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/session/{sessionId}")
+    public ResponseEntity<Void> deleteSession(
+            @AuthUser Long userId,
+            @PathVariable Long sessionId
+    ) {
+        gpsSessionService.deleteSession(userId, sessionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
+++ b/src/main/java/com/fitpet/server/dailyworkout/presentation/controller/GpsController.java
@@ -85,7 +85,7 @@ public class GpsController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/session/{sessionId}")
+    @DeleteMapping("/sessions/{sessionId}")
     public ResponseEntity<Void> deleteSession(
             @AuthUser Long userId,
             @PathVariable Long sessionId


### PR DESCRIPTION
## 📌 PR 요약

- GPS 세션 삭제 API를 추가했습니다.
- 세션 삭제는 실제 row 삭제가 아닌 소프트 삭제로 처리합니다.
- 삭제된 GPS 세션은 목록/상세/리포트/로그 추가/세션 종료 흐름에서 제외되도록 반영했습니다.

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [x] 관련 API 변경
- [x] 기타 리팩터링

- `DELETE /gps/session/{sessionId}` API 추가
- `gps_session`에 `is_deleted`, `deleted_at` 필드 추가
- 삭제 요청 시 세션 소유자 검증 후 `is_deleted=true`, `deleted_at=now` 처리
- 삭제된 세션은 `findActiveById` 기준으로 조회되지 않도록 처리
- 월별 GPS 세션 목록 조회에서 삭제된 세션 제외
- 오늘 활동 리포트 조회에서 삭제된 세션 제외
- 삭제된 세션에 대한 상세 조회, 로그 추가, 세션 종료 요청은 `SESSION_NOT_FOUND`로 처리

## 🧪 테스트 방법

<img width="1313" height="628" alt="image" src="https://github.com/user-attachments/assets/97c496a0-2254-441a-9b3f-adf19736b806" />

<img width="966" height="53" alt="image" src="https://github.com/user-attachments/assets/d79ee544-832b-45c5-bf0e-2ecf7e5437f5" />

## 추가 전달 사항

- 신규 컬럼:
  - `gps_session.is_deleted`
  - `gps_session.deleted_at`
- `ddl-auto=update` 환경에서는 컬럼 자동 추가가 예상됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * GPS 세션 삭제 기능 추가: 사용자는 이제 DELETE 엔드포인트를 통해 GPS 세션을 삭제할 수 있습니다.
  * 삭제된 세션은 시스템에서 더 이상 조회되지 않으며, 삭제 시간이 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->