### PR TITLE
chore: HTTPS 배포 프록시 설정 반영

### DIFF
--- a/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
+++ b/src/main/java/com/fitpet/server/shared/config/SecurityConfig.java
@@ -85,7 +85,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOriginPatterns(List.of("https://*.run.app"));
+        config.setAllowedOriginPatterns(List.of(
+                "https://*.run.app",
+                "https://slimpet.duckdns.org"
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization", "dev-user-id"));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: framework
+
 spring:
   profiles:
     active: ${ACTIVE_PROFILE}


### PR DESCRIPTION
## 📌 PR 요약

- HTTPS 도메인 배포 환경에서 백엔드가 프록시 헤더를 인식하도록 설정합니다.
- `slimpet.duckdns.org` 도메인을 CORS 허용 origin에 추가합니다.

## ✅ 작업 상세 내용

- [ ] 주요 기능 구현
- [x] 관련 API 변경
- [x] 기타 리팩터링

## 🧪 테스트 방법

- `./gradlew compileJava`
- VM Nginx에서 `https://slimpet.duckdns.org/actuator/health` 200 응답 확인

## 📎 관련 이슈

- 없음

## 추가 전달 사항

- `server.forward-headers-strategy=framework` 설정으로 Nginx reverse proxy 뒤에서 `X-Forwarded-*` 헤더를 반영하도록 했습니다.
- React Native 앱은 CORS 영향이 제한적이지만, Swagger/웹 클라이언트 접근을 위해 `https://slimpet.duckdns.org`를 허용 origin에 포함했습니다.
- Actuator 접근 제한은 기존 Prometheus/Grafana 연동 영향 가능성이 있어 이번 PR에서는 변경하지 않았습니다.
