### PR TITLE
 [📌Feat] Discord 알림 훅 + Gemini AI 에러 분석 도입 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,9 @@ services:
     env_file:
       - .env
     environment:
-      ACTIVE_PROFILE: ${ACTIVE_PROFILE:-local}
-      SPRING_PROFILES_ACTIVE: ${ACTIVE_PROFILE:-local}
+      ACTIVE_PROFILE: ${ACTIVE_PROFILE:-dev}
+      SPRING_PROFILES_ACTIVE: ${ACTIVE_PROFILE:-dev}
+      VALKEY_HOST: valkey
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_PORT: 5672
       LOG_PATH: /app/logs

--- a/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
@@ -1,7 +1,10 @@
 package com.fitpet.server.shared.config;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.ClientHttpRequestFactories;
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -24,6 +27,11 @@ public class DiscordNotificationConfig {
 
     @Bean
     public RestClient geminiRestClient() {
-        return RestClient.create();
+        var factory = ClientHttpRequestFactories.get(
+                ClientHttpRequestFactorySettings.DEFAULTS
+                        .withConnectTimeout(Duration.ofSeconds(3))
+                        .withReadTimeout(Duration.ofSeconds(10))
+        );
+        return RestClient.builder().requestFactory(factory).build();
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
@@ -26,6 +26,16 @@ public class DiscordNotificationConfig {
     }
 
     @Bean
+    public RestClient discordRestClient() {
+        var factory = ClientHttpRequestFactories.get(
+                ClientHttpRequestFactorySettings.DEFAULTS
+                        .withConnectTimeout(Duration.ofSeconds(3))
+                        .withReadTimeout(Duration.ofSeconds(5))
+        );
+        return RestClient.builder().requestFactory(factory).build();
+    }
+
+    @Bean
     public RestClient geminiRestClient() {
         var factory = ClientHttpRequestFactories.get(
                 ClientHttpRequestFactorySettings.DEFAULTS

--- a/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
@@ -1,0 +1,23 @@
+package com.fitpet.server.shared.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableConfigurationProperties(DiscordWebhookProperties.class)
+public class DiscordNotificationConfig {
+
+    @Bean("notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("notif-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/DiscordNotificationConfig.java
@@ -5,9 +5,10 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.client.RestClient;
 
 @Configuration
-@EnableConfigurationProperties(DiscordWebhookProperties.class)
+@EnableConfigurationProperties({DiscordWebhookProperties.class, GeminiProperties.class})
 public class DiscordNotificationConfig {
 
     @Bean("notificationExecutor")
@@ -19,5 +20,10 @@ public class DiscordNotificationConfig {
         executor.setThreadNamePrefix("notif-");
         executor.initialize();
         return executor;
+    }
+
+    @Bean
+    public RestClient geminiRestClient() {
+        return RestClient.create();
     }
 }

--- a/src/main/java/com/fitpet/server/shared/config/DiscordWebhookProperties.java
+++ b/src/main/java/com/fitpet/server/shared/config/DiscordWebhookProperties.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.shared.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "notification.discord")
+public class DiscordWebhookProperties {
+    private boolean enabled;
+    private String errorWebhookUrl;
+    private String signupWebhookUrl;
+}

--- a/src/main/java/com/fitpet/server/shared/config/GeminiProperties.java
+++ b/src/main/java/com/fitpet/server/shared/config/GeminiProperties.java
@@ -1,0 +1,14 @@
+package com.fitpet.server.shared.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "gemini")
+public class GeminiProperties {
+    private String apiKey;
+    private String model = "gemini-2.5-flash";
+    private boolean enabled = true;
+}

--- a/src/main/java/com/fitpet/server/shared/controller/DiscordTestController.java
+++ b/src/main/java/com/fitpet/server/shared/controller/DiscordTestController.java
@@ -18,7 +18,7 @@ public class DiscordTestController {
     public String testError() {
         notificationService.notifyError(
                 new RuntimeException("Discord 에러 훅 테스트"),
-                new ErrorContext("/api/test/discord/error", "POST", null)
+                new ErrorContext("/api/test/discord/error", "POST", null, null)
         );
         return "error notification sent";
     }

--- a/src/main/java/com/fitpet/server/shared/controller/DiscordTestController.java
+++ b/src/main/java/com/fitpet/server/shared/controller/DiscordTestController.java
@@ -1,0 +1,31 @@
+package com.fitpet.server.shared.controller;
+
+import com.fitpet.server.shared.notification.ErrorContext;
+import com.fitpet.server.shared.notification.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/test/discord")
+public class DiscordTestController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/error")
+    public String testError() {
+        notificationService.notifyError(
+                new RuntimeException("Discord 에러 훅 테스트"),
+                new ErrorContext("/api/test/discord/error", "POST", null)
+        );
+        return "error notification sent";
+    }
+
+    @PostMapping("/signup")
+    public String testSignup() {
+        notificationService.notifySignup(9999L, 9999L);
+        return "signup notification sent";
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fitpet/server/shared/exception/GlobalExceptionHandler.java
@@ -1,27 +1,41 @@
 package com.fitpet.server.shared.exception;
 
-import java.util.LinkedHashMap;          
+import com.fitpet.server.shared.notification.ErrorContext;
+import com.fitpet.server.shared.notification.NotificationService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import java.util.LinkedHashMap;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import jakarta.validation.ConstraintViolationException;
-
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
+    private final NotificationService notificationService;
+
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
+        if (errorCode.getStatus().is5xxServerError()) {
+            notificationService.notifyError(e, ErrorContext.from(request));
+        }
         return ResponseEntity.status(errorCode.getStatus())
                 .body(new ErrorResponse(errorCode));
     }
 
-    /** @Valid @RequestBody 실패 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception e, HttpServletRequest request) {
+        notificationService.notifyError(e, ErrorContext.from(request));
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleInvalidBody(MethodArgumentNotValidException e) {
         Map<String, String> errors = new LinkedHashMap<>();
@@ -36,7 +50,6 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    /** @Validated 파라미터/패스변수 실패 */
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Object> handleConstraintViolation(ConstraintViolationException e) {
         Map<String, String> errors = new LinkedHashMap<>();

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -22,6 +22,7 @@ public class DiscordNotificationService implements NotificationService {
     private static final int ERROR_COLOR = 0xED4245;
     private static final int SIGNUP_COLOR = 0x57F287;
     private static final int MAX_STACK_LENGTH = 1900;
+    private static final int STACK_TOP_LINES = 5;
 
     private final DiscordWebhookClient webhookClient;
     private final DiscordWebhookProperties properties;
@@ -78,7 +79,10 @@ public class DiscordNotificationService implements NotificationService {
     private String truncateStackTrace(Throwable throwable) {
         StringWriter sw = new StringWriter();
         throwable.printStackTrace(new PrintWriter(sw));
-        String stack = sw.toString();
+        String stack = sw.toString().lines()
+                .limit(STACK_TOP_LINES)
+                .reduce("", (acc, line) -> acc + line + "\n")
+                .strip();
         return stack.length() > MAX_STACK_LENGTH ? stack.substring(0, MAX_STACK_LENGTH) + "..." : stack;
     }
 }

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -54,6 +54,10 @@ public class DiscordNotificationService implements NotificationService {
         List<DiscordEmbedField> fields = new ArrayList<>();
         fields.add(new DiscordEmbedField("URI", context.uri(), true));
         fields.add(new DiscordEmbedField("Method", context.method(), true));
+        fields.add(new DiscordEmbedField("User", context.userId() != null ? "#" + context.userId() : "비인증", true));
+        if (StringUtils.hasText(context.queryString())) {
+            fields.add(new DiscordEmbedField("Query", context.queryString(), false));
+        }
         if (StringUtils.hasText(aiAnalysis)) {
             fields.add(new DiscordEmbedField("🤖 AI 분석", aiAnalysis, false));
         }

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -6,11 +6,13 @@ import com.fitpet.server.shared.notification.dto.DiscordEmbedField;
 import com.fitpet.server.shared.notification.dto.DiscordWebhookPayload;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -23,13 +25,15 @@ public class DiscordNotificationService implements NotificationService {
 
     private final DiscordWebhookClient webhookClient;
     private final DiscordWebhookProperties properties;
+    private final GeminiErrorAnalyzer geminiErrorAnalyzer;
 
     @Override
     @Async("notificationExecutor")
     public void notifyError(Throwable throwable, ErrorContext context) {
         if (!properties.isEnabled()) return;
         try {
-            webhookClient.send(properties.getErrorWebhookUrl(), buildErrorPayload(throwable, context));
+            String aiAnalysis = geminiErrorAnalyzer.analyze(throwable, context);
+            webhookClient.send(properties.getErrorWebhookUrl(), buildErrorPayload(throwable, context, aiAnalysis));
         } catch (Exception e) {
             log.error("Discord error notification failed", e);
         }
@@ -45,11 +49,13 @@ public class DiscordNotificationService implements NotificationService {
         }
     }
 
-    private DiscordWebhookPayload buildErrorPayload(Throwable throwable, ErrorContext context) {
-        List<DiscordEmbedField> fields = List.of(
-                new DiscordEmbedField("URI", context.uri(), true),
-                new DiscordEmbedField("Method", context.method(), true)
-        );
+    private DiscordWebhookPayload buildErrorPayload(Throwable throwable, ErrorContext context, String aiAnalysis) {
+        List<DiscordEmbedField> fields = new ArrayList<>();
+        fields.add(new DiscordEmbedField("URI", context.uri(), true));
+        fields.add(new DiscordEmbedField("Method", context.method(), true));
+        if (StringUtils.hasText(aiAnalysis)) {
+            fields.add(new DiscordEmbedField("🤖 AI 분석", aiAnalysis, false));
+        }
         DiscordEmbed embed = new DiscordEmbed(
                 "🚨 " + throwable.getClass().getSimpleName(),
                 "```" + truncateStackTrace(throwable) + "```",

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -1,0 +1,78 @@
+package com.fitpet.server.shared.notification;
+
+import com.fitpet.server.shared.config.DiscordWebhookProperties;
+import com.fitpet.server.shared.notification.dto.DiscordEmbed;
+import com.fitpet.server.shared.notification.dto.DiscordEmbedField;
+import com.fitpet.server.shared.notification.dto.DiscordWebhookPayload;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordNotificationService implements NotificationService {
+
+    private static final int ERROR_COLOR = 0xED4245;
+    private static final int SIGNUP_COLOR = 0x57F287;
+    private static final int MAX_STACK_LENGTH = 1900;
+
+    private final DiscordWebhookClient webhookClient;
+    private final DiscordWebhookProperties properties;
+
+    @Override
+    @Async("notificationExecutor")
+    public void notifyError(Throwable throwable, ErrorContext context) {
+        if (!properties.isEnabled()) return;
+        try {
+            webhookClient.send(properties.getErrorWebhookUrl(), buildErrorPayload(throwable, context));
+        } catch (Exception e) {
+            log.error("Discord error notification failed", e);
+        }
+    }
+
+    @Override
+    public void notifySignup(Long userId, long totalCount) {
+        if (!properties.isEnabled()) return;
+        try {
+            webhookClient.send(properties.getSignupWebhookUrl(), buildSignupPayload(userId, totalCount));
+        } catch (Exception e) {
+            log.error("Discord signup notification failed", e);
+        }
+    }
+
+    private DiscordWebhookPayload buildErrorPayload(Throwable throwable, ErrorContext context) {
+        List<DiscordEmbedField> fields = List.of(
+                new DiscordEmbedField("URI", context.uri(), true),
+                new DiscordEmbedField("Method", context.method(), true)
+        );
+        DiscordEmbed embed = new DiscordEmbed(
+                "🚨 " + throwable.getClass().getSimpleName(),
+                "```" + truncateStackTrace(throwable) + "```",
+                ERROR_COLOR,
+                fields
+        );
+        return DiscordWebhookPayload.of(embed);
+    }
+
+    private DiscordWebhookPayload buildSignupPayload(Long userId, long totalCount) {
+        DiscordEmbed embed = new DiscordEmbed(
+                "🎉 신규 회원 가입",
+                totalCount + "번째 회원 #" + userId + " 회원가입 완료!",
+                SIGNUP_COLOR,
+                List.of()
+        );
+        return DiscordWebhookPayload.of(embed);
+    }
+
+    private String truncateStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        String stack = sw.toString();
+        return stack.length() > MAX_STACK_LENGTH ? stack.substring(0, MAX_STACK_LENGTH) + "..." : stack;
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -33,14 +33,14 @@ public class DiscordNotificationService implements NotificationService {
     public void notifyError(Throwable throwable, ErrorContext context) {
         if (!properties.isEnabled()) return;
         if (!StringUtils.hasText(properties.getErrorWebhookUrl())) {
-            log.warn("Discord error webhook URL is not configured");
+            log.warn("[DiscordNotificationService] 에러 webhookURL이 확인되지 않습니다");
             return;
         }
         try {
             String aiAnalysis = geminiErrorAnalyzer.analyze(throwable, context);
             webhookClient.send(properties.getErrorWebhookUrl(), buildErrorPayload(throwable, context, aiAnalysis));
         } catch (Exception e) {
-            log.error("Discord error notification failed", e);
+            log.error("[DiscordNotificationService] 에러 알림 전송 실패", e);
         }
     }
 
@@ -48,13 +48,13 @@ public class DiscordNotificationService implements NotificationService {
     public void notifySignup(Long userId, long totalCount) {
         if (!properties.isEnabled()) return;
         if (!StringUtils.hasText(properties.getSignupWebhookUrl())) {
-            log.warn("Discord signup webhook URL is not configured");
+            log.warn("[DiscordNotificationService] 회원가입 webhookURL이 확인되지 않습니다");
             return;
         }
         try {
             webhookClient.send(properties.getSignupWebhookUrl(), buildSignupPayload(userId, totalCount));
         } catch (Exception e) {
-            log.error("Discord signup notification failed", e);
+            log.error("[DiscordNotificationService] 회원가입 알림 전송 실패", e);
         }
     }
 

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordNotificationService.java
@@ -32,6 +32,10 @@ public class DiscordNotificationService implements NotificationService {
     @Async("notificationExecutor")
     public void notifyError(Throwable throwable, ErrorContext context) {
         if (!properties.isEnabled()) return;
+        if (!StringUtils.hasText(properties.getErrorWebhookUrl())) {
+            log.warn("Discord error webhook URL is not configured");
+            return;
+        }
         try {
             String aiAnalysis = geminiErrorAnalyzer.analyze(throwable, context);
             webhookClient.send(properties.getErrorWebhookUrl(), buildErrorPayload(throwable, context, aiAnalysis));
@@ -43,6 +47,10 @@ public class DiscordNotificationService implements NotificationService {
     @Override
     public void notifySignup(Long userId, long totalCount) {
         if (!properties.isEnabled()) return;
+        if (!StringUtils.hasText(properties.getSignupWebhookUrl())) {
+            log.warn("Discord signup webhook URL is not configured");
+            return;
+        }
         try {
             webhookClient.send(properties.getSignupWebhookUrl(), buildSignupPayload(userId, totalCount));
         } catch (Exception e) {

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordWebhookClient.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordWebhookClient.java
@@ -1,6 +1,7 @@
 package com.fitpet.server.shared.notification;
 
 import com.fitpet.server.shared.notification.dto.DiscordWebhookPayload;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -8,12 +9,13 @@ import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class DiscordWebhookClient {
 
-    private final RestClient restClient = RestClient.create();
+    private final RestClient discordRestClient;
 
     public void send(String webhookUrl, DiscordWebhookPayload payload) {
-        restClient.post()
+        discordRestClient.post()
                 .uri(webhookUrl)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)

--- a/src/main/java/com/fitpet/server/shared/notification/DiscordWebhookClient.java
+++ b/src/main/java/com/fitpet/server/shared/notification/DiscordWebhookClient.java
@@ -1,0 +1,23 @@
+package com.fitpet.server.shared.notification;
+
+import com.fitpet.server.shared.notification.dto.DiscordWebhookPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class DiscordWebhookClient {
+
+    private final RestClient restClient = RestClient.create();
+
+    public void send(String webhookUrl, DiscordWebhookPayload payload) {
+        restClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/ErrorContext.java
+++ b/src/main/java/com/fitpet/server/shared/notification/ErrorContext.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.shared.notification;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public record ErrorContext(String uri, String method, Long userId) {
+
+    public static ErrorContext from(HttpServletRequest request) {
+        return new ErrorContext(request.getRequestURI(), request.getMethod(), null);
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/ErrorContext.java
+++ b/src/main/java/com/fitpet/server/shared/notification/ErrorContext.java
@@ -1,10 +1,26 @@
 package com.fitpet.server.shared.notification;
 
+import com.fitpet.server.shared.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
-public record ErrorContext(String uri, String method, Long userId) {
+public record ErrorContext(String uri, String method, Long userId, String queryString) {
 
     public static ErrorContext from(HttpServletRequest request) {
-        return new ErrorContext(request.getRequestURI(), request.getMethod(), null);
+        return new ErrorContext(
+                request.getRequestURI(),
+                request.getMethod(),
+                extractUserId(),
+                request.getQueryString()
+        );
+    }
+
+    private static Long extractUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            return userDetails.getUserId();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
+++ b/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
@@ -1,0 +1,101 @@
+package com.fitpet.server.shared.notification;
+
+import com.fitpet.server.shared.config.GeminiProperties;
+import com.fitpet.server.shared.notification.dto.gemini.GeminiRequest;
+import com.fitpet.server.shared.notification.dto.gemini.GeminiResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiErrorAnalyzer {
+
+    private static final int MAX_ANALYSIS_LENGTH = 1000;
+    private static final String API_URL =
+            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}";
+
+    private final GeminiProperties properties;
+    private final RestClient geminiRestClient;
+
+    @Value("${spring.profiles.active:local}")
+    private String activeProfile;
+
+    public String analyze(Throwable throwable, ErrorContext context) {
+        if (!properties.isEnabled() || !StringUtils.hasText(properties.getApiKey())) {
+            return null;
+        }
+
+        try {
+            return callGemini(throwable, context);
+        } catch (Exception e) {
+            log.warn("Gemini analysis failed, proceeding without AI analysis", e);
+            return null;
+        }
+    }
+
+    private String callGemini(Throwable throwable, ErrorContext context) {
+        GeminiRequest request = GeminiRequest.of(buildPrompt(throwable, context));
+
+        GeminiResponse response = geminiRestClient.post()
+                .uri(API_URL, properties.getModel(), properties.getApiKey())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(GeminiResponse.class);
+
+        if (response == null) return null;
+        List<GeminiResponse.Candidate> candidates = response.candidates();
+        if (candidates == null || candidates.isEmpty()) return null;
+
+        String text = candidates.get(0).content().parts().get(0).text();
+        return text.length() > MAX_ANALYSIS_LENGTH ? text.substring(0, MAX_ANALYSIS_LENGTH) + "..." : text;
+    }
+
+    private static final int STACK_TOP_LINES = 5;
+
+    private String buildPrompt(Throwable throwable, ErrorContext context) {
+        String topFrames = getStackTrace(throwable).lines()
+                .limit(STACK_TOP_LINES)
+                .reduce("", (a, b) -> a + b + "\n")
+                .strip();
+
+        return String.format("""
+                당신은 Spring Boot 3 + JPA + Redis 기반 헥사고날/DDD 백엔드를 운영하는 시니어 엔지니어입니다.
+                아래 예외를 분석하세요.
+
+                [환경] %s
+                [요청] %s %s
+                [예외] %s: %s
+                [스택 트레이스 상위]
+                %s
+
+                아래 형식을 정확히 지켜 한국어로만, 매우 간결하게 답하세요.
+                전체 450자 이내. 각 항목은 한 문장. 불필요한 수식어·코드블록·재진술 금지. 추측은 "추정:" 표기.
+
+                **요약**: (한 문장으로 무슨 에러인지)
+                **원인**: (핵심 근본 원인 한 문장)
+                **해결**: (가장 먼저 할 조치 1~2개, 짧게)
+                **긴급도**: (높음/보통/낮음 + 한 줄 사유)
+                """,
+                activeProfile,
+                context.method(), context.uri(),
+                throwable.getClass().getSimpleName(), throwable.getMessage(),
+                topFrames
+        );
+    }
+
+    private String getStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
+++ b/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
@@ -37,7 +37,7 @@ public class GeminiErrorAnalyzer {
         try {
             return callGemini(throwable, context);
         } catch (Exception e) {
-            log.warn("Gemini analysis failed, proceeding without AI analysis", e);
+            log.warn("[GeminiErrorAnalyzer] AI 분석 실패, AI 분석 없이 진행합니다", e);
             return null;
         }
     }

--- a/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
+++ b/src/main/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzer.java
@@ -56,7 +56,12 @@ public class GeminiErrorAnalyzer {
         List<GeminiResponse.Candidate> candidates = response.candidates();
         if (candidates == null || candidates.isEmpty()) return null;
 
-        String text = candidates.get(0).content().parts().get(0).text();
+        GeminiResponse.Candidate candidate = candidates.get(0);
+        if (candidate.content() == null) return null;
+        List<GeminiResponse.Part> parts = candidate.content().parts();
+        if (parts == null || parts.isEmpty()) return null;
+        String text = parts.get(0).text();
+        if (!StringUtils.hasText(text)) return null;
         return text.length() > MAX_ANALYSIS_LENGTH ? text.substring(0, MAX_ANALYSIS_LENGTH) + "..." : text;
     }
 

--- a/src/main/java/com/fitpet/server/shared/notification/NotificationService.java
+++ b/src/main/java/com/fitpet/server/shared/notification/NotificationService.java
@@ -1,0 +1,6 @@
+package com.fitpet.server.shared.notification;
+
+public interface NotificationService {
+    void notifyError(Throwable throwable, ErrorContext context);
+    void notifySignup(Long userId, long totalCount);
+}

--- a/src/main/java/com/fitpet/server/shared/notification/dto/DiscordEmbed.java
+++ b/src/main/java/com/fitpet/server/shared/notification/dto/DiscordEmbed.java
@@ -1,0 +1,6 @@
+package com.fitpet.server.shared.notification.dto;
+
+import java.util.List;
+
+public record DiscordEmbed(String title, String description, int color, List<DiscordEmbedField> fields) {
+}

--- a/src/main/java/com/fitpet/server/shared/notification/dto/DiscordEmbedField.java
+++ b/src/main/java/com/fitpet/server/shared/notification/dto/DiscordEmbedField.java
@@ -1,0 +1,4 @@
+package com.fitpet.server.shared.notification.dto;
+
+public record DiscordEmbedField(String name, String value, boolean inline) {
+}

--- a/src/main/java/com/fitpet/server/shared/notification/dto/DiscordWebhookPayload.java
+++ b/src/main/java/com/fitpet/server/shared/notification/dto/DiscordWebhookPayload.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.shared.notification.dto;
+
+import java.util.List;
+
+public record DiscordWebhookPayload(List<DiscordEmbed> embeds) {
+
+    public static DiscordWebhookPayload of(DiscordEmbed embed) {
+        return new DiscordWebhookPayload(List.of(embed));
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/dto/gemini/GeminiRequest.java
+++ b/src/main/java/com/fitpet/server/shared/notification/dto/gemini/GeminiRequest.java
@@ -1,0 +1,18 @@
+package com.fitpet.server.shared.notification.dto.gemini;
+
+import java.util.List;
+
+public record GeminiRequest(List<Content> contents, GenerationConfig generationConfig) {
+
+    public record Content(List<Part> parts) {}
+    public record Part(String text) {}
+    public record GenerationConfig(int maxOutputTokens, ThinkingConfig thinkingConfig) {}
+    public record ThinkingConfig(int thinkingBudget) {}
+
+    public static GeminiRequest of(String prompt) {
+        return new GeminiRequest(
+                List.of(new Content(List.of(new Part(prompt)))),
+                new GenerationConfig(1024, new ThinkingConfig(0))
+        );
+    }
+}

--- a/src/main/java/com/fitpet/server/shared/notification/dto/gemini/GeminiResponse.java
+++ b/src/main/java/com/fitpet/server/shared/notification/dto/gemini/GeminiResponse.java
@@ -1,0 +1,10 @@
+package com.fitpet.server.shared.notification.dto.gemini;
+
+import java.util.List;
+
+public record GeminiResponse(List<Candidate> candidates) {
+
+    public record Candidate(Content content) {}
+    public record Content(List<Part> parts) {}
+    public record Part(String text) {}
+}

--- a/src/main/java/com/fitpet/server/user/application/event/SignupNotificationListener.java
+++ b/src/main/java/com/fitpet/server/user/application/event/SignupNotificationListener.java
@@ -1,0 +1,22 @@
+package com.fitpet.server.user.application.event;
+
+import com.fitpet.server.shared.notification.NotificationService;
+import com.fitpet.server.user.domain.event.SignupCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class SignupNotificationListener {
+
+    private final NotificationService notificationService;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void handle(SignupCompletedEvent event) {
+        notificationService.notifySignup(event.userId(), event.totalCount());
+    }
+}

--- a/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/fitpet/server/user/application/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import com.fitpet.server.user.application.dto.UserCreateCommand;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.application.dto.UserUpdateCommand;
+import com.fitpet.server.user.domain.event.SignupCompletedEvent;
 import com.fitpet.server.user.application.mapper.UserMapper;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
 import com.fitpet.server.user.domain.entity.User;
@@ -27,6 +28,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.http.HttpStatus;
@@ -51,6 +53,7 @@ public class UserServiceImpl implements UserService {
     @Qualifier("hsetWithExpireScript")
     private final RedisScript<Long> hsetWithExpireScript;
     private final UserProfileImageRepository profileImageRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final String USER_IMAGE_KEY = "user:images";
     private static final String PROFILE_PRESET_PREFIX = "profile-presets/";
@@ -69,7 +72,10 @@ public class UserServiceImpl implements UserService {
                     validateUserCreateRequest(command);
                     User user = userMapper.toEntity(command);
                     user.changePassword(passwordEncoder.encode(command.password()));
-                    return userMapper.toResult(userRepository.save(user));
+                    User saved = userRepository.save(user);
+                    long totalCount = userRepository.count();
+                    eventPublisher.publishEvent(new SignupCompletedEvent(saved.getId(), totalCount));
+                    return userMapper.toResult(saved);
                 });
     }
 

--- a/src/main/java/com/fitpet/server/user/domain/event/SignupCompletedEvent.java
+++ b/src/main/java/com/fitpet/server/user/domain/event/SignupCompletedEvent.java
@@ -1,0 +1,4 @@
+package com.fitpet.server.user.domain.event;
+
+public record SignupCompletedEvent(Long userId, long totalCount) {
+}

--- a/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/fitpet/server/user/domain/repository/UserRepository.java
@@ -52,4 +52,6 @@ public interface UserRepository {
     long countByDailyStepCountGreaterThan(int dailyStepCount);
 
     List<User> findAllById(Iterable<Long> ids);
+
+    long count();
 }

--- a/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
+++ b/src/main/java/com/fitpet/server/user/infra/adapter/UserRepositoryAdapter.java
@@ -127,4 +127,9 @@ public class UserRepositoryAdapter implements UserRepository {
     public List<User> findAllById(Iterable<Long> ids) {
         return jpa.findAllById(ids);
     }
+
+    @Override
+    public long count() {
+        return jpa.count();
+    }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,4 +1,4 @@
 spring:
   datasource:
     #url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${CLOUDSQL_INSTANCE}&unixSocketPath=/cloudsql&cloudSqlRefreshStrategy=lazy
-    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${INSTANCE_CONNECTION_NAME}&cloudSqlRefreshStrategy=lazy
+    url: jdbc:mysql:///${DB_NAME}?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=${GCP_SQL_CONNECTION_NAME}&cloudSqlRefreshStrategy=lazy

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -110,6 +110,11 @@ notification:
     error-webhook-url: ${DISCORD_ERROR_WEBHOOK_URL:}
     signup-webhook-url: ${DISCORD_SIGNUP_WEBHOOK_URL:}
 
+gemini:
+  api-key: ${GEMINI_API_KEY:}
+  enabled: ${GEMINI_ENABLED:true}
+  model: ${GEMINI_MODEL:gemini-2.5-flash}
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,6 +104,12 @@ springdoc:
   swagger-ui:
     disable-swagger-default-url: true
 
+notification:
+  discord:
+    enabled: ${DISCORD_WEBHOOK_ENABLED:false}
+    error-webhook-url: ${DISCORD_ERROR_WEBHOOK_URL:}
+    signup-webhook-url: ${DISCORD_SIGNUP_WEBHOOK_URL:}
+
 management:
   endpoints:
     web:

--- a/src/test/java/com/fitpet/server/shared/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/fitpet/server/shared/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,56 @@
+package com.fitpet.server.shared.exception;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fitpet.server.shared.notification.ErrorContext;
+import com.fitpet.server.shared.notification.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock NotificationService notificationService;
+    @InjectMocks GlobalExceptionHandler sut;
+
+    @Test
+    @DisplayName("처리되지 않은 Exception 발생 시 notifyError가 호출된다")
+    void handleUnexpected_notifyError_호출() {
+        RuntimeException e = new RuntimeException("unexpected");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/test");
+
+        sut.handleUnexpected(e, request);
+
+        verify(notificationService).notifyError(eq(e), any(ErrorContext.class));
+    }
+
+    @Test
+    @DisplayName("BusinessException이 5xx이면 notifyError가 호출된다")
+    void handleBusinessException_5xx이면_notifyError_호출() {
+        BusinessException e = new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+
+        sut.handleBusinessException(e, request);
+
+        verify(notificationService).notifyError(eq(e), any(ErrorContext.class));
+    }
+
+    @Test
+    @DisplayName("BusinessException이 4xx이면 notifyError가 호출되지 않는다")
+    void handleBusinessException_4xx이면_notifyError_미호출() {
+        BusinessException e = new BusinessException(ErrorCode.USER_NOT_FOUND);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/1");
+
+        sut.handleBusinessException(e, request);
+
+        verify(notificationService, never()).notifyError(any(), any());
+    }
+}

--- a/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
+++ b/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
@@ -22,6 +22,7 @@ class DiscordNotificationServiceTest {
 
     @Mock DiscordWebhookClient webhookClient;
     @Mock DiscordWebhookProperties properties;
+    @Mock GeminiErrorAnalyzer geminiErrorAnalyzer;
     @InjectMocks DiscordNotificationService sut;
 
     @Test

--- a/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
+++ b/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
@@ -31,7 +31,7 @@ class DiscordNotificationServiceTest {
         when(properties.isEnabled()).thenReturn(true);
         when(properties.getErrorWebhookUrl()).thenReturn("https://discord.test/error");
 
-        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null));
+        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null, null));
 
         verify(webhookClient).send(eq("https://discord.test/error"), any(DiscordWebhookPayload.class));
     }
@@ -52,7 +52,7 @@ class DiscordNotificationServiceTest {
     void notifyError_disabled이면_웹훅_미전송() {
         when(properties.isEnabled()).thenReturn(false);
 
-        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null));
+        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null, null));
 
         verify(webhookClient, never()).send(any(), any());
     }
@@ -65,7 +65,7 @@ class DiscordNotificationServiceTest {
         doThrow(new RuntimeException("webhook failed")).when(webhookClient).send(any(), any());
 
         assertThatNoException().isThrownBy(() ->
-                sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null))
+                sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null, null))
         );
     }
 }

--- a/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
+++ b/src/test/java/com/fitpet/server/shared/notification/DiscordNotificationServiceTest.java
@@ -1,0 +1,70 @@
+package com.fitpet.server.shared.notification;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fitpet.server.shared.config.DiscordWebhookProperties;
+import com.fitpet.server.shared.notification.dto.DiscordWebhookPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DiscordNotificationServiceTest {
+
+    @Mock DiscordWebhookClient webhookClient;
+    @Mock DiscordWebhookProperties properties;
+    @InjectMocks DiscordNotificationService sut;
+
+    @Test
+    @DisplayName("notifyError - enabled이면 에러 웹훅 URL로 Discord 메시지를 전송한다")
+    void notifyError_enabled이면_에러_웹훅_전송() {
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getErrorWebhookUrl()).thenReturn("https://discord.test/error");
+
+        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null));
+
+        verify(webhookClient).send(eq("https://discord.test/error"), any(DiscordWebhookPayload.class));
+    }
+
+    @Test
+    @DisplayName("notifySignup - enabled이면 회원가입 웹훅 URL로 Discord 메시지를 전송한다")
+    void notifySignup_enabled이면_회원가입_웹훅_전송() {
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getSignupWebhookUrl()).thenReturn("https://discord.test/signup");
+
+        sut.notifySignup(42L, 100L);
+
+        verify(webhookClient).send(eq("https://discord.test/signup"), any(DiscordWebhookPayload.class));
+    }
+
+    @Test
+    @DisplayName("notifyError - disabled이면 웹훅을 전송하지 않는다")
+    void notifyError_disabled이면_웹훅_미전송() {
+        when(properties.isEnabled()).thenReturn(false);
+
+        sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null));
+
+        verify(webhookClient, never()).send(any(), any());
+    }
+
+    @Test
+    @DisplayName("notifyError - 웹훅 전송 실패 시 예외를 삼키고 호출자에게 영향을 주지 않는다")
+    void notifyError_웹훅_실패_시_예외_삼킴() {
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getErrorWebhookUrl()).thenReturn("https://discord.test/error");
+        doThrow(new RuntimeException("webhook failed")).when(webhookClient).send(any(), any());
+
+        assertThatNoException().isThrownBy(() ->
+                sut.notifyError(new RuntimeException("test"), new ErrorContext("/api/test", "GET", null))
+        );
+    }
+}

--- a/src/test/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzerTest.java
+++ b/src/test/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzerTest.java
@@ -37,7 +37,7 @@ class GeminiErrorAnalyzerTest {
 
     @InjectMocks GeminiErrorAnalyzer sut;
 
-    private final ErrorContext context = new ErrorContext("/api/test", "GET", null);
+    private final ErrorContext context = new ErrorContext("/api/test", "GET", null, null);
     private final RuntimeException throwable = new RuntimeException("test error");
 
     @BeforeEach

--- a/src/test/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzerTest.java
+++ b/src/test/java/com/fitpet/server/shared/notification/GeminiErrorAnalyzerTest.java
@@ -1,0 +1,119 @@
+package com.fitpet.server.shared.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fitpet.server.shared.config.GeminiProperties;
+import com.fitpet.server.shared.notification.dto.gemini.GeminiResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.RequestBodySpec;
+import org.springframework.web.client.RestClient.RequestBodyUriSpec;
+import org.springframework.web.client.RestClient.ResponseSpec;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class GeminiErrorAnalyzerTest {
+
+    @Mock GeminiProperties properties;
+    @Mock RestClient geminiRestClient;
+    @Mock(answer = Answers.RETURNS_SELF) RequestBodyUriSpec postSpec;
+    @Mock(answer = Answers.RETURNS_SELF) RequestBodySpec bodySpec;
+    @Mock ResponseSpec responseSpec;
+
+    @InjectMocks GeminiErrorAnalyzer sut;
+
+    private final ErrorContext context = new ErrorContext("/api/test", "GET", null);
+    private final RuntimeException throwable = new RuntimeException("test error");
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(sut, "activeProfile", "test");
+    }
+
+    @Test
+    @DisplayName("analyze - disabled이면 null을 반환하고 API를 호출하지 않는다")
+    void analyze_disabled이면_null_반환() {
+        when(properties.isEnabled()).thenReturn(false);
+
+        String result = sut.analyze(throwable, context);
+
+        assertThat(result).isNull();
+        verify(geminiRestClient, never()).post();
+    }
+
+    @Test
+    @DisplayName("analyze - apiKey가 비어 있으면 null을 반환한다")
+    void analyze_apiKey_없으면_null_반환() {
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getApiKey()).thenReturn("");
+
+        String result = sut.analyze(throwable, context);
+
+        assertThat(result).isNull();
+        verify(geminiRestClient, never()).post();
+    }
+
+    @Test
+    @DisplayName("analyze - Gemini API를 호출하고 분석 결과를 반환한다")
+    void analyze_API_호출_및_결과_반환() {
+        GeminiResponse response = new GeminiResponse(List.of(
+                new GeminiResponse.Candidate(
+                        new GeminiResponse.Content(List.of(
+                                new GeminiResponse.Part("AI 분석 결과입니다."))))));
+
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getApiKey()).thenReturn("test-api-key");
+        when(properties.getModel()).thenReturn("gemini-2.5-flash");
+        when(geminiRestClient.post()).thenReturn(postSpec);
+        when(postSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(GeminiResponse.class)).thenReturn(response);
+
+        String result = sut.analyze(throwable, context);
+
+        assertThat(result).isEqualTo("AI 분석 결과입니다.");
+    }
+
+    @Test
+    @DisplayName("analyze - Gemini API 호출 실패 시 null을 반환하고 예외를 삼킨다")
+    void analyze_API_실패_시_null_반환() {
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getApiKey()).thenReturn("test-api-key");
+        when(geminiRestClient.post()).thenThrow(new RuntimeException("Gemini API timeout"));
+
+        String result = sut.analyze(throwable, context);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("analyze - 응답 candidates가 비어 있으면 null을 반환한다")
+    void analyze_빈_candidates_null_반환() {
+        GeminiResponse empty = new GeminiResponse(List.of());
+
+        when(properties.isEnabled()).thenReturn(true);
+        when(properties.getApiKey()).thenReturn("test-api-key");
+        when(properties.getModel()).thenReturn("gemini-2.5-flash");
+        when(geminiRestClient.post()).thenReturn(postSpec);
+        when(postSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(GeminiResponse.class)).thenReturn(empty);
+
+        String result = sut.analyze(throwable, context);
+
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
+++ b/src/test/java/com/fitpet/server/user/application/service/UserServiceImplTest.java
@@ -17,6 +17,7 @@ import com.fitpet.server.user.application.dto.UserCreateCommand;
 import com.fitpet.server.user.application.dto.UserInputInfoCommand;
 import com.fitpet.server.user.application.dto.UserResult;
 import com.fitpet.server.user.application.dto.UserUpdateCommand;
+import com.fitpet.server.user.domain.event.SignupCompletedEvent;
 import com.fitpet.server.user.application.mapper.UserMapper;
 import com.fitpet.server.user.domain.entity.Gender;
 import com.fitpet.server.user.domain.entity.RegistrationStatus;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -48,6 +50,7 @@ class UserServiceImplTest {
     @Mock StringRedisTemplate redisTemplate;
     @Mock RedisScript<Long> hsetWithExpireScript;
     @Mock com.fitpet.server.user.domain.repository.UserProfileImageRepository profileImageRepository;
+    @Mock ApplicationEventPublisher eventPublisher;
 
     @InjectMocks UserServiceImpl sut;
 
@@ -294,6 +297,44 @@ class UserServiceImplTest {
         sut.withdrawUser(USER_ID);
 
         assertThat(user.getDeletedAt()).isNotNull();
+    }
+
+    // createUser() — SignupCompletedEvent
+
+    @Test
+    @DisplayName("createUser 신규 가입 시 SignupCompletedEvent가 발행된다")
+    void createUser_신규가입_SignupCompletedEvent_발행() {
+        when(userRepository.findByEmailIncludeDeleted("new@test.com")).thenReturn(Optional.empty());
+        when(userRepository.existsByEmail("new@test.com")).thenReturn(false);
+        when(userRepository.existsByNickname("새닉네임")).thenReturn(false);
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        User newUser = User.builder().id(2L).email("new@test.com").build();
+        when(userMapper.toEntity(any())).thenReturn(newUser);
+        when(userRepository.save(any())).thenReturn(newUser);
+        when(userMapper.toResult(any())).thenReturn(UserResult.builder().userId(2L).build());
+        when(userRepository.count()).thenReturn(100L);
+
+        UserCreateCommand command = new UserCreateCommand("new@test.com", "pass", "새닉네임", null, null, null, null, null, null, null, null);
+        sut.createUser(command);
+
+        verify(eventPublisher).publishEvent(any(SignupCompletedEvent.class));
+    }
+
+    @Test
+    @DisplayName("createUser 탈퇴 계정 재활성화 시 SignupCompletedEvent가 발행되지 않는다")
+    void createUser_재활성화시_SignupCompletedEvent_미발행() {
+        User deleted = User.builder().id(USER_ID).email("test@test.com").nickname("기존닉네임").build();
+        deleted.withdraw();
+
+        when(userRepository.findByEmailIncludeDeleted("test@test.com")).thenReturn(Optional.of(deleted));
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded");
+        when(userRepository.save(any())).thenReturn(deleted);
+        when(userMapper.toResult(any())).thenReturn(UserResult.builder().userId(USER_ID).build());
+
+        UserCreateCommand command = new UserCreateCommand("test@test.com", "pass", "닉네임", null, null, null, null, null, null, null, null);
+        sut.createUser(command);
+
+        verify(eventPublisher, never()).publishEvent(any(SignupCompletedEvent.class));
     }
 
     @Test


### PR DESCRIPTION
 ## 📌 PR 요약

  서버 운영 가시성을 위한 **Discord 알림 훅**을 도입합니다.
  - **에러 알림**: 5xx 예외 발생 시 스택 트레이스를 Discord에 자동 전송
  - **회원가입 알림**: 신규 가입 시 이벤트 기반으로 Discord 알림 발행
  - **AI 에러 분석**: Gemini LLM이 에러를 분석해 요약/원인/해결/긴급도를 알림에 함께 표시

  ## ✅ 작업 상세 내용

  - [x] **Discord 웹훅 인프라 구성**
    - `DiscordWebhookProperties`, `DiscordNotificationConfig` 및 웹훅 설정 추가
    - 에러용 / 회원가입용 웹훅 URL 분리


  - [x] **Gemini LLM 기반 에러 분석**
    - 예외 발생 시 Gemini API 호출 → 요약/원인/해결/긴급도 분석
    - 스택 트레이스 상위 5줄만 추출해 토큰 사용량 최소화
    - `thinkingBudget=0`으로 추론 비활성화 (응답 잘림 방지), 간결화 프롬프트(450자 이내)
    - AI 분석 결과를 에러 embed에 "🤖 AI 분석" 필드로 추가
    - 분석 실패 시 기존 에러 알림은 정상 전송 (graceful degradation)
    - `GeminiProperties` / `GeminiRequest` / `GeminiResponse` DTO, `geminiRestClient` Bean 구성


  ## 🧪 테스트 방법

<img width="1202" height="518" alt="image" src="https://github.com/user-attachments/assets/1172a273-70c5-4883-99cd-a399f75bb227" />
<img width="528" height="717" alt="image" src="https://github.com/user-attachments/assets/5e57c58d-31b3-4ef0-b076-ccd6f9b5a7fe" />
<img width="240" height="88" alt="image" src="https://github.com/user-attachments/assets/70be9fd9-a03f-490c-af0f-79fb11d65988" />

  ## 📎 관련 이슈

  - Close #

  ## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Discord로 오류 및 회원가입 알림 전송 기능 추가
  * 가입 완료 시 비동기 알림 발송 흐름 도입
  * AI(Gemini) 기반 오류 분석 결과를 알림에 포함

* **설정**
  * 개발 프로필 기본값을 local → dev로 변경
  * VALKEY_HOST 항목 추가 및 Discord/Gemini 관련 설정 추가

* **테스트**
  * 알림·분석 동작과 예외처리 관련 단위테스트 대폭 추가/강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pposiregi/Back/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->